### PR TITLE
Normalize markdown math delimiters

### DIFF
--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -37,6 +37,22 @@ async function main() {
     assertExists(path.join(distDir, relativePath));
   }
 
+  const attentionPagePath = path.join(
+    distDir,
+    'ponderings',
+    '2025',
+    '05',
+    '25',
+    'attention-mechanisms-demystified.html',
+  );
+  const attentionHtml = await readFile(attentionPagePath, 'utf8');
+  if (!attentionHtml.includes('katex-display')) {
+    throw new Error('Expected the attention mechanisms post to contain rendered KaTeX output.');
+  }
+  if (attentionHtml.includes('<h1 id="operatornameattentionq-k-v">[')) {
+    throw new Error('Attention mechanisms post still contains raw markdown-mangled math output.');
+  }
+
   console.log(`Verified ${criticalPages.length} critical pages and ${manifest.length} post routes.`);
 }
 

--- a/src/content/posts/attention-is-all-you-need.md
+++ b/src/content/posts/attention-is-all-you-need.md
@@ -49,9 +49,9 @@ def scaled_dot_product_attention(
     return output, weights
 ```
 
-The scaling by \(\sqrt{d_k}\) keeps the logits numerically stable as \(d_k\) grows.
-The additive mask inserts \(-\infty\) so the softmax cleanly ignores blocked positions.
-Multi-head attention, typically eight heads with \(d_k = d_v = 64\),
+The scaling by $\sqrt{d_k}$ keeps the logits numerically stable as $d_k$ grows.
+The additive mask inserts $-\infty$ so the softmax cleanly ignores blocked positions.
+Multi-head attention, typically eight heads with $d_k = d_v = 64$,
 preserves information that a single head would compress.
 
 <img src="/assets/images/attention.png" alt="Transformer" style="max-width:60%;margin:1rem auto;display:block;">

--- a/src/content/posts/attention-mechanisms-demystified.md
+++ b/src/content/posts/attention-mechanisms-demystified.md
@@ -35,17 +35,17 @@ It scores candidate sources using keys, then mixes their values into a new repre
 
 The entire mechanism is summarized by a single expression:
 
-\[
+$$
 \operatorname{Attention}(Q, K, V)
 =
 \operatorname{softmax}\left(\frac{QK^\top}{\sqrt{d_k}}\right)V
-\]
+$$
 
 This looks abstract at first, but each term has a clean interpretation:
 
-- \(QK^\top\) computes compatibility scores between what each token is looking for and what every other token advertises.
-- The softmax turns those scores into a probability distribution, so each row becomes a set of attention weights that sum to \(1\).
-- Multiplying by \(V\) produces a weighted combination of the returned content.
+- $QK^\top$ computes compatibility scores between what each token is looking for and what every other token advertises.
+- The softmax turns those scores into a probability distribution, so each row becomes a set of attention weights that sum to $1$.
+- Multiplying by $V$ produces a weighted combination of the returned content.
 
 The most important conceptual point is this:
 **attention weights choose where to look; values determine what information is retrieved.**
@@ -114,21 +114,21 @@ the current token emits a query,
 scores every candidate key,
 and then mixes the returned values into a contextualized representation.*
 
-### Why the scaling term \(\sqrt{d_k}\) matters
+### Why the scaling term $\sqrt{d_k}$ matters
 
-The division by \(\sqrt{d_k}\) is not a cosmetic trick.
+The division by $\sqrt{d_k}$ is not a cosmetic trick.
 It keeps the softmax in a regime where learning remains stable.
 
 Here is the intuition.
-If query and key vectors have dimension \(d_k\),
-their dot product tends to grow in magnitude as \(d_k\) increases.
+If query and key vectors have dimension $d_k$,
+their dot product tends to grow in magnitude as $d_k$ increases.
 Without scaling, those scores can become very large,
 which makes the softmax extremely sharp.
 When that happens, one position wins too early,
 the distribution loses useful entropy,
 and gradients become small or brittle.
 
-Dividing by \(\sqrt{d_k}\) acts like a temperature control.
+Dividing by $\sqrt{d_k}$ acts like a temperature control.
 It prevents the model from becoming prematurely overconfident,
 especially during training,
 and lets the network compare candidates without collapsing into a near one-hot choice too soon.
@@ -136,27 +136,27 @@ and lets the network compare candidates without collapsing into a near one-hot c
 ### Self-attention: every token rewrites itself using the whole sequence
 
 In self-attention, the same sequence provides the queries, keys, and values.
-If the input token matrix is \(X \in \mathbb{R}^{n \times d_{\text{model}}}\),
+If the input token matrix is $X \in \mathbb{R}^{n \times d_{\text{model}}}$,
 the model computes
 
-\[
+$$
 Q = XW^Q,\qquad
 K = XW^K,\qquad
 V = XW^V
-\]
+$$
 
 and then
 
-\[
+$$
 A = \operatorname{softmax}\left(\frac{QK^\top}{\sqrt{d_k}}\right),
 \qquad
 Y = AV
-\]
+$$
 
 where:
 
-- each row of \(A\) tells us **where one token looks**,
-- each row of \(Y\) is the **rewritten version of that token after gathering context**.
+- each row of $A$ tells us **where one token looks**,
+- each row of $Y$ is the **rewritten version of that token after gathering context**.
 
 This is the deepest intuition behind self-attention:
 **a token does not keep a fixed meaning as it moves upward through the network.**
@@ -185,7 +185,7 @@ But language contains many kinds of relationships at once:
 - long-range topic continuity.
 
 Multi-head attention addresses this by learning multiple sets of projections.
-Each head gets its own \(W^Q\), \(W^K\), and \(W^V\),
+Each head gets its own $W^Q$, $W^K$, and $W^V$,
 so each head can build a different compatibility function over the same sequence.
 
 This is often explained as "different heads specialize in different things."

--- a/src/content/posts/auto-encoding-variational-bayes.md
+++ b/src/content/posts/auto-encoding-variational-bayes.md
@@ -22,7 +22,7 @@ summary: 2014 – Auto-Encoding Variational Bayes
 **Summary (abstract in plain English):**
 Kingma and Welling propose training deep generative models with continuous latent variables by
 optimising a reparameterised evidence lower bound (ELBO) using standard stochastic gradient descent.
-An encoder \(q_\phi(z \mid x)\) approximates the true posterior, while a decoder \(p_\theta(x \mid z)\)
+An encoder $q_\phi(z \mid x)$ approximates the true posterior, while a decoder $p_\theta(x \mid z)$
 reconstructs observations. The reparameterisation trick makes the stochastic nodes differentiable,
 enabling efficient gradient learning.
 
@@ -31,11 +31,11 @@ enabling efficient gradient learning.
 - Recognition networks fuse amortised inference with deep learning, making variational Bayes practical
   at scale.
 - Established VAEs as a general-purpose unsupervised representation learner, inspiring variants such as
-  \(\beta\)-VAE, conditional VAEs, and flow-based models.
+  $\beta$-VAE, conditional VAEs, and flow-based models.
 
 **Evals / Latency benchmarks:**
 
-| Dataset | Latent dim | \(-\log p(x)\) ↓ (nats) | Notes |
+| Dataset | Latent dim | $-\log p(x)$ ↓ (nats) | Notes |
 | ------- | ---------- | ---------------------- | ----- |
 | Binarised MNIST | 30 | ≈ 88 nats (ELBO estimate) | Competed closely with deep latent-Gaussian models |
 | Frey Faces | 2 | Smooth latent manifold | Visually coherent reconstructions |

--- a/src/content/posts/cs336-revision-notes.md
+++ b/src/content/posts/cs336-revision-notes.md
@@ -158,9 +158,9 @@ Benefit: Einops manipulates only metadata when strides allow, enabling intuitive
 FLOPs (Floating Point Operations per Second) measure computational efficiency. Model FLOP Utilization (MFU) is the ratio of actual FLOPs achieved by the hardware to its theoretical maximum, typically less than 1 due to overheads like memory latency, kernel launch overheads, and suboptimal hardware utilization.
 
 <div class="equation-box">
-\[
+$$
 MFU = \frac{\text{achieved FLOPs}}{\text{theoretical FLOPs}}
-\]
+$$
 </div>
 
 ```python

--- a/src/content/posts/deep-residual-learning-for-image-recognition.md
+++ b/src/content/posts/deep-residual-learning-for-image-recognition.md
@@ -19,10 +19,10 @@ summary: 2015 – Deep Residual Learning for Image Recognition
 
 **Conference:** CVPR 2016 (1st place ILSVRC 2015 classifier)
 
-**Summary (abstract in plain English):** ResNet reframes a layer’s objective from learning an outright mapping \(H(x)\) to learning a residual \(F(x)=H(x)-x\), then adding back the identity shortcut: \(H(x)=F(x)+x\). These identity “highways” let gradients flow through 152-layer nets without vanishing, so extremely deep models become easier to optimise and more accurate. Despite being eight times deeper than VGG-19, a ResNet-152 is 38 % cheaper in FLOPs thanks to the 1×1–3×3–1×1 bottleneck design. An ensemble of ResNets (50–152 layers) achieved 3.57 % top‑5 error on ImageNet, winning ILSVRC 2015.
+**Summary (abstract in plain English):** ResNet reframes a layer’s objective from learning an outright mapping $H(x)$ to learning a residual $F(x)=H(x)-x$, then adding back the identity shortcut: $H(x)=F(x)+x$. These identity “highways” let gradients flow through 152-layer nets without vanishing, so extremely deep models become easier to optimise and more accurate. Despite being eight times deeper than VGG-19, a ResNet-152 is 38 % cheaper in FLOPs thanks to the 1×1–3×3–1×1 bottleneck design. An ensemble of ResNets (50–152 layers) achieved 3.57 % top‑5 error on ImageNet, winning ILSVRC 2015.
 
 **Novel insights:**
-- **Residual vs. direct mapping:** if the identity mapping is optimal, a residual block can simply drive \(F(x) \rightarrow 0\), dodging the degradation that afflicts plain deep nets.
+- **Residual vs. direct mapping:** if the identity mapping is optimal, a residual block can simply drive $F(x) \rightarrow 0$, dodging the degradation that afflicts plain deep nets.
 - **Cost-free identity shortcuts** give gradient highways without adding parameters or inference cost.
 - **Depth with efficiency:** bottleneck blocks cut computation so a 152-layer ResNet needs 11.3 GFLOPs vs. VGG‑19’s 19.6 GFLOPs while being far deeper.
 

--- a/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
+++ b/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
@@ -21,7 +21,7 @@ summary: '2020 – EfficientDet: Scalable and Efficient Object Detection'
 
 **Conference:** CVPR 2020
 
-**Summary (abstract in plain English):** EfficientDet revisits object-detector design under tight efficiency constraints. Building on EfficientNet backbones, the authors introduce Bi-directional Feature Pyramid Networks (BiFPN) for fast, weighted multi-scale fusion and a compound-scaling rule that grows depth, width and input resolution of all detector components with a single coefficient \(\phi\). This yields the D0→D7 family, each tuned to a specific FLOP or latency budget while sharing the same architecture and training recipe.
+**Summary (abstract in plain English):** EfficientDet revisits object-detector design under tight efficiency constraints. Building on EfficientNet backbones, the authors introduce Bi-directional Feature Pyramid Networks (BiFPN) for fast, weighted multi-scale fusion and a compound-scaling rule that grows depth, width and input resolution of all detector components with a single coefficient $\phi$. This yields the D0→D7 family, each tuned to a specific FLOP or latency budget while sharing the same architecture and training recipe.
 
 **Novel insights:**
 - Weighted BiFPN learns per-edge weights so the network can emphasise informative paths with little overhead.

--- a/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
+++ b/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
@@ -24,11 +24,11 @@ summary: 2019 – EfficientNet — Rethinking Model Scaling for ConvNets
 **Summary (abstract in plain English):**
 Standard CNNs tend to grow along a single axis: make them deeper, wider or feed higher-resolution images.
 Tan and Le show that such unbalanced scaling leaves accuracy on the table.
-They first search for a mobile-sized baseline (B0) then scale depth, width and resolution together using a single factor \(\phi\).
+They first search for a mobile-sized baseline (B0) then scale depth, width and resolution together using a single factor $\phi$.
 The compound rule keeps FLOPs roughly constant while delivering much better accuracy–efficiency trade-offs.
 
 **Novel insights:**
-- Compound scaling jointly tunes depth \(\alpha^\phi\), width \(\beta^\phi\) and resolution \(\gamma^\phi\) for better performance.
+- Compound scaling jointly tunes depth $\alpha^\phi$, width $\beta^\phi$ and resolution $\gamma^\phi$ for better performance.
 - One NAS-derived micro-architecture (B0) can be stretched analytically into a full B1–B7 family.
 - B1 matches ResNet-152 with 27× fewer FLOPs, while B7 tops ImageNet using a fraction of prior NAS parameters.
 

--- a/src/content/posts/generative-adversarial-networks.md
+++ b/src/content/posts/generative-adversarial-networks.md
@@ -21,11 +21,11 @@ summary: 2014 – Generative Adversarial Networks
 
 **Summary (abstract in plain English):**
 GANs formulate generative modelling as a game between two neural networks.
-A generator \(G\) transforms random noise into synthetic samples, while a
- discriminator \(D\) learns to distinguish real data from fakes.
-Training alternates between improving \(D\) to classify correctly and
-adjusting \(G\) to fool \(D\).
-At equilibrium, \(G\) replicates the true data distribution and \(D\) outputs
+A generator $G$ transforms random noise into synthetic samples, while a
+ discriminator $D$ learns to distinguish real data from fakes.
+Training alternates between improving $D$ to classify correctly and
+adjusting $G$ to fool $D$.
+At equilibrium, $G$ replicates the true data distribution and $D$ outputs
 0.5 everywhere.
 Initial experiments with multilayer perceptrons produced realistic MNIST
  digits without needing explicit likelihoods.

--- a/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
@@ -23,7 +23,7 @@ summary: 2021 – Improved Denoising Diffusion Probabilistic Models (ID DPM)
 Nichol and Dhariwal revisit DDPMs with three upgrades that lift both likelihood and sample quality while
 reducing sampling cost.
 
-- Learn the reverse-process variance \(\Sigma_\theta\) instead of keeping it fixed.
+- Learn the reverse-process variance $\Sigma_\theta$ instead of keeping it fixed.
 - Optimise a hybrid objective: half ELBO, half simple noise-prediction loss.
 - Use a cosine noise schedule with importance-weighted loss terms for stable gradients.
 
@@ -63,7 +63,7 @@ def iddpm_loss(model, x0, timesteps, betas, logvar_schedule):
     kl = 0.5 * (torch.exp(-logvar_hat) * (noise ** 2) + logvar_hat).mean()
     return 0.5 * (mse + kl)
 ```
-Switching to the cosine \(\beta_t\) schedule from the appendix further sharpens FID at low step counts.
+Switching to the cosine $\beta_t$ schedule from the appendix further sharpens FID at low step counts.
 
 **Critiques**
 - **What shines:** Simple, drop-in upgrades that became the default for Stable Diffusion and DALLE‑2.

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import fg from 'fast-glob';
 import { describe, expect, it } from 'vitest';
 import {
   groupPostsByField,
@@ -13,6 +14,7 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 const manifestPath = path.join(projectRoot, 'src', 'content', 'migration-manifest.json');
+const postsDir = path.join(projectRoot, 'src', 'content', 'posts');
 
 type ManifestEntry = {
   legacyPath: string;
@@ -64,6 +66,28 @@ describe('migration manifest', () => {
         'my-journey',
       ]),
     );
+  });
+});
+
+describe('markdown authoring', () => {
+  it('uses remark-math compatible delimiters in posts', async () => {
+    const postFiles = await fg('**/*.{md,mdx}', {
+      cwd: postsDir,
+      absolute: true,
+    });
+
+    const offenders: string[] = [];
+    for (const filePath of postFiles) {
+      const source = await readFile(filePath, 'utf8');
+      if (/\\\(|\\\)|\\\[|\\\]/.test(source)) {
+        offenders.push(path.relative(projectRoot, filePath));
+      }
+    }
+
+    expect(
+      offenders,
+      'Use $...$ or $$...$$ instead of \\(...\\) or \\[...\\] in markdown posts.',
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- convert markdown posts from TeX-style \(...\) and \[...\] delimiters to the dollar-based syntax supported by the Astro math pipeline
- keep the attention post and other math-heavy posts rendering at build time instead of relying on brittle client-side recovery
- add a CI guard so unsupported math delimiters fail fast in tests and build verification

## Testing
- npm run ci