### PR TITLE
Scrub equation rendering rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 ## Math In Posts
 
-- For markdown posts, use `$...$` for inline math and `$$...$$` for display math.
-- Do not use `\(...\)` or `\[...\]` in markdown posts. This repo's `remark-math` pipeline is validated against dollar-style delimiters.
-- Before shipping math-heavy post edits, run `npm run ci`. The test suite and build verification now check for unsupported delimiters and for rendered KaTeX output on the attention post.
+- Use `$...$` for inline math and `$$...$$` for display math in markdown posts.
+- Do not use `\(...\)` or `\[...\]` in markdown posts. This repo's math pipeline and tests are built around dollar-style delimiters.
+- After math-heavy content edits, run `npm run ci`. The test suite rejects unsupported delimiters and the build verification checks that math posts emit KaTeX markup.
 
 ## KaTeX Assets
 
-- If you change the KaTeX CDN URL or version in `src/layouts/BaseLayout.astro`, update the stylesheet SRI hash at the same time.
-- A bad KaTeX CSS integrity hash causes browsers to reject the stylesheet, which makes equations show both MathML and KaTeX HTML at once.
+- If you update the KaTeX CDN URL or version in `src/layouts/BaseLayout.astro`, update the stylesheet SRI hash too.
+- A bad KaTeX CSS integrity hash causes browsers to reject the stylesheet, which makes equations render as a broken mix of MathML and visible KaTeX HTML.

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -783,19 +783,6 @@ tbody tr:nth-child(odd) {
    9) EQUATION BOX
    ------------------------------------------------------ */
 
-.equation-box {
-  background-color: var(--equation-bg);
-  color: var(--equation-text);
-  border: 1px solid var(--table-border-color);
-  padding: 1rem;
-  margin: 1rem 0;
-  overflow-x: auto;
-}
-
-.equation-box .katex-display {
-  margin: 0;
-}
-
 .katex-display {
   display: block;
   width: 100%;
@@ -826,18 +813,6 @@ tbody tr:nth-child(odd) {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-}
-
-.katex-display::before {
-  content: "Equation";
-  display: block;
-  margin-bottom: 0.8rem;
-  font-family: var(--font-heading);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--text-secondary-color);
 }
 
 .katex-display .katex-html {

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -2,11 +2,14 @@ import { readFile } from 'node:fs/promises';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import fg from 'fast-glob';
+import matter from 'gray-matter';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 const distDir = path.join(projectRoot, 'dist');
 const manifestPath = path.join(projectRoot, 'src', 'content', 'migration-manifest.json');
+const postsDir = path.join(projectRoot, 'src', 'content', 'posts');
 
 const criticalPages = [
   'index.html',
@@ -24,6 +27,30 @@ function assertExists(targetPath) {
   if (!fs.existsSync(targetPath)) {
     throw new Error(`Expected build output missing: ${targetPath}`);
   }
+}
+
+async function getMathPostRoutes() {
+  const postFiles = await fg('**/*.{md,mdx}', {
+    cwd: postsDir,
+    absolute: true,
+  });
+
+  const routes = [];
+  for (const filePath of postFiles) {
+    const source = await readFile(filePath, 'utf8');
+    if (!/\$\$|\$[^$\n]+\$/.test(source)) {
+      continue;
+    }
+
+    const { data } = matter(source);
+    if (typeof data.legacyPath !== 'string') {
+      throw new Error(`Expected legacyPath in frontmatter for ${path.relative(projectRoot, filePath)}.`);
+    }
+
+    routes.push(data.legacyPath.trim());
+  }
+
+  return routes;
 }
 
 async function main() {
@@ -51,6 +78,16 @@ async function main() {
   }
   if (attentionHtml.includes('<h1 id="operatornameattentionq-k-v">[')) {
     throw new Error('Attention mechanisms post still contains raw markdown-mangled math output.');
+  }
+
+  const mathRoutes = await getMathPostRoutes();
+  for (const route of mathRoutes) {
+    const relativePath = route.replace(/^\//, '');
+    const builtPath = path.join(distDir, relativePath);
+    const html = await readFile(builtPath, 'utf8');
+    if (!html.includes('class="katex"')) {
+      throw new Error(`Expected rendered KaTeX output in ${relativePath}.`);
+    }
   }
 
   console.log(`Verified ${criticalPages.length} critical pages and ${manifest.length} post routes.`);

--- a/src/content/posts/cs336-revision-notes.md
+++ b/src/content/posts/cs336-revision-notes.md
@@ -157,11 +157,9 @@ Benefit: Einops manipulates only metadata when strides allow, enabling intuitive
 
 FLOPs (Floating Point Operations per Second) measure computational efficiency. Model FLOP Utilization (MFU) is the ratio of actual FLOPs achieved by the hardware to its theoretical maximum, typically less than 1 due to overheads like memory latency, kernel launch overheads, and suboptimal hardware utilization.
 
-<div class="equation-box">
 $$
 MFU = \frac{\text{achieved FLOPs}}{\text{theoretical FLOPs}}
 $$
-</div>
 
 ```python
 from math import prod


### PR DESCRIPTION
## Summary
- remove the extra equation label from display math blocks and delete the unused raw HTML equation wrapper path
- fix the remaining revision-notes equation so it renders through the same markdown math pipeline as the rest of the site
- add repo guidance in AGENTS.md and extend build verification so all current math posts are checked for KaTeX output

## Testing
- npm run ci