### PR TITLE
Simplify theme controls and add pre-push CI

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+if command -v npm >/dev/null 2>&1; then
+  npm_bin="$(command -v npm)"
+else
+  npm_bin=""
+  for candidate in \
+    "$repo_root/../.local/node-current/bin/npm" \
+    "$HOME/.local/node-current/bin/npm" \
+    "$HOME/.volta/bin/npm" \
+    "/opt/homebrew/bin/npm" \
+    "/usr/local/bin/npm"
+  do
+    if [ -x "$candidate" ]; then
+      npm_bin="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$npm_bin" ]; then
+  printf '%s\n' 'Unable to find npm for pre-push checks.' >&2
+  exit 1
+fi
+
+printf '%s\n' 'Running CI checks before push...'
+"$npm_bin" run ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   validate:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -33,6 +33,22 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run checks, tests, and build verification
+        run: npm run ci
+
+  build:
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
 
       - name: Build site
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ npm run ci
 - Content lives in `src/content/posts`.
 - Static assets live in `public/assets`.
 - Build verification checks both critical pages and migrated post routes.
+
+## Structure
+
+- `src/layouts` contains the shared page shells.
+- `src/components` contains reusable UI building blocks.
+- `src/lib/content.ts` contains shared post querying and date formatting helpers.
+- `src/pages/[...slug].astro` renders migrated post routes from content frontmatter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "arunabh-blog-v2",
+  "name": "arunabh1904.github.io",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "arunabh-blog-v2",
+      "name": "arunabh1904.github.io",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "verify:build": "node ./scripts/verify-build.mjs",
     "ci": "npm run check && npm run test && npm run build && npm run verify:build",
+    "prepare": "node ./scripts/setup-git-hooks.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -7,11 +7,14 @@
 }
 :root {
   --background-color: #f8f8f8;
+  --background-secondary: #eef2ff;
   --text-color: #000080;
+  --text-secondary-color: #2c3e8f;
+  --accent-color: #7da2ff;
   --icon-color: #000080;
   --image-border-color: #000000;
   --code-border-color: #000000;
-  --panel-bg: rgba(0, 0, 0, 0.3);
+  --panel-bg: rgba(8, 19, 79, 0.22);
   --music-bg-start: #3b82f6;
   --music-bg-end: #0ea5e9;
   --music-vibe-start: #60a5fa;
@@ -19,18 +22,37 @@
   --table-border-color: #cccccc;
   --table-header-bg: #e8e8ff;
   --table-row-alt-bg: rgba(0, 0, 0, 0.05);
+  --button-bg: rgba(255, 255, 255, 0.9);
+  --button-bg-hover: rgba(248, 250, 255, 0.98);
+  --button-border: rgba(16, 24, 40, 0.08);
+  --button-shadow: 0 10px 28px rgba(15, 23, 42, 0.14);
+  --button-shadow-hover: 0 14px 32px rgba(15, 23, 42, 0.18);
+  --home-overlay: linear-gradient(135deg, rgba(248, 249, 255, 0.82), rgba(235, 240, 255, 0.58));
+  --home-text: #0d1b6f;
+  --home-panel-bg: rgba(255, 255, 255, 0.12);
 }
 
 :root[data-theme="light"] {
   --background-color: #f8f8f8;
+  --background-secondary: #eef2ff;
   --text-color: #000080;
+  --text-secondary-color: #2c3e8f;
+  --accent-color: #7da2ff;
   --icon-color: #000080;
   --image-border-color: #000080;
   --code-border-color: #000000;
-  --panel-bg: rgba(5, 5, 5, 0.3);
+  --panel-bg: rgba(8, 19, 79, 0.22);
   --table-border-color: #cccccc;
   --table-header-bg: #e8e8ff;
   --table-row-alt-bg: rgba(0, 0, 0, 0.05);
+  --button-bg: rgba(255, 255, 255, 0.9);
+  --button-bg-hover: rgba(248, 250, 255, 0.98);
+  --button-border: rgba(16, 24, 40, 0.08);
+  --button-shadow: 0 10px 28px rgba(15, 23, 42, 0.14);
+  --button-shadow-hover: 0 14px 32px rgba(15, 23, 42, 0.18);
+  --home-overlay: linear-gradient(135deg, rgba(248, 249, 255, 0.82), rgba(235, 240, 255, 0.58));
+  --home-text: #0d1b6f;
+  --home-panel-bg: rgba(255, 255, 255, 0.12);
 }
 
 :root[data-theme="dark"] {
@@ -38,20 +60,28 @@
   --background-secondary: #1E1E1E;
   --text-color: #E0E0E0;
   --text-secondary-color: #A3A3A3;
-  --accent-color: #5E81AC;
+  --accent-color: #7aa2f7;
   --icon-color: #E0E0E0;
   --image-border-color: #E0E0E0;
   --code-border-color: #FFFFFF;
   --music-bg-start: #7aa2f7;
   --music-bg-end: #bb9af7;
-  --music-vibe-start: #7dcfff;a
+  --music-vibe-start: #7dcfff;
   --music-vibe-end: #f7768e;
-  --panel-bg: rgba(0, 0, 0, 0.3);
+  --panel-bg: rgba(6, 10, 24, 0.7);
   --equation-bg: #1E1E1E;
   --equation-text: #E0E0E0;
   --table-border-color: #3b3b3b;
   --table-header-bg: #1E1E1E;
   --table-row-alt-bg: rgba(255, 255, 255, 0.05);
+  --button-bg: rgba(23, 27, 39, 0.88);
+  --button-bg-hover: rgba(30, 36, 52, 0.96);
+  --button-border: rgba(255, 255, 255, 0.08);
+  --button-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  --button-shadow-hover: 0 16px 34px rgba(0, 0, 0, 0.46);
+  --home-overlay: linear-gradient(135deg, rgba(2, 6, 23, 0.7), rgba(8, 15, 36, 0.82));
+  --home-text: #f2f4ff;
+  --home-panel-bg: rgba(4, 10, 26, 0.26);
 }
 
 html {
@@ -64,6 +94,36 @@ body {
   margin: 0;
   font-family: "IBM Plex Sans", sans-serif;
   line-height: 1.6;
+  transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+body.home-page {
+  background:
+    var(--home-overlay),
+    url('/assets/images/shootingstar.jpg') center/cover fixed;
+  color: var(--home-text);
+}
+
+body.home-page h1,
+body.home-page h2,
+body.home-page h3,
+body.home-page p,
+body.home-page li,
+body.home-page small {
+  color: inherit;
+}
+
+.home-content-shell {
+  max-width: 650px;
+  margin: 2rem;
+  padding: 1.5rem;
+  border-radius: 24px;
+  background: var(--home-panel-bg);
+  backdrop-filter: blur(4px);
+}
+
+.page-content {
+  padding: 5.75rem 1.5rem 2.5rem;
 }
 
 .lead {
@@ -160,8 +220,10 @@ img:not(.float-right):not(.float-left) {
 }
 
 .music-page {
-  background: radial-gradient(circle at top left, #3a1c71, #1e1e1e);
-  color: #eee;
+  background:
+    radial-gradient(circle at top left, rgba(67, 97, 238, 0.18), transparent 32%),
+    linear-gradient(160deg, var(--background-color), var(--background-secondary));
+  color: var(--text-color);
   font-family: "IBM Plex Sans", sans-serif;
   margin: 0;
   height: 100vh;
@@ -173,24 +235,38 @@ img:not(.float-right):not(.float-left) {
 
 /* 2) Small rounded button styling */
 .small-rounded-button {
-  position: absolute;
-  width: 100px;            
-  height: 40px;           
-  border: none;
-  border-radius: 999px;  
-  background-color: #f0f0f0;
+  position: fixed;
+  width: 100px;
+  height: 40px;
+  border: 1px solid var(--button-border);
+  border-radius: 999px;
+  background-color: var(--button-bg);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
   color: var(--icon-color);
   cursor: pointer;
   font-size: 14px;
   text-align: center;
-  line-height: 40px;        /* Vertically center text */
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  transition: background-color 0.2s, box-shadow 0.2s;
+  line-height: 40px;
+  box-shadow: var(--button-shadow);
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease,
+    color 0.2s ease;
   outline: none;
+  z-index: 20;
 }
 
 .small-rounded-button:hover {
-  background-color: #e0e0e0;
+  background-color: var(--button-bg-hover);
+  box-shadow: var(--button-shadow-hover);
+  transform: translateY(-1px);
+}
+
+.small-rounded-button:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 3px;
 }
 
 /* Hero section for the title page */
@@ -203,28 +279,56 @@ img:not(.float-right):not(.float-left) {
 
 
 #home-button {
-  top: 10px;
-  right: 10px;
-  width: 48px;
-  height: 48px;
+  top: 28px;
+  right: 28px;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
-  line-height: 48px;
+  line-height: 56px;
   padding: 0;
   font-size: 32px;
 }
 
 #theme-toggle {
-  top: 10px;
-  right: 70px;
-  width: 48px;
-  height: 48px;
+  top: 28px;
+  right: 96px;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
-  line-height: 48px;
+  line-height: 56px;
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 0;
   font-size: 24px;
+}
+
+.icon-only-button {
+  justify-content: center;
+}
+
+.button-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.theme-icon {
+  position: absolute;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+:root[data-theme="light"] .theme-icon-sun,
+:root[data-theme="dark"] .theme-icon-moon {
+  opacity: 0;
+  transform: scale(0.8);
+  pointer-events: none;
+}
+
+:root[data-theme="light"] .theme-icon-moon,
+:root[data-theme="dark"] .theme-icon-sun {
+  opacity: 1;
+  transform: scale(1);
 }
 
 #music-button {
@@ -278,8 +382,13 @@ img:not(.float-right):not(.float-left) {
 .vibe {
   animation: vibe 0.2s linear infinite, vibeColor 3s ease-in-out infinite;
 }
-#music-button i {
-  margin-right: 6px;
+.music-button-icon {
+  margin-right: 10px;
+}
+
+#music-button svg {
+  width: 20px;
+  height: 20px;
 }
 #music-button:hover {
   transform: scale(1.05);
@@ -288,9 +397,11 @@ img:not(.float-right):not(.float-left) {
 
 #music-widget {
   text-align: center;
-  background-color: rgba(0, 0, 0, 0.6);
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+  background-color: var(--button-bg);
+  border: 1px solid var(--button-border);
+  border-radius: 20px;
+  box-shadow: var(--button-shadow);
+  color: var(--text-color);
   padding: 16px;
   width: 320px;
   margin: auto;
@@ -385,9 +496,12 @@ img:not(.float-right):not(.float-left) {
 }
 
 /* Space between icon and text */
-.link-list li i {
-  margin-right: 8px;
+.contact-icon {
+  width: 18px;
+  height: 18px;
+  margin-right: 10px;
   color: #ffffff;
+  flex-shrink: 0;
 }
 
 /* Links inside the pinned panel */
@@ -406,7 +520,7 @@ img:not(.float-right):not(.float-left) {
 
 /* All <a> tags: light blue by default, no underline */
 a {
-  color: #9bbcff;          /* Lighter blue for unvisited links. */
+  color: #7d9dff;
   text-decoration: none;
 }
 
@@ -435,6 +549,19 @@ a:visited {
     line-height: 35px;
     font-size: 12px;
   }
+  #theme-toggle,
+  #home-button {
+    top: 18px;
+    width: 48px;
+    height: 48px;
+    line-height: 48px;
+  }
+  #theme-toggle {
+    right: 74px;
+  }
+  #home-button {
+    right: 18px;
+  }
   #music-button {
     width: auto;
     max-width: 200px;
@@ -444,6 +571,13 @@ a:visited {
   }
   body {
     font-size: 16px;
+  }
+  .home-content-shell {
+    margin: 1rem;
+    padding: 1.25rem;
+  }
+  .page-content {
+    padding: 5rem 1rem 2rem;
   }
   .main-container {
     margin: 1rem;
@@ -456,16 +590,6 @@ a:visited {
     margin-top: 1rem;
     box-shadow: none;
   }
-}
-
-
-/* Icons for the theme toggle button */
-.sun-icon {
-  color: #ffcc00;
-}
-
-.moon-icon {
-  color: #4b5563;
 }
 
 /* ------------------------------------------------------

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+if (process.env.CI) {
+  process.exit(0);
+}
+
+try {
+  execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    stdio: "ignore",
+  });
+} catch {
+  process.exit(0);
+}
+
+try {
+  execFileSync("git", ["config", "--local", "core.hooksPath", ".githooks"], {
+    stdio: "ignore",
+  });
+  process.stdout.write("Configured git hooks at .githooks\n");
+} catch (error) {
+  process.stderr.write(`Failed to configure git hooks: ${error.message}\n`);
+  process.exit(1);
+}

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -1,0 +1,159 @@
+---
+interface Props {
+  name:
+    | 'sun'
+    | 'moon'
+    | 'arrow-left'
+    | 'music'
+    | 'email'
+    | 'github'
+    | 'linkedin'
+    | 'x';
+  class?: string;
+  decorative?: boolean;
+  title?: string;
+}
+
+const { name, class: className = '', decorative = true, title } = Astro.props;
+---
+
+{name === 'sun' && (
+  <svg
+    class={className}
+    viewBox="0 0 24 24"
+    aria-hidden={decorative ? 'true' : undefined}
+    aria-label={!decorative ? title : undefined}
+    role="img"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.8"
+  >
+    {!decorative && title && <title>{title}</title>}
+    <circle cx="12" cy="12" r="4.25"></circle>
+    <path d="M12 2.5v2.5"></path>
+    <path d="M12 19v2.5"></path>
+    <path d="M21.5 12H19"></path>
+    <path d="M5 12H2.5"></path>
+    <path d="M18.72 5.28l-1.77 1.77"></path>
+    <path d="M7.05 16.95l-1.77 1.77"></path>
+    <path d="M18.72 18.72l-1.77-1.77"></path>
+    <path d="M7.05 7.05L5.28 5.28"></path>
+  </svg>
+)}
+
+{name === 'moon' && (
+  <svg
+    class={className}
+    viewBox="0 0 24 24"
+    aria-hidden={decorative ? 'true' : undefined}
+    aria-label={!decorative ? title : undefined}
+    role="img"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.8"
+  >
+    {!decorative && title && <title>{title}</title>}
+    <path d="M20.5 14.2A8.7 8.7 0 1 1 9.8 3.5a7.1 7.1 0 0 0 10.7 10.7Z"></path>
+  </svg>
+)}
+
+{name === 'arrow-left' && (
+  <svg
+    class={className}
+    viewBox="0 0 24 24"
+    aria-hidden={decorative ? 'true' : undefined}
+    aria-label={!decorative ? title : undefined}
+    role="img"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.9"
+  >
+    {!decorative && title && <title>{title}</title>}
+    <path d="M15.5 5.5 9 12l6.5 6.5"></path>
+  </svg>
+)}
+
+{name === 'music' && (
+  <svg
+    class={className}
+    viewBox="0 0 24 24"
+    aria-hidden={decorative ? 'true' : undefined}
+    aria-label={!decorative ? title : undefined}
+    role="img"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.8"
+  >
+    {!decorative && title && <title>{title}</title>}
+    <path d="M15 4v10.25a2.75 2.75 0 1 1-1.75-2.58V6.05l7-1.55v7.75a2.75 2.75 0 1 1-1.75-2.58V4.9L15 5.7"></path>
+  </svg>
+)}
+
+{name === 'email' && (
+  <svg
+    class={className}
+    viewBox="0 0 24 24"
+    aria-hidden={decorative ? 'true' : undefined}
+    aria-label={!decorative ? title : undefined}
+    role="img"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.8"
+  >
+    {!decorative && title && <title>{title}</title>}
+    <rect x="3" y="5.5" width="18" height="13" rx="2"></rect>
+    <path d="m4.5 7 7.5 6 7.5-6"></path>
+  </svg>
+)}
+
+{name === 'github' && (
+  <svg
+    class={className}
+    viewBox="0 0 24 24"
+    aria-hidden={decorative ? 'true' : undefined}
+    aria-label={!decorative ? title : undefined}
+    role="img"
+    fill="currentColor"
+  >
+    {!decorative && title && <title>{title}</title>}
+    <path d="M12 .75a11.25 11.25 0 0 0-3.56 21.92c.56.1.76-.24.76-.54v-2.08c-3.1.67-3.75-1.32-3.75-1.32-.5-1.28-1.24-1.62-1.24-1.62-1.01-.69.08-.68.08-.68 1.12.08 1.7 1.14 1.7 1.14.99 1.7 2.61 1.2 3.25.92.1-.72.39-1.2.7-1.47-2.47-.28-5.07-1.24-5.07-5.5 0-1.22.43-2.2 1.14-2.98-.11-.28-.49-1.4.11-2.92 0 0 .94-.3 3.08 1.14a10.65 10.65 0 0 1 5.6 0c2.13-1.44 3.07-1.14 3.07-1.14.6 1.52.22 2.64.11 2.92.71.78 1.14 1.76 1.14 2.98 0 4.27-2.61 5.21-5.09 5.49.4.35.76 1.05.76 2.13v3.15c0 .3.2.65.77.54A11.25 11.25 0 0 0 12 .75Z"></path>
+  </svg>
+)}
+
+{name === 'linkedin' && (
+  <svg
+    class={className}
+    viewBox="0 0 24 24"
+    aria-hidden={decorative ? 'true' : undefined}
+    aria-label={!decorative ? title : undefined}
+    role="img"
+    fill="currentColor"
+  >
+    {!decorative && title && <title>{title}</title>}
+    <path d="M4.98 3.5a1.73 1.73 0 1 1 0 3.46 1.73 1.73 0 0 1 0-3.46ZM3.5 8.25h2.96v12.25H3.5ZM10.02 8.25h2.84v1.67h.04c.4-.75 1.36-1.92 3.14-1.92 3.35 0 3.96 2.2 3.96 5.06v7.44h-2.96v-6.6c0-1.57-.03-3.58-2.18-3.58-2.18 0-2.51 1.7-2.51 3.46v6.72h-2.96Z"></path>
+  </svg>
+)}
+
+{name === 'x' && (
+  <svg
+    class={className}
+    viewBox="0 0 24 24"
+    aria-hidden={decorative ? 'true' : undefined}
+    aria-label={!decorative ? title : undefined}
+    role="img"
+    fill="currentColor"
+  >
+    {!decorative && title && <title>{title}</title>}
+    <path d="M18.9 3.75h2.88l-6.29 7.18 7.4 9.32h-5.79l-4.53-5.64-4.94 5.64H4.75l6.73-7.69L4.38 3.75h5.94l4.09 5.2 4.49-5.2Zm-1.01 14.77h1.6L9.45 5.39H7.74Z"></path>
+  </svg>
+)}

--- a/src/components/LinkList.astro
+++ b/src/components/LinkList.astro
@@ -1,0 +1,23 @@
+---
+interface LinkListItem {
+  href: string;
+  label: string;
+  meta?: string;
+}
+
+interface Props {
+  items: readonly LinkListItem[];
+  class?: string;
+}
+
+const { items, class: className = 'icon-list' } = Astro.props;
+---
+
+<ul class={className}>
+  {items.map((item) => (
+    <li>
+      <a href={item.href}>{item.label}</a>
+      {item.meta && <small>— {item.meta}</small>}
+    </li>
+  ))}
+</ul>

--- a/src/components/LinksPanel.astro
+++ b/src/components/LinksPanel.astro
@@ -1,4 +1,5 @@
 ---
+import Icon from './Icon.astro';
 import { CONTACT_LINKS } from '../lib/site';
 ---
 
@@ -7,7 +8,7 @@ import { CONTACT_LINKS } from '../lib/site';
   <ul class="link-list" style="list-style: none; margin: 0; padding: 0;">
     {CONTACT_LINKS.map((link) => (
       <li style="display: flex; align-items: center; margin-bottom: 1rem;">
-        <i class={link.iconClass} style="margin-right: 8px;"></i>
+        <Icon name={link.iconName} class="contact-icon" />
         <a href={link.href} target={link.href.startsWith('mailto:') ? undefined : '_blank'}>
           {link.label}
         </a>

--- a/src/components/MusicLauncher.astro
+++ b/src/components/MusicLauncher.astro
@@ -1,5 +1,9 @@
+---
+import Icon from './Icon.astro';
+---
+
 <button type="button" id="music-button" class="small-rounded-button">
-  <i class="fas fa-music"></i>
+  <Icon name="music" class="button-icon music-button-icon" />
   Play some music while browsing...
 </button>
 <div id="music-bar"></div>

--- a/src/components/PageControls.astro
+++ b/src/components/PageControls.astro
@@ -1,0 +1,32 @@
+---
+import Icon from './Icon.astro';
+
+interface Props {
+  showHomeButton?: boolean;
+}
+
+const { showHomeButton = false } = Astro.props;
+---
+
+<button
+  type="button"
+  id="theme-toggle"
+  class="small-rounded-button icon-only-button"
+  aria-label="Toggle theme"
+  data-theme-toggle
+>
+  <Icon name="moon" class="button-icon theme-icon theme-icon-moon" />
+  <Icon name="sun" class="button-icon theme-icon theme-icon-sun" />
+</button>
+
+{showHomeButton && (
+  <button
+    type="button"
+    id="home-button"
+    class="small-rounded-button icon-only-button"
+    aria-label="Go home"
+    data-home-button
+  >
+    <Icon name="arrow-left" class="button-icon" />
+  </button>
+)}

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,26 +1,18 @@
 ---
 import type { PostEntry } from '../lib/content';
+import { formatShortDate } from '../lib/content';
+import LinkList from './LinkList.astro';
 
 interface Props {
   posts: PostEntry[];
 }
 
 const { posts } = Astro.props;
+const items = posts.map((post) => ({
+  href: post.data.legacyPath,
+  label: post.data.title,
+  meta: formatShortDate(post.data.date),
+}));
 ---
 
-<ul class="icon-list">
-  {posts.map((post) => (
-    <li>
-      <a href={post.data.legacyPath}>{post.data.title}</a>
-      <small>
-        — {
-          post.data.date.toLocaleDateString('en-US', {
-            month: 'short',
-            day: '2-digit',
-            year: 'numeric',
-          })
-        }
-      </small>
-    </li>
-  ))}
-</ul>
+<LinkList items={items} />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,6 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../lib/site';
 interface Props {
   title: string;
   description?: string;
-  staticTheme?: boolean;
   pageClass?: string;
   bodyStyle?: string;
 }
@@ -12,7 +11,6 @@ interface Props {
 const {
   title,
   description = SITE_DESCRIPTION,
-  staticTheme = false,
   pageClass = '',
   bodyStyle = '',
 } = Astro.props;
@@ -22,7 +20,6 @@ const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
 ---
-
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
   <head>
@@ -32,23 +29,18 @@ const canonicalUrl = Astro.site
     <link rel="canonical" href={canonicalUrl} />
     <link rel="alternate" type="application/rss+xml" title={SITE_TITLE} href="/feed.xml" />
     <title>{pageTitle}</title>
-    {!staticTheme && (
-      <script is:inline>
-        {`(() => {
-          const saved = localStorage.getItem('theme');
-          if (saved === 'light' || saved === 'dark') {
-            document.documentElement.setAttribute('data-theme', saved);
-          }
-        })();`}
-      </script>
-    )}
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
-      integrity="sha512-ac7VU+So8QGeqzsaT6JZijv8I1MInE4x9NnY5KFSgptSZlPqqJldT+zgrfjIrXcLoB8WY/cHZ9faffV9IWLtmg=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
+    <script is:inline>
+      {`(() => {
+        const saved = localStorage.getItem('theme');
+        const theme =
+          saved === 'light' || saved === 'dark'
+            ? saved
+            : window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? 'dark'
+              : 'light';
+        document.documentElement.setAttribute('data-theme', theme);
+      })();`}
+    </script>
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
@@ -98,5 +90,29 @@ const canonicalUrl = Astro.site
   </head>
   <body class={pageClass} style={bodyStyle}>
     <slot />
+    <script is:inline>
+      {`(() => {
+        const STORAGE_KEY = 'theme';
+        const html = document.documentElement;
+
+        const applyTheme = (theme) => {
+          html.setAttribute('data-theme', theme);
+          localStorage.setItem(STORAGE_KEY, theme);
+        };
+
+        document.querySelectorAll('[data-theme-toggle]').forEach((button) => {
+          button.addEventListener('click', () => {
+            const nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+            applyTheme(nextTheme);
+          });
+        });
+
+        document.querySelectorAll('[data-home-button]').forEach((button) => {
+          button.addEventListener('click', () => {
+            window.location.href = '/';
+          });
+        });
+      })();`}
+    </script>
   </body>
 </html>

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -1,6 +1,7 @@
 ---
 import MusicLauncher from '../components/MusicLauncher.astro';
 import LinksPanel from '../components/LinksPanel.astro';
+import PageControls from '../components/PageControls.astro';
 import BaseLayout from './BaseLayout.astro';
 
 interface Props {
@@ -14,30 +15,12 @@ const { title, description } = Astro.props;
 <BaseLayout
   title={title}
   description={description}
-  staticTheme={true}
   pageClass="home-page"
-  bodyStyle={`
-    margin: 0;
-    padding: 0;
-    background:
-      radial-gradient(circle at 30% 30%, rgba(0, 0, 0, 0.4) 0%, rgba(0, 0, 0, 0.8) 70%),
-      url('/assets/images/shootingstar.jpg') center/cover fixed;
-    min-height: 100vh;
-    color: #f0ead6;
-    font-family: "IBM Plex Sans", sans-serif;
-    --text-color: #f0ead6;
-  `}
+  bodyStyle={`margin: 0; padding: 0; min-height: 100vh;`}
 >
+  <PageControls />
   <MusicLauncher />
-  <div
-    style="
-      max-width: 650px;
-      margin: 2rem;
-      background: rgba(0,0,0,0.0);
-      border-radius: 8px;
-      padding: 1.5rem;
-    "
-  >
+  <div class="home-content-shell">
     <h1 style="margin-top: 0;">Arunabh.BLOG</h1>
     <slot />
   </div>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,5 +1,6 @@
 ---
 import MusicLauncher from '../components/MusicLauncher.astro';
+import PageControls from '../components/PageControls.astro';
 import PostNavigation from '../components/PostNavigation.astro';
 import type { PostEntry } from '../lib/content';
 import BaseLayout from './BaseLayout.astro';
@@ -22,51 +23,10 @@ const {
 ---
 
 <BaseLayout title={title} description={description}>
-  <button type="button" id="theme-toggle" class="small-rounded-button" aria-label="Toggle theme">
-    <i class="fas fa-moon moon-icon"></i>
-  </button>
-  <button type="button" id="home-button" class="small-rounded-button">
-    <i class="fas fa-arrow-left"></i>
-  </button>
+  <PageControls showHomeButton={true} />
   <MusicLauncher />
   <main class="page-content" style="max-width:800px; margin:2rem auto;" aria-label="Content">
     <slot />
     {showNavigation && <PostNavigation previous={previous} next={next} />}
   </main>
-  <script is:inline>
-    {`const STORAGE_KEY = 'theme';
-    const toggleButton = document.getElementById('theme-toggle');
-    const homeButton = document.getElementById('home-button');
-    const html = document.documentElement;
-
-    function applySavedTheme() {
-      const saved = localStorage.getItem(STORAGE_KEY);
-      if (saved === 'light' || saved === 'dark') {
-        html.setAttribute('data-theme', saved);
-      }
-    }
-
-    function updateToggleIcon() {
-      if (!toggleButton) return;
-      toggleButton.innerHTML =
-        html.getAttribute('data-theme') === 'dark'
-          ? '<i class="fas fa-sun sun-icon"></i>'
-          : '<i class="fas fa-moon moon-icon"></i>';
-    }
-
-    applySavedTheme();
-    updateToggleIcon();
-
-    toggleButton?.addEventListener('click', () => {
-      const newTheme =
-        html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-      html.setAttribute('data-theme', newTheme);
-      localStorage.setItem(STORAGE_KEY, newTheme);
-      updateToggleIcon();
-    });
-
-    homeButton?.addEventListener('click', () => {
-      window.location.href = '/';
-    });`}
-  </script>
 </BaseLayout>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -3,6 +3,21 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 export type PostEntry = CollectionEntry<'posts'>;
 export type Section = PostEntry['data']['section'];
 
+export function formatShortDate(date: Date) {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  });
+}
+
+export function formatMonthYear(date: Date) {
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
 export function sortPostsAscending(posts: PostEntry[]) {
   return [...posts].sort(
     (left, right) => left.data.date.getTime() - right.data.date.getTime(),

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -3,17 +3,17 @@ export const SITE_DESCRIPTION =
   'A personal blog on computer vision, robotics, and more.';
 
 export const CONTACT_LINKS = [
-  { href: 'mailto:arunabh1904@gmail.com', iconClass: 'fas fa-envelope fa-lg', label: 'Email' },
-  { href: 'https://github.com/arunabh1904', iconClass: 'fab fa-github fa-lg', label: 'GitHub' },
+  { href: 'mailto:arunabh1904@gmail.com', iconName: 'email', label: 'Email' },
+  { href: 'https://github.com/arunabh1904', iconName: 'github', label: 'GitHub' },
   {
     href: 'https://www.linkedin.com/in/arunabh-mishra',
-    iconClass: 'fab fa-linkedin fa-lg',
+    iconName: 'linkedin',
     label: 'LinkedIn',
   },
   {
     href: 'https://twitter.com/ArunabhMishra8',
-    iconClass: 'fab fa-twitter fa-lg',
-    label: 'Twitter',
+    iconName: 'x',
+    label: 'X',
   },
 ] as const;
 

--- a/src/pages/ai_generated_reports.astro
+++ b/src/pages/ai_generated_reports.astro
@@ -1,4 +1,5 @@
 ---
+import LinkList from '../components/LinkList.astro';
 import PostLayout from '../layouts/PostLayout.astro';
 import PostList from '../components/PostList.astro';
 import { getPostsBySection } from '../lib/content';
@@ -12,12 +13,5 @@ const posts = await getPostsBySection('ai-generated-reports', 'asc');
   {posts.length > 0 ? <PostList posts={posts} /> : <p>No audio summaries yet.</p>}
 
   <h2>Deep research summaries</h2>
-  <ul class="icon-list">
-    {PDF_REPORTS.map((report) => (
-      <li>
-        <a href={report.href}>{report.label}</a>
-        <small>— {report.dateLabel}</small>
-      </li>
-    ))}
-  </ul>
+  <LinkList items={PDF_REPORTS} />
 </PostLayout>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,6 +1,6 @@
 ---
 import PostLayout from '../layouts/PostLayout.astro';
-import { getAllPosts, groupPostsByTag } from '../lib/content';
+import { formatMonthYear, getAllPosts, groupPostsByTag } from '../lib/content';
 
 const posts = await getAllPosts();
 const grouped = groupPostsByTag(posts);
@@ -14,9 +14,7 @@ const grouped = groupPostsByTag(posts);
         {items.map((post) => (
           <li>
             <a href={post.data.legacyPath}>
-              {post.data.date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })} -
-              {' '}
-              {post.data.title}
+              {formatMonthYear(post.data.date)} - {post.data.title}
             </a>
           </li>
         ))}

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -1,17 +1,10 @@
 ---
+import PageControls from '../components/PageControls.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Music Player" pageClass="music-page">
-  <button
-    type="button"
-    id="theme-toggle"
-    class="small-rounded-button"
-    aria-label="Toggle theme"
-    style="top:10px; right:10px; position:absolute;"
-  >
-    <i class="fas fa-moon moon-icon"></i>
-  </button>
+  <PageControls />
   <div id="music-widget">
     <div class="music-controls">
       <button id="choose-spotify" class="music-choice">Spotify</button>
@@ -20,40 +13,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </div>
     <iframe
       id="music-iframe"
-      frameborder="0"
+      style="border:0;"
       allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
     ></iframe>
   </div>
-  <script is:inline>
-    {`const STORAGE_KEY = 'theme';
-    const toggleButton = document.getElementById('theme-toggle');
-    const html = document.documentElement;
-
-    function applySavedTheme() {
-      const saved = localStorage.getItem(STORAGE_KEY);
-      if (saved === 'light' || saved === 'dark') {
-        html.setAttribute('data-theme', saved);
-      }
-    }
-
-    function updateToggleIcon() {
-      if (!toggleButton) return;
-      toggleButton.innerHTML =
-        html.getAttribute('data-theme') === 'dark'
-          ? '<i class="fas fa-sun sun-icon"></i>'
-          : '<i class="fas fa-moon moon-icon"></i>';
-    }
-
-    applySavedTheme();
-    updateToggleIcon();
-
-    toggleButton?.addEventListener('click', () => {
-      const newTheme =
-        html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-      html.setAttribute('data-theme', newTheme);
-      localStorage.setItem(STORAGE_KEY, newTheme);
-      updateToggleIcon();
-    });`}
-  </script>
   <script is:inline src="/assets/js/music.js"></script>
 </BaseLayout>

--- a/src/pages/paper_summaries_field.astro
+++ b/src/pages/paper_summaries_field.astro
@@ -1,6 +1,7 @@
 ---
+import LinkList from '../components/LinkList.astro';
 import PostLayout from '../layouts/PostLayout.astro';
-import { getPostsByField } from '../lib/content';
+import { formatShortDate, getPostsByField } from '../lib/content';
 
 const fields = await getPostsByField();
 ---
@@ -9,20 +10,14 @@ const fields = await getPostsByField();
   {fields.map(({ field, items }) => (
     <>
       <h2>{field}</h2>
-      <ul>
-        {items.map((post) => (
-          <li>
-            <a href={post.data.legacyPath}>{post.data.title}</a>
-            <small>
-              — {post.data.date.toLocaleDateString('en-US', {
-                month: 'short',
-                day: '2-digit',
-                year: 'numeric',
-              })}
-            </small>
-          </li>
-        ))}
-      </ul>
+      <LinkList
+        items={items.map((post) => ({
+          href: post.data.legacyPath,
+          label: post.data.title,
+          meta: formatShortDate(post.data.date),
+        }))}
+        class="icon-list"
+      />
     </>
   ))}
 </PostLayout>


### PR DESCRIPTION
## Summary
- centralize theme initialization and shared page controls for more consistent dark/light mode behavior
- replace broken icon-font usage with local SVG icons and shared list/control components
- add pre-push CI hook setup plus gated Pages deploy updates

## Testing
- npm run ci