### PR TITLE
Restore cyberpunk theme styling

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -6,82 +6,112 @@
   text-rendering: auto;
 }
 :root {
-  --background-color: #f8f8f8;
-  --background-secondary: #eef2ff;
-  --text-color: #000080;
-  --text-secondary-color: #2c3e8f;
-  --accent-color: #7da2ff;
-  --icon-color: #000080;
-  --image-border-color: #000000;
-  --code-border-color: #000000;
-  --panel-bg: rgba(8, 19, 79, 0.22);
-  --music-bg-start: #3b82f6;
-  --music-bg-end: #0ea5e9;
-  --music-vibe-start: #60a5fa;
-  --music-vibe-end: #38bdf8;
-  --table-border-color: #cccccc;
-  --table-header-bg: #e8e8ff;
-  --table-row-alt-bg: rgba(0, 0, 0, 0.05);
-  --button-bg: rgba(255, 255, 255, 0.9);
-  --button-bg-hover: rgba(248, 250, 255, 0.98);
-  --button-border: rgba(16, 24, 40, 0.08);
-  --button-shadow: 0 10px 28px rgba(15, 23, 42, 0.14);
-  --button-shadow-hover: 0 14px 32px rgba(15, 23, 42, 0.18);
-  --home-overlay: linear-gradient(135deg, rgba(248, 249, 255, 0.82), rgba(235, 240, 255, 0.58));
-  --home-text: #0d1b6f;
-  --home-panel-bg: rgba(255, 255, 255, 0.12);
+  --font-body: "Rajdhani", sans-serif;
+  --font-reading: "IBM Plex Sans", sans-serif;
+  --font-heading: "Orbitron", sans-serif;
+  --font-mono: "Roboto Mono", monospace;
+  --background-color: #f4f8ff;
+  --background-secondary: #e5eefc;
+  --text-color: #10213f;
+  --text-secondary-color: #4d628f;
+  --accent-color: #356dff;
+  --icon-color: #356dff;
+  --image-border-color: #6c96ff;
+  --code-border-color: rgba(53, 109, 255, 0.18);
+  --panel-bg: rgba(245, 249, 255, 0.84);
+  --music-bg-start: #5c8fff;
+  --music-bg-end: #b7ceff;
+  --music-vibe-start: #d8e5ff;
+  --music-vibe-end: #4b79e6;
+  --table-border-color: rgba(53, 109, 255, 0.18);
+  --table-header-bg: rgba(146, 178, 255, 0.18);
+  --table-row-alt-bg: rgba(53, 109, 255, 0.04);
+  --button-bg: rgba(248, 251, 255, 0.94);
+  --button-bg-hover: rgba(239, 245, 255, 0.98);
+  --button-border: rgba(53, 109, 255, 0.16);
+  --button-shadow: 0 0 0 1px rgba(53, 109, 255, 0.05), 0 14px 34px rgba(53, 85, 150, 0.1);
+  --button-shadow-hover: 0 0 0 1px rgba(53, 109, 255, 0.1), 0 18px 38px rgba(53, 85, 150, 0.14);
+  --equation-bg: rgba(247, 250, 255, 0.9);
+  --equation-text: #10213f;
+  --home-overlay:
+    linear-gradient(135deg, rgba(244, 248, 255, 0.8), rgba(222, 234, 255, 0.7)),
+    radial-gradient(circle at top right, rgba(77, 132, 255, 0.14), transparent 34%),
+    linear-gradient(rgba(106, 151, 255, 0.1) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(106, 151, 255, 0.1) 1px, transparent 1px);
+  --home-text: #0d1b3d;
+  --home-panel-bg: linear-gradient(145deg, rgba(248, 251, 255, 0.9), rgba(228, 238, 255, 0.82));
 }
 
 :root[data-theme="light"] {
-  --background-color: #f8f8f8;
-  --background-secondary: #eef2ff;
-  --text-color: #000080;
-  --text-secondary-color: #2c3e8f;
-  --accent-color: #7da2ff;
-  --icon-color: #000080;
-  --image-border-color: #000080;
-  --code-border-color: #000000;
-  --panel-bg: rgba(8, 19, 79, 0.22);
-  --table-border-color: #cccccc;
-  --table-header-bg: #e8e8ff;
-  --table-row-alt-bg: rgba(0, 0, 0, 0.05);
-  --button-bg: rgba(255, 255, 255, 0.9);
-  --button-bg-hover: rgba(248, 250, 255, 0.98);
-  --button-border: rgba(16, 24, 40, 0.08);
-  --button-shadow: 0 10px 28px rgba(15, 23, 42, 0.14);
-  --button-shadow-hover: 0 14px 32px rgba(15, 23, 42, 0.18);
-  --home-overlay: linear-gradient(135deg, rgba(248, 249, 255, 0.82), rgba(235, 240, 255, 0.58));
-  --home-text: #0d1b6f;
-  --home-panel-bg: rgba(255, 255, 255, 0.12);
+  --font-body: "Rajdhani", sans-serif;
+  --font-reading: "IBM Plex Sans", sans-serif;
+  --font-heading: "Orbitron", sans-serif;
+  --font-mono: "Roboto Mono", monospace;
+  --background-color: #f4f8ff;
+  --background-secondary: #e5eefc;
+  --text-color: #10213f;
+  --text-secondary-color: #4d628f;
+  --accent-color: #356dff;
+  --icon-color: #356dff;
+  --image-border-color: #6c96ff;
+  --code-border-color: rgba(53, 109, 255, 0.18);
+  --panel-bg: rgba(245, 249, 255, 0.84);
+  --equation-bg: rgba(247, 250, 255, 0.9);
+  --equation-text: #10213f;
+  --table-border-color: rgba(53, 109, 255, 0.18);
+  --table-header-bg: rgba(146, 178, 255, 0.18);
+  --table-row-alt-bg: rgba(53, 109, 255, 0.04);
+  --button-bg: rgba(248, 251, 255, 0.94);
+  --button-bg-hover: rgba(239, 245, 255, 0.98);
+  --button-border: rgba(53, 109, 255, 0.16);
+  --button-shadow: 0 0 0 1px rgba(53, 109, 255, 0.05), 0 14px 34px rgba(53, 85, 150, 0.1);
+  --button-shadow-hover: 0 0 0 1px rgba(53, 109, 255, 0.1), 0 18px 38px rgba(53, 85, 150, 0.14);
+  --home-overlay:
+    linear-gradient(135deg, rgba(244, 248, 255, 0.8), rgba(222, 234, 255, 0.7)),
+    radial-gradient(circle at top right, rgba(77, 132, 255, 0.14), transparent 34%),
+    linear-gradient(rgba(106, 151, 255, 0.1) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(106, 151, 255, 0.1) 1px, transparent 1px);
+  --home-text: #0d1b3d;
+  --home-panel-bg: linear-gradient(145deg, rgba(248, 251, 255, 0.9), rgba(228, 238, 255, 0.82));
 }
 
 :root[data-theme="dark"] {
-  --background-color: #121212;
-  --background-secondary: #1E1E1E;
-  --text-color: #E0E0E0;
-  --text-secondary-color: #A3A3A3;
-  --accent-color: #7aa2f7;
-  --icon-color: #E0E0E0;
-  --image-border-color: #E0E0E0;
-  --code-border-color: #FFFFFF;
-  --music-bg-start: #7aa2f7;
-  --music-bg-end: #bb9af7;
-  --music-vibe-start: #7dcfff;
-  --music-vibe-end: #f7768e;
-  --panel-bg: rgba(6, 10, 24, 0.7);
-  --equation-bg: #1E1E1E;
-  --equation-text: #E0E0E0;
-  --table-border-color: #3b3b3b;
-  --table-header-bg: #1E1E1E;
-  --table-row-alt-bg: rgba(255, 255, 255, 0.05);
-  --button-bg: rgba(23, 27, 39, 0.88);
-  --button-bg-hover: rgba(30, 36, 52, 0.96);
-  --button-border: rgba(255, 255, 255, 0.08);
-  --button-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
-  --button-shadow-hover: 0 16px 34px rgba(0, 0, 0, 0.46);
-  --home-overlay: linear-gradient(135deg, rgba(2, 6, 23, 0.7), rgba(8, 15, 36, 0.82));
-  --home-text: #f2f4ff;
-  --home-panel-bg: rgba(4, 10, 26, 0.26);
+  --font-body: "Rajdhani", sans-serif;
+  --font-heading: "Orbitron", sans-serif;
+  --font-mono: "Roboto Mono", monospace;
+  --background-color: #050505;
+  --background-secondary: #101010;
+  --text-color: #f6e7a6;
+  --text-secondary-color: #b9ab66;
+  --accent-color: #ffe45c;
+  --icon-color: #ffe45c;
+  --image-border-color: #ffe45c;
+  --code-border-color: rgba(255, 228, 92, 0.55);
+  --music-bg-start: #f7c600;
+  --music-bg-end: #ffea70;
+  --music-vibe-start: #fff5a8;
+  --music-vibe-end: #ffb800;
+  --panel-bg: rgba(16, 16, 16, 0.84);
+  --equation-bg: #0f0f0f;
+  --equation-text: #f6e7a6;
+  --table-border-color: rgba(255, 228, 92, 0.3);
+  --table-header-bg: rgba(255, 228, 92, 0.09);
+  --table-row-alt-bg: rgba(255, 228, 92, 0.04);
+  --button-bg: rgba(12, 12, 12, 0.92);
+  --button-bg-hover: rgba(26, 26, 26, 0.96);
+  --button-border: rgba(255, 228, 92, 0.34);
+  --button-shadow: 0 0 0 1px rgba(255, 228, 92, 0.1), 0 14px 34px rgba(0, 0, 0, 0.5);
+  --button-shadow-hover: 0 0 0 1px rgba(255, 228, 92, 0.2), 0 18px 38px rgba(0, 0, 0, 0.58);
+  --code-block-bg-dark: linear-gradient(145deg, rgba(20, 20, 20, 0.98), rgba(10, 10, 10, 0.99));
+  --code-block-text-dark: #fff4b8;
+  --code-block-border-dark: rgba(255, 228, 92, 0.3);
+  --home-overlay:
+    linear-gradient(135deg, rgba(0, 0, 0, 0.82), rgba(20, 16, 0, 0.74)),
+    radial-gradient(circle at top right, rgba(255, 228, 92, 0.14), transparent 30%),
+    linear-gradient(rgba(255, 228, 92, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 228, 92, 0.08) 1px, transparent 1px);
+  --home-text: #fff2b2;
+  --home-panel-bg: linear-gradient(145deg, rgba(11, 11, 11, 0.9), rgba(22, 18, 2, 0.8));
 }
 
 html {
@@ -92,9 +122,21 @@ body {
   background-color: var(--background-color);
   color: var(--text-color);
   margin: 0;
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-body);
   line-height: 1.6;
   transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+:root[data-theme="light"] body {
+  background-image:
+    radial-gradient(circle at top, rgba(77, 132, 255, 0.08), transparent 36%),
+    linear-gradient(180deg, rgba(231, 240, 255, 0.56), transparent 22%);
+}
+
+:root[data-theme="dark"] body {
+  background-image:
+    radial-gradient(circle at top, rgba(255, 228, 92, 0.08), transparent 34%),
+    linear-gradient(180deg, rgba(255, 228, 92, 0.04), transparent 18%);
 }
 
 body.home-page {
@@ -123,6 +165,22 @@ body.home-page small {
   backdrop-filter: blur(4px);
 }
 
+:root[data-theme="light"] .home-content-shell {
+  border: 1px solid rgba(53, 109, 255, 0.18);
+  box-shadow:
+    0 0 0 1px rgba(53, 109, 255, 0.05),
+    0 18px 48px rgba(53, 85, 150, 0.12);
+  backdrop-filter: blur(12px);
+}
+
+:root[data-theme="dark"] .home-content-shell {
+  border: 1px solid rgba(255, 228, 92, 0.24);
+  box-shadow:
+    0 0 0 1px rgba(255, 228, 92, 0.06),
+    0 18px 48px rgba(0, 0, 0, 0.52);
+  backdrop-filter: blur(12px);
+}
+
 .page-content {
   padding: 5.75rem 1.5rem 2.5rem;
 }
@@ -139,6 +197,14 @@ body.home-page small {
 .lead {
   line-height: 1.6;
   letter-spacing: 0.02em;
+}
+
+.page-content p,
+.page-content li,
+.page-content blockquote,
+.page-content td,
+.page-content th {
+  font-family: var(--font-reading);
 }
 
 .intro-text {
@@ -234,7 +300,7 @@ img:not(.float-right):not(.float-left) {
     radial-gradient(circle at top left, rgba(67, 97, 238, 0.18), transparent 32%),
     linear-gradient(160deg, var(--background-color), var(--background-secondary));
   color: var(--text-color);
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: var(--font-body);
   margin: 0;
   height: 100vh;
   display: flex;
@@ -261,6 +327,7 @@ img:not(.float-right):not(.float-left) {
   box-shadow: var(--button-shadow);
   transition:
     background-color 0.2s ease,
+    border-color 0.2s ease,
     box-shadow 0.2s ease,
     transform 0.2s ease,
     color 0.2s ease;
@@ -272,6 +339,22 @@ img:not(.float-right):not(.float-left) {
   background-color: var(--button-bg-hover);
   box-shadow: var(--button-shadow-hover);
   transform: translateY(-1px);
+}
+
+:root[data-theme="light"] .small-rounded-button {
+  color: var(--accent-color);
+}
+
+:root[data-theme="light"] .small-rounded-button:hover {
+  border-color: rgba(53, 109, 255, 0.42);
+}
+
+:root[data-theme="dark"] .small-rounded-button {
+  color: var(--accent-color);
+}
+
+:root[data-theme="dark"] .small-rounded-button:hover {
+  border-color: rgba(255, 228, 92, 0.6);
 }
 
 .small-rounded-button:focus-visible {
@@ -352,9 +435,9 @@ img:not(.float-right):not(.float-left) {
   line-height: 1.2;
   white-space: normal;
   background: linear-gradient(135deg, var(--music-bg-start), var(--music-bg-end));
-  color: #fff;
+  color: #111;
   font-weight: bold;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.36);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 #music-bar {
@@ -417,6 +500,22 @@ img:not(.float-right):not(.float-left) {
   margin: auto;
 }
 
+:root[data-theme="light"] #music-widget,
+:root[data-theme="light"] .links-panel,
+:root[data-theme="light"] .quick-overview {
+  box-shadow:
+    0 0 0 1px rgba(53, 109, 255, 0.06),
+    0 16px 40px rgba(53, 85, 150, 0.12);
+}
+
+:root[data-theme="dark"] #music-widget,
+:root[data-theme="dark"] .links-panel,
+:root[data-theme="dark"] .quick-overview {
+  box-shadow:
+    0 0 0 1px rgba(255, 228, 92, 0.12),
+    0 16px 40px rgba(0, 0, 0, 0.52);
+}
+
 #music-overlay {
   position: fixed;
   bottom: 80px;
@@ -443,10 +542,10 @@ img:not(.float-right):not(.float-left) {
 .music-choice {
   margin-right: 6px;
   padding: 6px 12px;
-  background: linear-gradient(135deg, #4b0082, #e100ff);
+  background: linear-gradient(135deg, #d7a700, #fff087);
   border: none;
   border-radius: 20px;
-  color: #fff;
+  color: #111;
   cursor: pointer;
   font-weight: bold;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
@@ -483,12 +582,22 @@ img:not(.float-right):not(.float-left) {
   position: fixed;
   bottom: 20px;
   right: 20px;
-  background-color: var(--panel-bg);
-  color: #ffffff;
+  background: var(--panel-bg);
+  color: var(--text-color);
   padding: 1rem;
   border-radius: 8px;
   width: 220px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
+:root[data-theme="light"] .links-panel {
+  border: 1px solid rgba(53, 109, 255, 0.16);
+  border-radius: 18px;
+}
+
+:root[data-theme="dark"] .links-panel {
+  border: 1px solid rgba(255, 228, 92, 0.22);
+  border-radius: 18px;
 }
 
 .links-panel__title {
@@ -515,18 +624,18 @@ img:not(.float-right):not(.float-left) {
   width: 18px;
   height: 18px;
   margin-right: 10px;
-  color: #ffffff;
+  color: inherit;
   flex-shrink: 0;
 }
 
 /* Links inside the pinned panel */
 .links-panel a {
-  color: #ffffff !important;
+  color: inherit !important;
 }
 
 .links-panel a:hover,
 .links-panel a:visited {
-  color: #ffffff !important;
+  color: inherit !important;
 }
 
 /* ------------------------------------------------------
@@ -548,6 +657,36 @@ a:hover {
 a:visited {
   color: #7aa2f7 !important; /* Slightly darker for visited links. */
   text-decoration: none;
+}
+
+:root[data-theme="light"] a {
+  color: var(--accent-color);
+  text-decoration-color: rgba(53, 109, 255, 0.4);
+}
+
+:root[data-theme="light"] a:hover {
+  color: #214fcb;
+  text-decoration: underline;
+  text-shadow: 0 0 10px rgba(79, 132, 255, 0.16);
+}
+
+:root[data-theme="light"] a:visited {
+  color: #4a58c8 !important;
+}
+
+:root[data-theme="dark"] a {
+  color: var(--accent-color);
+  text-decoration-color: rgba(255, 228, 92, 0.5);
+}
+
+:root[data-theme="dark"] a:hover {
+  color: #fff2a1;
+  text-decoration: underline;
+  text-shadow: 0 0 12px rgba(255, 228, 92, 0.34);
+}
+
+:root[data-theme="dark"] a:visited {
+  color: #d8bc45 !important;
 }
 
 /* ------------------------------------------------------
@@ -658,9 +797,25 @@ tbody tr:nth-child(odd) {
 h1,
 h2,
 h3 {
-  font-family: "Inter", sans-serif;
+  font-family: var(--font-heading);
   color: var(--text-color);
   margin-bottom: 20px;
+}
+
+:root[data-theme="light"] h1,
+:root[data-theme="light"] h2,
+:root[data-theme="light"] h3 {
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-shadow: 0 0 10px rgba(79, 132, 255, 0.1);
+}
+
+:root[data-theme="dark"] h1,
+:root[data-theme="dark"] h2,
+:root[data-theme="dark"] h3 {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-shadow: 0 0 18px rgba(255, 228, 92, 0.18);
 }
 
 .quick-overview {
@@ -670,12 +825,26 @@ h3 {
   margin-bottom: 32px;
 }
 
+:root[data-theme="light"] .quick-overview {
+  border: 1px solid rgba(53, 109, 255, 0.14);
+  border-radius: 18px;
+  background:
+    linear-gradient(145deg, rgba(249, 252, 255, 0.97), rgba(232, 240, 255, 0.92));
+}
+
+:root[data-theme="dark"] .quick-overview {
+  border: 1px solid rgba(255, 228, 92, 0.22);
+  border-radius: 18px;
+  background:
+    linear-gradient(145deg, rgba(17, 17, 17, 0.96), rgba(8, 8, 8, 0.92));
+}
+
 .quick-overview li {
   margin-bottom: 12px;
 }
 
 code {
-  font-family: "Roboto Mono", monospace;
+  font-family: var(--font-mono);
   background-color: var(--background-secondary);
   padding: 4px 8px;
   border-radius: 4px;
@@ -691,9 +860,76 @@ pre {
   font-size: 13px;
 }
 
+pre code {
+  display: block;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+  font-size: inherit;
+  line-height: 1.7;
+  white-space: pre;
+}
+
+:root[data-theme="light"] code,
+:root[data-theme="light"] pre {
+  background:
+    linear-gradient(145deg, rgba(249, 252, 255, 0.98), rgba(233, 241, 255, 0.96));
+  color: #18305f;
+}
+
+:root[data-theme="light"] pre {
+  border: 1px solid rgba(53, 109, 255, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(53, 109, 255, 0.04);
+}
+
+:root[data-theme="dark"] code,
+:root[data-theme="dark"] pre {
+  background: var(--code-block-bg-dark);
+  color: var(--code-block-text-dark);
+}
+
+:root[data-theme="dark"] pre {
+  border: 1px solid var(--code-block-border-dark);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 228, 92, 0.06),
+    0 12px 30px rgba(0, 0, 0, 0.24);
+}
+
+:root[data-theme="dark"] pre.astro-code {
+  background-color: var(--shiki-dark-bg) !important;
+  color: var(--shiki-dark) !important;
+}
+
+:root[data-theme="dark"] pre code,
+:root[data-theme="dark"] pre code span,
+:root[data-theme="dark"] pre code span[style] {
+  background: transparent !important;
+  color: inherit;
+  text-shadow: none;
+  opacity: 1 !important;
+}
+
+:root[data-theme="dark"] pre code {
+  color: var(--shiki-dark, var(--code-block-text-dark));
+}
+
+:root[data-theme="dark"] pre code span[style] {
+  color: var(--shiki-dark) !important;
+}
+
 .section {
   padding-bottom: 32px;
   border-bottom: 1px solid var(--background-secondary);
+}
+
+:root[data-theme="light"] .section {
+  border-bottom: 1px solid rgba(53, 109, 255, 0.1);
+}
+
+:root[data-theme="dark"] .section {
+  border-bottom: 1px solid rgba(255, 228, 92, 0.14);
 }
 
 .section:last-child {
@@ -709,15 +945,64 @@ pre {
   color: var(--text-color);
 }
 
-.home-page a {
-  color: #0000ff;
+:root[data-theme="light"] .home-page {
+  --text-color: var(--home-text);
 }
 
-.home-page a:hover {
-  text-decoration: underline;
+:root[data-theme="light"] .home-page a {
+  color: var(--accent-color);
 }
 
-.home-page a:visited,
-.home-page a:active {
-  color: #7aa2f7;
+:root[data-theme="light"] .home-page a:visited,
+:root[data-theme="light"] .home-page a:active {
+  color: #4a58c8;
+}
+
+:root[data-theme="light"] .lead {
+  color: #15315e;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+:root[data-theme="light"] .intro-text,
+:root[data-theme="light"] small,
+:root[data-theme="light"] p {
+  color: var(--text-color);
+}
+
+:root[data-theme="light"] .icon-list li::before {
+  background:
+    linear-gradient(135deg, #4d82ff, #b7cbff);
+  box-shadow: 0 0 8px rgba(77, 130, 255, 0.22);
+}
+
+:root[data-theme="dark"] .home-page {
+  --text-color: var(--home-text);
+}
+
+:root[data-theme="dark"] .home-page a {
+  color: var(--accent-color);
+}
+
+:root[data-theme="dark"] .home-page a:visited,
+:root[data-theme="dark"] .home-page a:active {
+  color: #e0c54f;
+}
+
+:root[data-theme="dark"] .lead {
+  color: #fff3b7;
+  font-size: 1.1rem;
+  letter-spacing: 0.03em;
+}
+
+:root[data-theme="dark"] .intro-text,
+:root[data-theme="dark"] small,
+:root[data-theme="dark"] p {
+  color: var(--text-color);
+}
+
+:root[data-theme="dark"] .icon-list li::before {
+  background:
+    linear-gradient(135deg, #ffe45c, #fff2a8);
+  box-shadow: 0 0 10px rgba(255, 228, 92, 0.5);
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
+const themeStylesheetHref = '/css/override.css?v=20260318-cyberpunk-restore-1';
 ---
 
 <!DOCTYPE html>
@@ -51,9 +52,9 @@ const canonicalUrl = Astro.site
     />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=IBM+Plex+Sans:wght@300;400&family=Roboto+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400&family=Inter:wght@500;700&family=Orbitron:wght@500;700;800&family=Rajdhani:wght@400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap"
     />
-    <link rel="stylesheet" href="/css/override.css" />
+    <link rel="stylesheet" href={themeStylesheetHref} />
     <slot name="head" />
   </head>
   <body class={pageClass}>


### PR DESCRIPTION
## What changed
- restore the cyberpunk light/dark theme tokens, typography, code block styling, and accent treatments in the site stylesheet
- restore the theme-specific font import and cache-busted stylesheet load in the base layout
- keep the recent content/CI simplification changes intact

## Why
- the previous simplification PR accidentally overwrote the newer cyberpunk theme files with an older local snapshot
- this follow-up restores the intended visual design without undoing the authoring and validation cleanup

## Testing
- npm run ci