### PR TITLE
Add pre-push CI and gated Pages deploy

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+if command -v npm >/dev/null 2>&1; then
+  npm_bin="$(command -v npm)"
+else
+  npm_bin=""
+  for candidate in \
+    "$repo_root/../.local/node-current/bin/npm" \
+    "$HOME/.local/node-current/bin/npm" \
+    "$HOME/.volta/bin/npm" \
+    "/opt/homebrew/bin/npm" \
+    "/usr/local/bin/npm"
+  do
+    if [ -x "$candidate" ]; then
+      npm_bin="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$npm_bin" ]; then
+  printf '%s\n' 'Unable to find npm for pre-push checks.' >&2
+  exit 1
+fi
+
+PATH="$(dirname "$npm_bin"):$PATH"
+export PATH
+
+printf '%s\n' 'Running CI checks before push...'
+"$npm_bin" run ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   validate:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -33,6 +33,22 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run checks, tests, and build verification
+        run: npm run ci
+
+  build:
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
 
       - name: Build site
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "verify:build": "node ./scripts/verify-build.mjs",
     "ci": "npm run check && npm run test && npm run build && npm run verify:build",
+    "prepare": "node ./scripts/setup-git-hooks.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+if (process.env.CI) {
+  process.exit(0);
+}
+
+try {
+  execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    stdio: "ignore",
+  });
+} catch {
+  process.exit(0);
+}
+
+try {
+  execFileSync("git", ["config", "--local", "core.hooksPath", ".githooks"], {
+    stdio: "ignore",
+  });
+  process.stdout.write("Configured git hooks at .githooks\n");
+} catch (error) {
+  process.stderr.write(`Failed to configure git hooks: ${error.message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a repo-managed pre-push hook that runs the existing CI command before git push
- configure the repo to install that hook automatically via npm prepare
- make the Pages workflow validate on push before deploying
