### PR TITLE
Brighten dark code highlighting

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -34,7 +34,7 @@ export default defineConfig({
     shikiConfig: {
       themes: {
         light: 'github-light',
-        dark: 'github-dark',
+        dark: 'one-dark-pro',
       },
       wrap: true,
     },


### PR DESCRIPTION
## What changed
- switched the dark-mode Shiki syntax theme from github-dark to one-dark-pro

## Why
- improve syntax readability inside dark code blocks by using brighter token colors against the near-black theme

## Testing
- PATH=/Users/arunabhmishra/Code/.local/node-current/bin:/Users/arunabhmishra/.codex/tmp/arg0/codex-arg0n0y3Lh:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Applications/Codex.app/Contents/Resources npm run ci
- pre-push hook reran CI successfully during git push