### PR TITLE
Fix KaTeX CSS loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent Notes
+
+## Math In Posts
+
+- For markdown posts, use `$...$` for inline math and `$$...$$` for display math.
+- Do not use `\(...\)` or `\[...\]` in markdown posts. This repo's `remark-math` pipeline is validated against dollar-style delimiters.
+- Before shipping math-heavy post edits, run `npm run ci`. The test suite and build verification now check for unsupported delimiters and for rendered KaTeX output on the attention post.
+
+## KaTeX Assets
+
+- If you change the KaTeX CDN URL or version in `src/layouts/BaseLayout.astro`, update the stylesheet SRI hash at the same time.
+- A bad KaTeX CSS integrity hash causes browsers to reject the stylesheet, which makes equations show both MathML and KaTeX HTML at once.

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -797,6 +797,9 @@ tbody tr:nth-child(odd) {
 }
 
 .katex-display {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
   margin: 1.75rem 0;
   padding: 1.25rem 1.5rem;
   overflow-x: auto;
@@ -804,11 +807,25 @@ tbody tr:nth-child(odd) {
   border-radius: 18px;
   background: var(--equation-bg);
   box-shadow: var(--equation-shadow);
+  text-align: center;
 }
 
 .katex-display > .katex {
+  display: block;
   color: var(--equation-text);
   font-size: 1.08em;
+}
+
+.katex .katex-mathml {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .katex-display::before {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,7 +40,7 @@ const themeStylesheetHref = '/css/override.css?v=20260318-cyberpunk-restore-1';
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
-      integrity="sha384-CErX1DK4Fk6gXV8zvfuTQDXyP/d9vywgqbiZ9erjRzCQXDpUe1koRaSPjqH9fHYC"
+      integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV"
       crossorigin="anonymous"
     />
     <script


### PR DESCRIPTION
## Summary
- fix the KaTeX stylesheet integrity hash so browsers stop rejecting the CSS
- add a couple of lightweight equation layout safeguards in the site stylesheet
- document the markdown math and KaTeX asset rules in AGENTS.md for future edits

## Testing
- npm run ci