### PR TITLE
Fix equation rendering on post pages

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -23,6 +23,8 @@
   --music-bg-end: #b7ceff;
   --music-vibe-start: #d8e5ff;
   --music-vibe-end: #4b79e6;
+  --equation-border-color: rgba(53, 109, 255, 0.18);
+  --equation-shadow: 0 18px 40px rgba(53, 85, 150, 0.12);
   --table-border-color: rgba(53, 109, 255, 0.18);
   --table-header-bg: rgba(146, 178, 255, 0.18);
   --table-row-alt-bg: rgba(53, 109, 255, 0.04);
@@ -58,6 +60,8 @@
   --panel-bg: rgba(245, 249, 255, 0.84);
   --equation-bg: rgba(247, 250, 255, 0.9);
   --equation-text: #10213f;
+  --equation-border-color: rgba(53, 109, 255, 0.18);
+  --equation-shadow: 0 18px 40px rgba(53, 85, 150, 0.12);
   --table-border-color: rgba(53, 109, 255, 0.18);
   --table-header-bg: rgba(146, 178, 255, 0.18);
   --table-row-alt-bg: rgba(53, 109, 255, 0.04);
@@ -94,6 +98,8 @@
   --panel-bg: rgba(16, 16, 16, 0.84);
   --equation-bg: #0f0f0f;
   --equation-text: #f6e7a6;
+  --equation-border-color: rgba(255, 228, 92, 0.28);
+  --equation-shadow: 0 22px 42px rgba(0, 0, 0, 0.48);
   --table-border-color: rgba(255, 228, 92, 0.3);
   --table-header-bg: rgba(255, 228, 92, 0.09);
   --table-row-alt-bg: rgba(255, 228, 92, 0.04);
@@ -788,6 +794,42 @@ tbody tr:nth-child(odd) {
 
 .equation-box .katex-display {
   margin: 0;
+}
+
+.katex-display {
+  margin: 1.75rem 0;
+  padding: 1.25rem 1.5rem;
+  overflow-x: auto;
+  border: 1px solid var(--equation-border-color);
+  border-radius: 18px;
+  background: var(--equation-bg);
+  box-shadow: var(--equation-shadow);
+}
+
+.katex-display > .katex {
+  color: var(--equation-text);
+  font-size: 1.08em;
+}
+
+.katex-display::before {
+  content: "Equation";
+  display: block;
+  margin-bottom: 0.8rem;
+  font-family: var(--font-heading);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-secondary-color);
+}
+
+.katex-display .katex-html {
+  padding-bottom: 0.05rem;
+}
+
+.katex-error {
+  color: #ff6b6b;
+  font-weight: 600;
 }
 
 /* ------------------------------------------------------

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,6 +43,18 @@ const themeStylesheetHref = '/css/override.css?v=20260318-cyberpunk-restore-1';
       integrity="sha384-CErX1DK4Fk6gXV8zvfuTQDXyP/d9vywgqbiZ9erjRzCQXDpUe1koRaSPjqH9fHYC"
       crossorigin="anonymous"
     />
+    <script
+      is:inline
+      defer
+      src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      is:inline
+      defer
+      src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
+      crossorigin="anonymous"
+    ></script>
     <link
       rel="preload"
       href="https://rsms.me/inter/font-files/InterVariable.woff2"
@@ -60,5 +72,23 @@ const themeStylesheetHref = '/css/override.css?v=20260318-cyberpunk-restore-1';
   <body class={pageClass}>
     <slot />
     <script is:inline src="/assets/js/site-controls.js"></script>
+    <script is:inline>
+      {`document.addEventListener('DOMContentLoaded', () => {
+        if (typeof renderMathInElement !== 'function') {
+          return;
+        }
+
+        renderMathInElement(document.body, {
+          delimiters: [
+            { left: '$$', right: '$$', display: true },
+            { left: '\\\\[', right: '\\\\]', display: true },
+            { left: '$', right: '$', display: false },
+            { left: '\\\\(', right: '\\\\)', display: false },
+          ],
+          ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+          throwOnError: false,
+        });
+      });`}
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restore KaTeX auto-render in the base layout so posts using \(...\) and \[...\] render correctly
- style display equations with a theme-aware panel so they feel consistent with the existing code-block treatment

## Testing
- npm run ci