### PR TITLE
Bust cached theme stylesheet

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,6 +19,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
+const themeStylesheetHref = '/css/override.css?v=20260318-cyberpunk-2';
 const themeInitScript = `(() => {
   const saved = localStorage.getItem('theme');
   const theme =
@@ -108,7 +109,7 @@ const pageControlsScript = `(() => {
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400&family=Inter:wght@500;700&family=Orbitron:wght@500;700;800&family=Rajdhani:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap"
     />
-    <link rel="stylesheet" href="/css/override.css" />
+    <link rel="stylesheet" href={themeStylesheetHref} />
     <slot name="head" />
   </head>
   <body class={pageClass} style={bodyStyle}>


### PR DESCRIPTION
## What changed
- versioned the shared theme stylesheet URL in the base layout

## Why
- force browsers to fetch the updated cyberpunk dark-mode CSS instead of reusing a stale cached /css/override.css response

## Testing
- PATH=/Users/arunabhmishra/Code/.local/node-current/bin:/Users/arunabhmishra/.codex/tmp/arg0/codex-arg0n0y3Lh:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Applications/Codex.app/Contents/Resources npm run ci
- pre-push hook reran CI successfully during git push