### PR TITLE
Rewrite attention mechanisms post with deeper intuition

### DIFF
--- a/public/assets/images/attention-mechanisms-flow.svg
+++ b/public/assets/images/attention-mechanisms-flow.svg
@@ -1,0 +1,232 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Animated intuition for self-attention</title>
+  <desc id="desc">An animated diagram showing the token it emitting a query, scoring the tokens animal, street, and tired, and mixing their values into a contextualized representation.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f8fbff" />
+      <stop offset="100%" stop-color="#eef4fb" />
+    </linearGradient>
+    <linearGradient id="tokenFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="100%" stop-color="#f8fafc" />
+    </linearGradient>
+    <linearGradient id="queryFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#dbeafe" />
+      <stop offset="100%" stop-color="#bfdbfe" />
+    </linearGradient>
+    <linearGradient id="memoryFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#eef2ff" />
+      <stop offset="100%" stop-color="#e0e7ff" />
+    </linearGradient>
+    <linearGradient id="outputFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fef3c7" />
+      <stop offset="100%" stop-color="#fde68a" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity="0.1" />
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563eb" />
+    </marker>
+    <marker id="arrowSoft" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b" />
+    </marker>
+    <style>
+      .title { font: 700 34px Inter, Arial, sans-serif; fill: #0f172a; }
+      .subtitle { font: 21px "IBM Plex Sans", Arial, sans-serif; fill: #475569; }
+      .label { font: 600 20px Inter, Arial, sans-serif; fill: #334155; }
+      .body { font: 18px "IBM Plex Sans", Arial, sans-serif; fill: #334155; }
+      .mono { font: 500 22px "Roboto Mono", monospace; fill: #0f172a; }
+      .scoreText { font: 700 16px "IBM Plex Sans", Arial, sans-serif; }
+      .qPulse {
+        transform-origin: 540px 304px;
+        animation: qPulse 6s ease-in-out infinite;
+      }
+      .arrowStrong {
+        stroke-dasharray: 14 10;
+        animation: pulseStrong 6s ease-in-out infinite;
+      }
+      .arrowWeak {
+        stroke-dasharray: 10 10;
+        animation: pulseWeak 6s ease-in-out infinite;
+      }
+      .arrowMedium {
+        stroke-dasharray: 12 10;
+        animation: pulseMedium 6s ease-in-out infinite;
+      }
+      .returnStrong {
+        stroke-dasharray: 12 10;
+        animation: returnStrong 6s ease-in-out infinite;
+      }
+      .returnWeak {
+        stroke-dasharray: 10 10;
+        animation: returnWeak 6s ease-in-out infinite;
+      }
+      .returnMedium {
+        stroke-dasharray: 10 10;
+        animation: returnMedium 6s ease-in-out infinite;
+      }
+      .animalBar {
+        animation: barStrong 6s ease-in-out infinite;
+      }
+      .streetBar {
+        animation: barWeak 6s ease-in-out infinite;
+      }
+      .tiredBar {
+        animation: barMedium 6s ease-in-out infinite;
+      }
+      .outputPulse {
+        animation: outputPulse 6s ease-in-out infinite;
+      }
+      @keyframes qPulse {
+        0%, 100% { transform: scale(1); opacity: 0.88; }
+        12% { transform: scale(1.06); opacity: 1; }
+        24% { transform: scale(1); opacity: 0.92; }
+      }
+      @keyframes pulseStrong {
+        0%, 100% { opacity: 0.14; stroke-dashoffset: 0; }
+        18%, 44% { opacity: 1; stroke-dashoffset: -48; }
+        60% { opacity: 0.2; stroke-dashoffset: -70; }
+      }
+      @keyframes pulseWeak {
+        0%, 100% { opacity: 0.1; stroke-dashoffset: 0; }
+        22%, 46% { opacity: 0.55; stroke-dashoffset: -36; }
+        60% { opacity: 0.12; stroke-dashoffset: -56; }
+      }
+      @keyframes pulseMedium {
+        0%, 100% { opacity: 0.1; stroke-dashoffset: 0; }
+        26%, 52% { opacity: 0.78; stroke-dashoffset: -42; }
+        64% { opacity: 0.14; stroke-dashoffset: -62; }
+      }
+      @keyframes barStrong {
+        0%, 22%, 100% { width: 0; opacity: 0.25; }
+        34%, 56% { width: 180px; opacity: 1; }
+        70% { width: 180px; opacity: 0.4; }
+      }
+      @keyframes barWeak {
+        0%, 24%, 100% { width: 0; opacity: 0.2; }
+        38%, 56% { width: 32px; opacity: 0.9; }
+        70% { width: 32px; opacity: 0.35; }
+      }
+      @keyframes barMedium {
+        0%, 26%, 100% { width: 0; opacity: 0.2; }
+        40%, 58% { width: 92px; opacity: 0.95; }
+        72% { width: 92px; opacity: 0.35; }
+      }
+      @keyframes returnStrong {
+        0%, 42%, 100% { opacity: 0.08; stroke-dashoffset: 0; }
+        54%, 82% { opacity: 0.95; stroke-dashoffset: -44; }
+      }
+      @keyframes returnWeak {
+        0%, 44%, 100% { opacity: 0.08; stroke-dashoffset: 0; }
+        58%, 82% { opacity: 0.45; stroke-dashoffset: -36; }
+      }
+      @keyframes returnMedium {
+        0%, 46%, 100% { opacity: 0.08; stroke-dashoffset: 0; }
+        60%, 84% { opacity: 0.72; stroke-dashoffset: -40; }
+      }
+      @keyframes outputPulse {
+        0%, 52%, 100% { transform: scale(1); opacity: 0.95; }
+        70% { transform: scale(1.03); opacity: 1; }
+        82% { transform: scale(1.01); opacity: 0.98; }
+      }
+    </style>
+  </defs>
+
+  <rect width="1280" height="720" fill="url(#bg)" />
+  <rect x="30" y="30" width="1220" height="660" rx="32" fill="#ffffff" stroke="#dbe6f3" stroke-width="2" />
+
+  <text x="74" y="94" class="title">Self-attention as routing</text>
+  <text x="74" y="130" class="subtitle">
+    A token emits a query, compares it with every key, then mixes the returned values into a contextualized output.
+  </text>
+
+  <text x="78" y="186" class="label">Sequence</text>
+  <g filter="url(#shadow)">
+    <rect x="76" y="208" width="124" height="58" rx="16" fill="url(#tokenFill)" stroke="#cbd5e1" stroke-width="2" />
+    <rect x="216" y="208" width="140" height="58" rx="16" fill="#e0f2fe" stroke="#38bdf8" stroke-width="2.5" />
+    <rect x="372" y="208" width="118" height="58" rx="16" fill="url(#tokenFill)" stroke="#cbd5e1" stroke-width="2" />
+    <rect x="506" y="208" width="110" height="58" rx="16" fill="url(#tokenFill)" stroke="#cbd5e1" stroke-width="2" />
+    <rect x="632" y="208" width="128" height="58" rx="16" fill="#dbeafe" stroke="#2563eb" stroke-width="3" />
+    <rect x="776" y="208" width="110" height="58" rx="16" fill="url(#tokenFill)" stroke="#cbd5e1" stroke-width="2" />
+    <rect x="902" y="208" width="122" height="58" rx="16" fill="#dcfce7" stroke="#22c55e" stroke-width="2.5" />
+  </g>
+  <text x="138" y="245" text-anchor="middle" class="mono">The</text>
+  <text x="286" y="245" text-anchor="middle" class="mono">animal</text>
+  <text x="431" y="245" text-anchor="middle" class="mono">didn't</text>
+  <text x="561" y="245" text-anchor="middle" class="mono">cross</text>
+  <text x="696" y="245" text-anchor="middle" class="mono">it</text>
+  <text x="831" y="245" text-anchor="middle" class="mono">too</text>
+  <text x="963" y="245" text-anchor="middle" class="mono">tired</text>
+
+  <g class="qPulse" filter="url(#shadow)">
+    <rect x="454" y="292" width="242" height="94" rx="24" fill="url(#queryFill)" stroke="#3b82f6" stroke-width="2.5" />
+    <text x="486" y="332" fill="#1d4ed8" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">
+      Query from "it"
+    </text>
+    <text x="486" y="362" fill="#1e3a8a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
+      Find the right antecedent
+    </text>
+  </g>
+
+  <text x="80" y="446" class="label">Candidate keys and values</text>
+
+  <g filter="url(#shadow)">
+    <rect x="78" y="470" width="310" height="106" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2.5" />
+    <rect x="78" y="596" width="310" height="62" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
+    <rect x="78" y="596" width="0" height="62" rx="20" fill="#2563eb" opacity="0.92" class="animalBar" />
+
+    <rect x="432" y="470" width="310" height="106" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2" />
+    <rect x="432" y="596" width="310" height="62" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
+    <rect x="432" y="596" width="0" height="62" rx="20" fill="#64748b" opacity="0.92" class="streetBar" />
+
+    <rect x="786" y="470" width="310" height="106" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2.2" />
+    <rect x="786" y="596" width="310" height="62" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
+    <rect x="786" y="596" width="0" height="62" rx="20" fill="#0f766e" opacity="0.92" class="tiredBar" />
+  </g>
+
+  <text x="110" y="510" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">animal</text>
+  <text x="110" y="542" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">key: plausible antecedent</text>
+  <text x="110" y="630" fill="#ffffff" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18" font-weight="700">attention weight</text>
+  <text x="312" y="634" text-anchor="end" class="scoreText" fill="#dbeafe">0.72</text>
+
+  <text x="464" y="510" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">street</text>
+  <text x="464" y="542" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">key: weak semantic fit</text>
+  <text x="464" y="630" fill="#0f172a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18" font-weight="700">attention weight</text>
+  <text x="666" y="634" text-anchor="end" class="scoreText" fill="#334155">0.08</text>
+
+  <text x="818" y="510" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">tired</text>
+  <text x="818" y="542" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">key: useful causal clue</text>
+  <text x="818" y="630" fill="#ffffff" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18" font-weight="700">attention weight</text>
+  <text x="1020" y="634" text-anchor="end" class="scoreText" fill="#d1fae5">0.20</text>
+
+  <path d="M 548 386 C 470 418, 340 448, 232 468" fill="none" stroke="#2563eb" stroke-width="5.5" stroke-linecap="round" marker-end="url(#arrow)" class="arrowStrong" />
+  <path d="M 570 388 C 580 422, 580 442, 586 468" fill="none" stroke="#64748b" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrowSoft)" class="arrowWeak" />
+  <path d="M 604 386 C 720 416, 848 446, 938 468" fill="none" stroke="#0f766e" stroke-width="4.2" stroke-linecap="round" marker-end="url(#arrowSoft)" class="arrowMedium" />
+
+  <text x="1100" y="184" class="label">Contextualized output</text>
+  <g class="outputPulse" filter="url(#shadow)">
+    <rect x="1088" y="222" width="126" height="258" rx="26" fill="url(#outputFill)" stroke="#f59e0b" stroke-width="2.5" />
+    <text x="1151" y="274" text-anchor="middle" fill="#92400e" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">
+      New vector
+    </text>
+    <text x="1151" y="312" text-anchor="middle" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
+      "it" now means
+    </text>
+    <text x="1151" y="340" text-anchor="middle" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
+      mostly animal
+    </text>
+    <text x="1151" y="368" text-anchor="middle" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
+      plus a smaller
+    </text>
+    <text x="1151" y="396" text-anchor="middle" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
+      fatigue signal
+    </text>
+  </g>
+
+  <path d="M 388 520 C 492 520, 734 346, 1086 340" fill="none" stroke="#2563eb" stroke-width="4.8" stroke-linecap="round" marker-end="url(#arrowSoft)" class="returnStrong" />
+  <path d="M 742 522 C 842 520, 926 430, 1086 378" fill="none" stroke="#64748b" stroke-width="3.2" stroke-linecap="round" marker-end="url(#arrowSoft)" class="returnWeak" />
+  <path d="M 1096 522 C 1112 508, 1122 470, 1126 438" fill="none" stroke="#0f766e" stroke-width="3.8" stroke-linecap="round" marker-end="url(#arrowSoft)" class="returnMedium" />
+
+  <rect x="76" y="674" width="1130" height="0.5" fill="#cbd5e1" />
+</svg>

--- a/public/assets/images/attention-mechanisms-intuition.svg
+++ b/public/assets/images/attention-mechanisms-intuition.svg
@@ -1,0 +1,180 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900" role="img" aria-labelledby="title desc">
+  <title id="title">Attention as differentiable lookup</title>
+  <desc id="desc">A diagram showing a query from the token it matching the keys for animal, street, and tired, then mixing their values into a contextualized output representation.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f8fbff" />
+      <stop offset="100%" stop-color="#eef4fb" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="100%" stop-color="#f9fbfe" />
+    </linearGradient>
+    <linearGradient id="queryFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#dbeafe" />
+      <stop offset="100%" stop-color="#bfdbfe" />
+    </linearGradient>
+    <linearGradient id="memoryFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#eef2ff" />
+      <stop offset="100%" stop-color="#e0e7ff" />
+    </linearGradient>
+    <linearGradient id="valueFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#dcfce7" />
+      <stop offset="100%" stop-color="#bbf7d0" />
+    </linearGradient>
+    <linearGradient id="outputFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fef3c7" />
+      <stop offset="100%" stop-color="#fde68a" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity="0.08" />
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563eb" />
+    </marker>
+    <marker id="arrowSoft" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b" />
+    </marker>
+  </defs>
+
+  <rect width="1400" height="900" fill="url(#bg)" />
+  <rect x="34" y="34" width="1332" height="832" rx="34" fill="url(#panel)" stroke="#dbe6f3" stroke-width="2" />
+
+  <text x="80" y="105" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="40" font-weight="700">
+    Attention as differentiable lookup
+  </text>
+  <text x="80" y="145" fill="#475569" font-family="IBM Plex Sans, Arial, sans-serif" font-size="23">
+    The current token emits a query, scores candidate keys, then mixes their values into a new contextual representation.
+  </text>
+
+  <rect x="76" y="210" width="300" height="470" rx="28" fill="#f8fbff" stroke="#c8d7e7" stroke-width="2" />
+  <text x="108" y="258" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
+    Current token
+  </text>
+  <text x="108" y="294" fill="#64748b" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    Sentence fragment:
+  </text>
+  <rect x="108" y="320" width="190" height="64" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
+  <text x="203" y="362" text-anchor="middle" fill="#0f172a" font-family="Roboto Mono, monospace" font-size="28" font-weight="500">
+    it
+  </text>
+
+  <rect x="108" y="418" width="236" height="156" rx="22" fill="url(#queryFill)" stroke="#60a5fa" stroke-width="2.5" filter="url(#shadow)" />
+  <text x="136" y="458" fill="#1d4ed8" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">
+    Query q
+  </text>
+  <text x="136" y="494" fill="#1e3a8a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    What antecedent fits here?
+  </text>
+  <text x="136" y="526" fill="#1e3a8a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    What explains "too tired"?
+  </text>
+  <text x="136" y="558" fill="#1e3a8a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    Which prior token matters now?
+  </text>
+
+  <rect x="430" y="190" width="540" height="520" rx="28" fill="#f8fbff" stroke="#c8d7e7" stroke-width="2" />
+  <text x="460" y="238" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
+    Candidate memory slots
+  </text>
+  <text x="460" y="274" fill="#64748b" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    Each token advertises a key and carries a value.
+  </text>
+
+  <rect x="466" y="320" width="468" height="98" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2.5" filter="url(#shadow)" />
+  <text x="500" y="356" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">
+    animal
+  </text>
+  <text x="500" y="386" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
+    key: animate noun, plausible thing that can be tired
+  </text>
+  <rect x="718" y="336" width="184" height="60" rx="18" fill="url(#valueFill)" stroke="#22c55e" stroke-width="2" />
+  <text x="810" y="374" text-anchor="middle" fill="#166534" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20" font-weight="600">
+    value: entity meaning
+  </text>
+
+  <rect x="466" y="454" width="468" height="98" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2" />
+  <text x="500" y="490" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">
+    street
+  </text>
+  <text x="500" y="520" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
+    key: location, weak semantic fit for "too tired"
+  </text>
+  <rect x="718" y="470" width="184" height="60" rx="18" fill="url(#valueFill)" stroke="#22c55e" stroke-width="2" />
+  <text x="810" y="508" text-anchor="middle" fill="#166534" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20" font-weight="600">
+    value: scene detail
+  </text>
+
+  <rect x="466" y="588" width="468" height="98" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2" />
+  <text x="500" y="624" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">
+    tired
+  </text>
+  <text x="500" y="654" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
+    key: causal clue explaining why the event happened
+  </text>
+  <rect x="718" y="604" width="184" height="60" rx="18" fill="url(#valueFill)" stroke="#22c55e" stroke-width="2" />
+  <text x="810" y="642" text-anchor="middle" fill="#166534" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20" font-weight="600">
+    value: fatigue signal
+  </text>
+
+  <path d="M 344 496 C 404 468, 420 400, 458 368" fill="none" stroke="#2563eb" stroke-width="7" stroke-linecap="round" marker-end="url(#arrow)" opacity="0.95" />
+  <path d="M 344 500 C 404 510, 420 510, 458 504" fill="none" stroke="#94a3b8" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrowSoft)" opacity="0.9" />
+  <path d="M 344 520 C 398 570, 420 610, 458 640" fill="none" stroke="#0f766e" stroke-width="5" stroke-linecap="round" marker-end="url(#arrowSoft)" opacity="0.8" />
+
+  <text x="380" y="382" fill="#1d4ed8" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20" font-weight="600">
+    weight 0.72
+  </text>
+  <text x="382" y="494" fill="#64748b" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18" font-weight="600">
+    weight 0.08
+  </text>
+  <text x="378" y="610" fill="#0f766e" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18" font-weight="600">
+    weight 0.20
+  </text>
+
+  <rect x="1012" y="210" width="300" height="470" rx="28" fill="#f8fbff" stroke="#c8d7e7" stroke-width="2" />
+  <text x="1046" y="258" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
+    Weighted output
+  </text>
+  <text x="1046" y="294" fill="#64748b" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    Mix returned values into a new vector.
+  </text>
+
+  <rect x="1046" y="330" width="232" height="168" rx="24" fill="url(#outputFill)" stroke="#f59e0b" stroke-width="2.5" filter="url(#shadow)" />
+  <text x="1076" y="374" fill="#92400e" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">
+    Contextualized "it"
+  </text>
+  <text x="1076" y="412" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    Refers mostly to
+  </text>
+  <text x="1076" y="442" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    the animal, while also
+  </text>
+  <text x="1076" y="472" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    absorbing the causal
+  </text>
+  <text x="1076" y="502" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
+    clue from tired.
+  </text>
+
+  <text x="1048" y="560" fill="#0f172a" font-family="Roboto Mono, monospace" font-size="20">
+    0.72 v_animal
+  </text>
+  <text x="1048" y="592" fill="#0f172a" font-family="Roboto Mono, monospace" font-size="20">
+    + 0.08 v_street
+  </text>
+  <text x="1048" y="624" fill="#0f172a" font-family="Roboto Mono, monospace" font-size="20">
+    + 0.20 v_tired
+  </text>
+
+  <path d="M 934 368 C 980 368, 992 374, 1038 386" fill="none" stroke="#f59e0b" stroke-width="4" stroke-linecap="round" marker-end="url(#arrowSoft)" />
+  <path d="M 934 504 C 978 504, 994 476, 1038 456" fill="none" stroke="#94a3b8" stroke-width="3" stroke-linecap="round" marker-end="url(#arrowSoft)" opacity="0.7" />
+  <path d="M 934 638 C 978 638, 994 560, 1038 528" fill="none" stroke="#16a34a" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrowSoft)" opacity="0.8" />
+
+  <rect x="76" y="732" width="1236" height="96" rx="24" fill="#0f172a" opacity="0.95" />
+  <text x="112" y="780" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
+    Deep intuition
+  </text>
+  <text x="112" y="812" fill="#cbd5e1" font-family="IBM Plex Sans, Arial, sans-serif" font-size="22">
+    Keys decide where to look. Values decide what comes back. The output is a new representation, not a copied token.
+  </text>
+</svg>

--- a/src/content/posts/attention-mechanisms-demystified.md
+++ b/src/content/posts/attention-mechanisms-demystified.md
@@ -7,21 +7,254 @@ legacyPath: /ponderings/2025/05/25/attention-mechanisms-demystified.html
 tags:
   - Other
 summary: >-
-  2025 – Attention Mechanisms Demystified: An Expert's Deep Dive into Q, K, V,
-  and Self-Attention
+  An intuition-first guide to queries, keys, values, self-attention,
+  multi-head attention, and cross-attention, with equations, examples, and
+  visual explanations.
 ---
-## 2025 – Attention Mechanisms Demystified: An Expert's Deep Dive into Q, K, V, and Self-Attention
+## 2025 - Attention Mechanisms Demystified: Building Intuition for Q, K, V, and Self-Attention
 
-Attention mechanisms are a foundational innovation in modern machine learning, significantly enhancing models' capability to selectively process information relevant to their tasks. Originating in neural machine translation, attention provides a dynamic method for information aggregation, crucially influencing fields ranging from natural language processing (NLP) to computer vision. This post comprehensively elucidates the intricate mechanics of attention, clearly defining queries (Q), keys (K), and values (V), and progressively building from general attention to self- and cross-attention.
+Attention is easiest to understand as **learned information routing**.
+Older sequence models, especially recurrent networks, tried to compress everything seen so far into a single running hidden state.
+Attention takes a different approach:
+at every layer, each token can ask **which other tokens matter right now** and pull back only the information it needs.
 
-At its simplest, an attention mechanism computes an output as a weighted combination of values (V), with weights determined by the similarity between queries (Q) and keys (K). The intuition behind Q, K, and V parallels searching a database: queries represent what we seek, keys index relevant entries, and values deliver the information itself. Mathematically, given a query $q$ and key-value pairs $(k_i, v_i)$, attention calculates similarities (usually scaled dot products: $q \cdot k_i / \sqrt{d_k}$), normalizes them via softmax, and then aggregates the values based on these weights. The scaling by $\sqrt{d_k}$ prevents overly sharp distributions by controlling variance across high-dimensional vectors, thereby ensuring stable gradients during training.
+That shift is the real reason Transformers feel so powerful.
+Instead of forcing information to travel step by step through a sequence,
+attention creates direct communication paths between relevant positions.
+It is best thought of as a **differentiable content-addressable memory**:
+queries ask for information,
+keys determine where to look,
+and values determine what content comes back.
 
-Self-attention builds upon this foundation by allowing sequences to "attend to themselves." Instead of having distinct sets for queries and keys, each element of a sequence generates its own Q, K, and V through learned linear projections ($W^Q$, $W^K$, and $W^V$), transforming input embeddings into different subspaces optimized for querying, indexing, and content retrieval. This mechanism empowers each token to dynamically aggregate context from across the entire sequence, effectively capturing complex relationships and long-range dependencies that traditional recurrent architectures struggle with. For instance, in a sentence like "I saw a man with a telescope," self-attention allows "saw" to contextually attend to either "man" or "telescope" depending on the intended meaning, without sequential constraints.
+![Attention as differentiable lookup](/assets/images/attention-mechanisms-intuition.svg)
 
-The expressivity of attention is further enhanced through multi-head attention, where multiple independent attention computations ("heads") run in parallel, each with distinct learned projections. Each head specializes in different aspects—such as syntactic relationships, semantic similarities, or positional cues—allowing the model to simultaneously consider multiple perspectives. Outputs from all heads are concatenated and linearly combined into a unified representation, dramatically enriching the information captured from the same set of inputs. This multiplicity is vital for nuanced understanding, enabling transformers to excel in diverse tasks from language modeling to image recognition.
+*A useful mental model: attention does not copy tokens wholesale.
+It scores candidate sources using keys, then mixes their values into a new representation for the current token.*
 
-Cross-attention generalizes attention by introducing interactions between two distinct sequences or modalities. Here, queries are generated from one source (e.g., a decoder in machine translation), and keys and values come from another (e.g., encoder outputs). This mechanism allows a model to selectively retrieve relevant information across different data streams. In machine translation, cross-attention aligns source tokens with target tokens during decoding, dynamically focusing on relevant source words. Similarly, in multimodal models, cross-attention facilitates interactions between visual and textual information, crucial for tasks like image captioning and visual question answering.
+### The one-line equation
 
-Attention's versatility across domains is notable. In NLP, it fundamentally transforms how contextual embedding is achieved, underpinning models like BERT and GPT by enabling sophisticated internal token interactions. In computer vision, Vision Transformers (ViTs) adapt attention by dividing images into patches treated analogously to text tokens, allowing global interaction across spatially distant regions. While positional encodings become crucial in vision due to inherent spatial structures, the core attention operation remains consistent across modalities.
+The entire mechanism is summarized by a single expression:
 
-In essence, attention mechanisms grant neural networks the profound capability to learn what information to emphasize, thereby significantly enhancing their representational and predictive power. By mastering queries, keys, and values—and adeptly deploying self-, multi-head, and cross-attention—modern models achieve unprecedented flexibility and performance, truly illustrating that "attention is all you need."
+\[
+\operatorname{Attention}(Q, K, V)
+=
+\operatorname{softmax}\left(\frac{QK^\top}{\sqrt{d_k}}\right)V
+\]
+
+This looks abstract at first, but each term has a clean interpretation:
+
+- \(QK^\top\) computes compatibility scores between what each token is looking for and what every other token advertises.
+- The softmax turns those scores into a probability distribution, so each row becomes a set of attention weights that sum to \(1\).
+- Multiplying by \(V\) produces a weighted combination of the returned content.
+
+The most important conceptual point is this:
+**attention weights choose where to look; values determine what information is retrieved.**
+That is why the mechanism uses three learned projections rather than a single vector for everything.
+
+### Why queries, keys, and values are separate
+
+Each token in a sequence has to play three different roles at once:
+
+- **Query:** "What kind of information do I need right now?"
+- **Key:** "What kind of information do I contain, and when should others look at me?"
+- **Value:** "If someone attends to me, what content should I send back?"
+
+Separating these roles gives the model freedom.
+A token can be easy to match against without forcing its payload to look the same.
+That matters because being *discoverable* and being *useful* are not the same job.
+
+A good analogy is a library:
+
+- the **query** is the search phrase,
+- the **key** is the catalog entry,
+- the **value** is the actual book content.
+
+The catalog helps you find the right shelf,
+but it is not the thing you ultimately want to read.
+
+### A worked intuition: how a pronoun finds its meaning
+
+Consider the sentence:
+
+> "The animal did not cross the street because it was too tired."
+
+When the model updates the representation of the token `it`,
+it needs to decide what `it` most likely refers to.
+The query emitted by `it` will encode something like:
+
+- I am looking for a likely antecedent.
+- It should be compatible with being "too tired."
+- It should make sense in the broader sentence.
+
+Other tokens emit keys and values of their own.
+The key says how matchable that token is for the current need,
+while the value contains the information that should flow forward if chosen.
+
+| Source token | Why its key might match | Typical attention weight |
+| --- | --- | --- |
+| `animal` | Animate noun and plausible thing that can be tired | High |
+| `street` | Location, but a poor fit for "too tired" | Low |
+| `cross` | Relevant action, but not an antecedent | Medium-low |
+| `tired` | Important semantic clue about the cause | Medium |
+
+The result is subtle and important:
+the output for `it` is **not** a hard pointer to `animal`.
+It is a weighted mixture of useful information,
+with a large contribution from the value associated with `animal`
+and additional contextual signal from nearby tokens such as `tired`.
+
+So the new representation of `it` becomes richer than the raw word embedding.
+It now encodes something closer to:
+"this pronoun refers to the animal, in a context where fatigue explains the event."
+
+![Animated intuition for self-attention routing](/assets/images/attention-mechanisms-flow.svg)
+
+*Each output vector is built row by row:
+the current token emits a query,
+scores every candidate key,
+and then mixes the returned values into a contextualized representation.*
+
+### Why the scaling term \(\sqrt{d_k}\) matters
+
+The division by \(\sqrt{d_k}\) is not a cosmetic trick.
+It keeps the softmax in a regime where learning remains stable.
+
+Here is the intuition.
+If query and key vectors have dimension \(d_k\),
+their dot product tends to grow in magnitude as \(d_k\) increases.
+Without scaling, those scores can become very large,
+which makes the softmax extremely sharp.
+When that happens, one position wins too early,
+the distribution loses useful entropy,
+and gradients become small or brittle.
+
+Dividing by \(\sqrt{d_k}\) acts like a temperature control.
+It prevents the model from becoming prematurely overconfident,
+especially during training,
+and lets the network compare candidates without collapsing into a near one-hot choice too soon.
+
+### Self-attention: every token rewrites itself using the whole sequence
+
+In self-attention, the same sequence provides the queries, keys, and values.
+If the input token matrix is \(X \in \mathbb{R}^{n \times d_{\text{model}}}\),
+the model computes
+
+\[
+Q = XW^Q,\qquad
+K = XW^K,\qquad
+V = XW^V
+\]
+
+and then
+
+\[
+A = \operatorname{softmax}\left(\frac{QK^\top}{\sqrt{d_k}}\right),
+\qquad
+Y = AV
+\]
+
+where:
+
+- each row of \(A\) tells us **where one token looks**,
+- each row of \(Y\) is the **rewritten version of that token after gathering context**.
+
+This is the deepest intuition behind self-attention:
+**a token does not keep a fixed meaning as it moves upward through the network.**
+It repeatedly rewrites itself by pulling in information from the tokens most relevant to it at that layer.
+
+That is why the word `bank` can mean a riverbank in one context and a financial institution in another.
+The token starts ambiguous,
+then becomes progressively disambiguated by attending to surrounding context.
+
+In decoder-only language models such as GPT,
+self-attention is usually **causal**:
+future positions are masked out so a token can only attend to earlier tokens.
+The mechanism stays the same;
+the model is simply forbidden from looking ahead.
+
+### Multi-head attention: one mechanism, many simultaneous views
+
+A single attention operation forces every kind of dependency to compete inside one score matrix.
+But language contains many kinds of relationships at once:
+
+- syntactic structure,
+- coreference,
+- negation,
+- positional patterns,
+- semantic similarity,
+- long-range topic continuity.
+
+Multi-head attention addresses this by learning multiple sets of projections.
+Each head gets its own \(W^Q\), \(W^K\), and \(W^V\),
+so each head can build a different compatibility function over the same sequence.
+
+This is often explained as "different heads specialize in different things."
+That is a helpful intuition,
+even if real heads are not always perfectly interpretable.
+The key idea is that **multiple routing strategies can coexist in parallel**.
+One head can focus on local syntax while another tracks longer-range semantic dependencies.
+
+Afterward, the head outputs are concatenated and projected back into the model dimension,
+so the network can combine those different views into one richer representation.
+
+### Cross-attention: asking one representation to query another
+
+Cross-attention keeps the same mathematical structure,
+but queries come from one source while keys and values come from another.
+
+| Mechanism | Queries come from | Keys and values come from | Purpose |
+| --- | --- | --- | --- |
+| Self-attention | The current sequence | The same sequence | Let tokens contextualize one another |
+| Cross-attention | One sequence or modality | A different sequence or modality | Retrieve information from an external source |
+
+In machine translation,
+the decoder uses cross-attention to query the encoder outputs.
+While generating the next target token,
+it asks:
+"Which source words are relevant to what I am trying to produce right now?"
+
+In multimodal systems,
+text tokens can query image patches,
+or image features can query text embeddings.
+The deeper pattern is always the same:
+one representation acts as the current thinker,
+and another acts as an external memory to retrieve from.
+
+### Why attention changed modern deep learning
+
+Attention became foundational because it offers several powerful properties at once:
+
+- **Direct access to distant information:** relevant tokens do not have to wait through many recurrent steps to influence one another.
+- **Parallel computation:** the whole attention matrix can be computed efficiently on modern hardware.
+- **Dynamic relevance:** the model decides on the fly which pieces of context matter for the current computation.
+- **Modality flexibility:** the same basic mechanism works for text, images, audio, and multimodal systems.
+
+That said, attention is not magic.
+Vanilla self-attention has quadratic cost in sequence length,
+which becomes expensive for long contexts.
+It also has no built-in notion of locality or order;
+those biases have to be learned or injected with masking and positional information.
+
+### The mental model worth keeping
+
+If you remember only a few things, remember these:
+
+- **Attention is differentiable lookup.**
+  The model learns how to search memory rather than compressing everything into one fixed state.
+- **Keys decide where to look, values decide what comes back.**
+  That is the reason Q, K, and V are separate objects.
+- **Self-attention rewrites each token using context.**
+  The output is a new contextual representation, not a copied token.
+- **Multi-head attention lets the model run several routing strategies at once.**
+- **Cross-attention turns one representation into a query over another representation's memory.**
+
+Once that picture clicks,
+the famous equation stops looking mysterious.
+It becomes a very elegant answer to a simple question:
+how should a model decide what information matters right now?
+
+### Further reading
+
+- Bahdanau, Cho, and Bengio, [Neural Machine Translation by Jointly Learning to Align and Translate](https://arxiv.org/abs/1409.0473)
+- Vaswani et al., [Attention Is All You Need](https://arxiv.org/abs/1706.03762)
+- Dosovitskiy et al., [An Image Is Worth 16x16 Words: Transformers for Image Recognition at Scale](https://arxiv.org/abs/2010.11929)


### PR DESCRIPTION
## What changed
- rewrote the attention mechanisms post into a more research-blog style with stronger intuition and clearer structure
- added a static Q/K/V intuition diagram and an animated self-attention SVG explainer
- embedded both visuals directly in the post

## Why
- the original post was accurate but dense and high-level
- this version is meant to leave the reader with a much stronger mental model for queries, keys, values, scaling, self-attention, multi-head attention, and cross-attention

## How I tested
- npm run ci