### PR TITLE
Improve dark-mode code block legibility

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -104,6 +104,7 @@
   --button-shadow-hover: 0 0 0 1px rgba(255, 228, 92, 0.2), 0 18px 38px rgba(0, 0, 0, 0.58);
   --code-block-bg-dark: linear-gradient(145deg, rgba(20, 20, 20, 0.98), rgba(10, 10, 10, 0.99));
   --code-block-text-dark: #fff4b8;
+  --code-block-token-dark: #ffe98a;
   --code-block-border-dark: rgba(255, 228, 92, 0.3);
   --code-block-filter-dark: brightness(1.42) saturate(1.35) contrast(1.12);
   --home-overlay:
@@ -898,7 +899,8 @@ pre code {
 
 :root[data-theme="dark"] pre code span,
 :root[data-theme="dark"] pre code span[style] {
-  filter: var(--code-block-filter-dark);
+  color: var(--code-block-token-dark) !important;
+  filter: none;
 }
 
 .section {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,7 +19,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
-const themeStylesheetHref = '/css/override.css?v=20260318-cyberpunk-2';
+const themeStylesheetHref = '/css/override.css?v=20260318-cyberpunk-3';
 const themeInitScript = `(() => {
   const saved = localStorage.getItem('theme');
   const theme =


### PR DESCRIPTION
## Summary
- switch shared dark-mode code block tokens to the brighter yellow family used by the site theme
- keep the cyberpunk block background and border styling intact
- bump the stylesheet version so browsers fetch the updated code-block styles

## Testing
- PATH=/Users/arunabhmishra/Code/.local/node-current/bin:/Users/arunabhmishra/.codex/tmp/arg0/codex-arg0n0y3Lh:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Applications/Codex.app/Contents/Resources npm run build
- PATH=/Users/arunabhmishra/Code/.local/node-current/bin:/Users/arunabhmishra/.codex/tmp/arg0/codex-arg0n0y3Lh:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Applications/Codex.app/Contents/Resources npm run ci