### PR TITLE
Restyle dark mode with cyberpunk accents

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -6,6 +6,9 @@
   text-rendering: auto;
 }
 :root {
+  --font-body: "IBM Plex Sans", sans-serif;
+  --font-heading: "Inter", sans-serif;
+  --font-mono: "Roboto Mono", monospace;
   --background-color: #f8f8f8;
   --background-secondary: #eef2ff;
   --text-color: #000080;
@@ -56,32 +59,39 @@
 }
 
 :root[data-theme="dark"] {
-  --background-color: #121212;
-  --background-secondary: #1E1E1E;
-  --text-color: #E0E0E0;
-  --text-secondary-color: #A3A3A3;
-  --accent-color: #7aa2f7;
-  --icon-color: #E0E0E0;
-  --image-border-color: #E0E0E0;
-  --code-border-color: #FFFFFF;
-  --music-bg-start: #7aa2f7;
-  --music-bg-end: #bb9af7;
-  --music-vibe-start: #7dcfff;
-  --music-vibe-end: #f7768e;
-  --panel-bg: rgba(6, 10, 24, 0.7);
-  --equation-bg: #1E1E1E;
-  --equation-text: #E0E0E0;
-  --table-border-color: #3b3b3b;
-  --table-header-bg: #1E1E1E;
-  --table-row-alt-bg: rgba(255, 255, 255, 0.05);
-  --button-bg: rgba(23, 27, 39, 0.88);
-  --button-bg-hover: rgba(30, 36, 52, 0.96);
-  --button-border: rgba(255, 255, 255, 0.08);
-  --button-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
-  --button-shadow-hover: 0 16px 34px rgba(0, 0, 0, 0.46);
-  --home-overlay: linear-gradient(135deg, rgba(2, 6, 23, 0.7), rgba(8, 15, 36, 0.82));
-  --home-text: #f2f4ff;
-  --home-panel-bg: rgba(4, 10, 26, 0.26);
+  --font-body: "Rajdhani", sans-serif;
+  --font-heading: "Orbitron", sans-serif;
+  --font-mono: "Roboto Mono", monospace;
+  --background-color: #050505;
+  --background-secondary: #101010;
+  --text-color: #f6e7a6;
+  --text-secondary-color: #b9ab66;
+  --accent-color: #ffe45c;
+  --icon-color: #ffe45c;
+  --image-border-color: #ffe45c;
+  --code-border-color: rgba(255, 228, 92, 0.55);
+  --music-bg-start: #f7c600;
+  --music-bg-end: #ffea70;
+  --music-vibe-start: #fff5a8;
+  --music-vibe-end: #ffb800;
+  --panel-bg: rgba(16, 16, 16, 0.84);
+  --equation-bg: #0f0f0f;
+  --equation-text: #f6e7a6;
+  --table-border-color: rgba(255, 228, 92, 0.3);
+  --table-header-bg: rgba(255, 228, 92, 0.09);
+  --table-row-alt-bg: rgba(255, 228, 92, 0.04);
+  --button-bg: rgba(12, 12, 12, 0.92);
+  --button-bg-hover: rgba(26, 26, 26, 0.96);
+  --button-border: rgba(255, 228, 92, 0.34);
+  --button-shadow: 0 0 0 1px rgba(255, 228, 92, 0.1), 0 14px 34px rgba(0, 0, 0, 0.5);
+  --button-shadow-hover: 0 0 0 1px rgba(255, 228, 92, 0.2), 0 18px 38px rgba(0, 0, 0, 0.58);
+  --home-overlay:
+    linear-gradient(135deg, rgba(0, 0, 0, 0.82), rgba(20, 16, 0, 0.74)),
+    radial-gradient(circle at top right, rgba(255, 228, 92, 0.14), transparent 30%),
+    linear-gradient(rgba(255, 228, 92, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 228, 92, 0.08) 1px, transparent 1px);
+  --home-text: #fff2b2;
+  --home-panel-bg: linear-gradient(145deg, rgba(11, 11, 11, 0.9), rgba(22, 18, 2, 0.8));
 }
 
 html {
@@ -92,9 +102,15 @@ body {
   background-color: var(--background-color);
   color: var(--text-color);
   margin: 0;
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-body);
   line-height: 1.6;
   transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+:root[data-theme="dark"] body {
+  background-image:
+    radial-gradient(circle at top, rgba(255, 228, 92, 0.08), transparent 34%),
+    linear-gradient(180deg, rgba(255, 228, 92, 0.04), transparent 18%);
 }
 
 body.home-page {
@@ -120,6 +136,14 @@ body.home-page small {
   border-radius: 24px;
   background: var(--home-panel-bg);
   backdrop-filter: blur(4px);
+}
+
+:root[data-theme="dark"] .home-content-shell {
+  border: 1px solid rgba(255, 228, 92, 0.24);
+  box-shadow:
+    0 0 0 1px rgba(255, 228, 92, 0.06),
+    0 18px 48px rgba(0, 0, 0, 0.52);
+  backdrop-filter: blur(12px);
 }
 
 .page-content {
@@ -224,7 +248,7 @@ img:not(.float-right):not(.float-left) {
     radial-gradient(circle at top left, rgba(67, 97, 238, 0.18), transparent 32%),
     linear-gradient(160deg, var(--background-color), var(--background-secondary));
   color: var(--text-color);
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-body);
   margin: 0;
   height: 100vh;
   display: flex;
@@ -251,6 +275,7 @@ img:not(.float-right):not(.float-left) {
   box-shadow: var(--button-shadow);
   transition:
     background-color 0.2s ease,
+    border-color 0.2s ease,
     box-shadow 0.2s ease,
     transform 0.2s ease,
     color 0.2s ease;
@@ -262,6 +287,14 @@ img:not(.float-right):not(.float-left) {
   background-color: var(--button-bg-hover);
   box-shadow: var(--button-shadow-hover);
   transform: translateY(-1px);
+}
+
+:root[data-theme="dark"] .small-rounded-button {
+  color: var(--accent-color);
+}
+
+:root[data-theme="dark"] .small-rounded-button:hover {
+  border-color: rgba(255, 228, 92, 0.6);
 }
 
 .small-rounded-button:focus-visible {
@@ -342,9 +375,9 @@ img:not(.float-right):not(.float-left) {
   line-height: 1.2;
   white-space: normal;
   background: linear-gradient(135deg, var(--music-bg-start), var(--music-bg-end));
-  color: #fff;
+  color: #111;
   font-weight: bold;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.36);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 #music-bar {
@@ -407,6 +440,14 @@ img:not(.float-right):not(.float-left) {
   margin: auto;
 }
 
+:root[data-theme="dark"] #music-widget,
+:root[data-theme="dark"] .links-panel,
+:root[data-theme="dark"] .quick-overview {
+  box-shadow:
+    0 0 0 1px rgba(255, 228, 92, 0.12),
+    0 16px 40px rgba(0, 0, 0, 0.52);
+}
+
 #music-overlay {
   position: fixed;
   bottom: 80px;
@@ -433,10 +474,10 @@ img:not(.float-right):not(.float-left) {
 .music-choice {
   margin-right: 6px;
   padding: 6px 12px;
-  background: linear-gradient(135deg, #4b0082, #e100ff);
+  background: linear-gradient(135deg, #d7a700, #fff087);
   border: none;
   border-radius: 20px;
-  color: #fff;
+  color: #111;
   cursor: pointer;
   font-weight: bold;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
@@ -474,11 +515,16 @@ img:not(.float-right):not(.float-left) {
   bottom: 20px;
   right: 20px;
   background-color: var(--panel-bg);
-  color: #ffffff;
+  color: var(--text-color);
   padding: 1rem;
   border-radius: 8px;
   width: 220px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
+:root[data-theme="dark"] .links-panel {
+  border: 1px solid rgba(255, 228, 92, 0.22);
+  border-radius: 18px;
 }
 
 /* Unordered list inside the pinned panel */
@@ -500,18 +546,18 @@ img:not(.float-right):not(.float-left) {
   width: 18px;
   height: 18px;
   margin-right: 10px;
-  color: #ffffff;
+  color: inherit;
   flex-shrink: 0;
 }
 
 /* Links inside the pinned panel */
 .links-panel a {
-  color: #ffffff !important;
+  color: inherit !important;
 }
 
 .links-panel a:hover,
 .links-panel a:visited {
-  color: #ffffff !important;
+  color: inherit !important;
 }
 
 /* ------------------------------------------------------
@@ -533,6 +579,21 @@ a:hover {
 a:visited {
   color: #7aa2f7 !important; /* Slightly darker for visited links. */
   text-decoration: none;
+}
+
+:root[data-theme="dark"] a {
+  color: var(--accent-color);
+  text-decoration-color: rgba(255, 228, 92, 0.5);
+}
+
+:root[data-theme="dark"] a:hover {
+  color: #fff2a1;
+  text-decoration: underline;
+  text-shadow: 0 0 12px rgba(255, 228, 92, 0.34);
+}
+
+:root[data-theme="dark"] a:visited {
+  color: #d8bc45 !important;
 }
 
 /* ------------------------------------------------------
@@ -643,9 +704,17 @@ tbody tr:nth-child(odd) {
 h1,
 h2,
 h3 {
-  font-family: "Inter", sans-serif;
+  font-family: var(--font-heading);
   color: var(--text-color);
   margin-bottom: 20px;
+}
+
+:root[data-theme="dark"] h1,
+:root[data-theme="dark"] h2,
+:root[data-theme="dark"] h3 {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-shadow: 0 0 18px rgba(255, 228, 92, 0.18);
 }
 
 .quick-overview {
@@ -655,12 +724,19 @@ h3 {
   margin-bottom: 32px;
 }
 
+:root[data-theme="dark"] .quick-overview {
+  border: 1px solid rgba(255, 228, 92, 0.22);
+  border-radius: 18px;
+  background:
+    linear-gradient(145deg, rgba(17, 17, 17, 0.96), rgba(8, 8, 8, 0.92));
+}
+
 .quick-overview li {
   margin-bottom: 12px;
 }
 
 code {
-  font-family: "Roboto Mono", monospace;
+  font-family: var(--font-mono);
   background-color: var(--background-secondary);
   padding: 4px 8px;
   border-radius: 4px;
@@ -676,9 +752,25 @@ pre {
   font-size: 13px;
 }
 
+:root[data-theme="dark"] code,
+:root[data-theme="dark"] pre {
+  background:
+    linear-gradient(145deg, rgba(18, 18, 18, 0.96), rgba(7, 7, 7, 0.98));
+  color: #ffe98a;
+}
+
+:root[data-theme="dark"] pre {
+  border: 1px solid rgba(255, 228, 92, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255, 228, 92, 0.04);
+}
+
 .section {
   padding-bottom: 32px;
   border-bottom: 1px solid var(--background-secondary);
+}
+
+:root[data-theme="dark"] .section {
+  border-bottom: 1px solid rgba(255, 228, 92, 0.14);
 }
 
 .section:last-child {
@@ -705,4 +797,35 @@ pre {
 .home-page a:visited,
 .home-page a:active {
   color: #7aa2f7;
+}
+
+:root[data-theme="dark"] .home-page {
+  --text-color: var(--home-text);
+}
+
+:root[data-theme="dark"] .home-page a {
+  color: var(--accent-color);
+}
+
+:root[data-theme="dark"] .home-page a:visited,
+:root[data-theme="dark"] .home-page a:active {
+  color: #e0c54f;
+}
+
+:root[data-theme="dark"] .lead {
+  color: #fff3b7;
+  font-size: 1.1rem;
+  letter-spacing: 0.03em;
+}
+
+:root[data-theme="dark"] .intro-text,
+:root[data-theme="dark"] small,
+:root[data-theme="dark"] p {
+  color: var(--text-color);
+}
+
+:root[data-theme="dark"] .icon-list li::before {
+  background:
+    linear-gradient(135deg, #ffe45c, #fff2a8);
+  box-shadow: 0 0 10px rgba(255, 228, 92, 0.5);
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -106,7 +106,7 @@ const pageControlsScript = `(() => {
     />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=IBM+Plex+Sans:wght@300;400&family=Roboto+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400&family=Inter:wght@500;700&family=Orbitron:wght@500;700;800&family=Rajdhani:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap"
     />
     <link rel="stylesheet" href="/css/override.css" />
     <slot name="head" />


### PR DESCRIPTION
## What changed
- retuned dark mode to a black-and-yellow cyberpunk palette
- added Orbitron and Rajdhani for more futuristic dark-theme typography
- updated panels, links, buttons, code blocks, and the home shell to match the new dark aesthetic

## Why
- make dark mode feel more intentional and visually distinct, per the requested cyberpunk direction

## Testing
- PATH=/Users/arunabhmishra/Code/.local/node-current/bin:/Users/arunabhmishra/.codex/tmp/arg0/codex-arg0G5yjTE:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Codex.app/Contents/Resources npm run ci
- pre-push hook reran CI successfully during git push