### PR TITLE
Improve code readability without changing theme

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -34,7 +34,7 @@ export default defineConfig({
     shikiConfig: {
       themes: {
         light: 'github-light',
-        dark: 'one-dark-pro',
+        dark: 'github-dark',
       },
       wrap: true,
     },

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -870,12 +870,14 @@ pre code {
 :root[data-theme="dark"] pre {
   background:
     linear-gradient(145deg, rgba(18, 18, 18, 0.96), rgba(7, 7, 7, 0.98));
-  color: #ffe98a;
+  color: #fff2a8;
 }
 
 :root[data-theme="dark"] pre {
-  border: 1px solid rgba(255, 228, 92, 0.2);
-  box-shadow: inset 0 0 0 1px rgba(255, 228, 92, 0.04);
+  border: 1px solid rgba(255, 228, 92, 0.26);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 228, 92, 0.06),
+    0 12px 30px rgba(0, 0, 0, 0.24);
 }
 
 :root[data-theme="dark"] pre code,
@@ -883,6 +885,10 @@ pre code {
   background: transparent !important;
   color: inherit;
   text-shadow: none;
+}
+
+:root[data-theme="dark"] pre code {
+  filter: saturate(1.2) brightness(1.18);
 }
 
 .section {


### PR DESCRIPTION
## What changed
- restored the original dark syntax theme instead of replacing the code aesthetic
- brightened dark code text slightly and strengthened the code block border/shadow
- added a small saturation and brightness boost to dark-mode code tokens only

## Why
- keep the existing cyberpunk look while making code more legible

## Testing
- PATH=/Users/arunabhmishra/Code/.local/node-current/bin:/Users/arunabhmishra/.codex/tmp/arg0/codex-arg0n0y3Lh:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Applications/Codex.app/Contents/Resources npm run ci
- pre-push hook reran CI successfully during git push