### PR TITLE
Boost dark code block contrast

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -102,6 +102,10 @@
   --button-border: rgba(255, 228, 92, 0.34);
   --button-shadow: 0 0 0 1px rgba(255, 228, 92, 0.1), 0 14px 34px rgba(0, 0, 0, 0.5);
   --button-shadow-hover: 0 0 0 1px rgba(255, 228, 92, 0.2), 0 18px 38px rgba(0, 0, 0, 0.58);
+  --code-block-bg-dark: linear-gradient(145deg, rgba(20, 20, 20, 0.98), rgba(10, 10, 10, 0.99));
+  --code-block-text-dark: #fff4b8;
+  --code-block-border-dark: rgba(255, 228, 92, 0.3);
+  --code-block-filter-dark: brightness(1.42) saturate(1.35) contrast(1.12);
   --home-overlay:
     linear-gradient(135deg, rgba(0, 0, 0, 0.82), rgba(20, 16, 0, 0.74)),
     radial-gradient(circle at top right, rgba(255, 228, 92, 0.14), transparent 30%),
@@ -868,27 +872,33 @@ pre code {
 
 :root[data-theme="dark"] code,
 :root[data-theme="dark"] pre {
-  background:
-    linear-gradient(145deg, rgba(18, 18, 18, 0.96), rgba(7, 7, 7, 0.98));
-  color: #fff2a8;
+  background: var(--code-block-bg-dark);
+  color: var(--code-block-text-dark);
 }
 
 :root[data-theme="dark"] pre {
-  border: 1px solid rgba(255, 228, 92, 0.26);
+  border: 1px solid var(--code-block-border-dark);
   box-shadow:
     inset 0 0 0 1px rgba(255, 228, 92, 0.06),
     0 12px 30px rgba(0, 0, 0, 0.24);
 }
 
 :root[data-theme="dark"] pre code,
-:root[data-theme="dark"] pre code span {
+:root[data-theme="dark"] pre code span,
+:root[data-theme="dark"] pre code span[style] {
   background: transparent !important;
   color: inherit;
   text-shadow: none;
+  opacity: 1 !important;
 }
 
 :root[data-theme="dark"] pre code {
-  filter: saturate(1.2) brightness(1.18);
+  color: var(--code-block-text-dark);
+}
+
+:root[data-theme="dark"] pre code span,
+:root[data-theme="dark"] pre code span[style] {
+  filter: var(--code-block-filter-dark);
 }
 
 .section {


### PR DESCRIPTION
## What changed
- added shared dark-mode code block variables for background, text, border, and token filtering
- increased contrast specifically for dark code blocks and their syntax-highlight spans
- applied the change in the shared stylesheet so it affects all fenced code blocks site-wide

## Why
- improve readability of low-contrast dark tokens without changing the rest of the cyberpunk theme

## Testing
- PATH=/Users/arunabhmishra/Code/.local/node-current/bin:/Users/arunabhmishra/.codex/tmp/arg0/codex-arg0n0y3Lh:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Applications/Codex.app/Contents/Resources npm run ci
- pre-push hook reran CI successfully during git push