### PR TITLE
Fix dark mode code block styling

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -752,6 +752,18 @@ pre {
   font-size: 13px;
 }
 
+pre code {
+  display: block;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+  font-size: inherit;
+  line-height: 1.7;
+  white-space: pre;
+}
+
 :root[data-theme="dark"] code,
 :root[data-theme="dark"] pre {
   background:
@@ -762,6 +774,13 @@ pre {
 :root[data-theme="dark"] pre {
   border: 1px solid rgba(255, 228, 92, 0.2);
   box-shadow: inset 0 0 0 1px rgba(255, 228, 92, 0.04);
+}
+
+:root[data-theme="dark"] pre code,
+:root[data-theme="dark"] pre code span {
+  background: transparent !important;
+  color: inherit;
+  text-shadow: none;
 }
 
 .section {


### PR DESCRIPTION
## What changed
- stopped fenced code blocks from inheriting the inline code chip styles
- reset nested code and syntax-highlight spans inside pre blocks so Shiki can render cleanly
- kept inline code styling intact elsewhere

## Why
- remove the muddy nested outlines and preserve readable syntax highlighting in dark mode

## Testing
- PATH=/Users/arunabhmishra/Code/.local/node-current/bin:/Users/arunabhmishra/.codex/tmp/arg0/codex-arg0n0y3Lh:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Applications/Codex.app/Contents/Resources npm run ci
- pre-push hook reran CI successfully during git push