### PR TITLE
Refresh homepage layout

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1073,3 +1073,572 @@ pre code {
     linear-gradient(135deg, #ffe45c, #fff2a8);
   box-shadow: 0 0 10px rgba(255, 228, 92, 0.5);
 }
+
+/* ------------------------------------------------------
+   Homepage layout refresh
+   ------------------------------------------------------ */
+
+:root[data-theme="light"] {
+  --home-shell-surface:
+    linear-gradient(180deg, rgba(251, 253, 255, 0.88), rgba(237, 244, 255, 0.78));
+  --home-shell-border: rgba(53, 109, 255, 0.16);
+  --home-shell-shadow:
+    0 0 0 1px rgba(53, 109, 255, 0.04),
+    0 22px 54px rgba(53, 85, 150, 0.12);
+  --home-shell-muted: #5d7095;
+  --home-shell-strong: #132a57;
+  --home-shell-accent: #2f66f2;
+  --home-shell-accent-soft: rgba(53, 109, 255, 0.08);
+  --home-grid-line: rgba(53, 109, 255, 0.08);
+}
+
+:root[data-theme="dark"] {
+  --home-shell-surface:
+    linear-gradient(180deg, rgba(14, 14, 14, 0.88), rgba(24, 20, 6, 0.76));
+  --home-shell-border: rgba(255, 228, 92, 0.22);
+  --home-shell-shadow:
+    0 0 0 1px rgba(255, 228, 92, 0.06),
+    0 24px 58px rgba(0, 0, 0, 0.5);
+  --home-shell-muted: #c7b978;
+  --home-shell-strong: #fff3b8;
+  --home-shell-accent: #ffe45c;
+  --home-shell-accent-soft: rgba(255, 228, 92, 0.1);
+  --home-grid-line: rgba(255, 228, 92, 0.08);
+}
+
+body.home-page {
+  background:
+    radial-gradient(circle at 12% 16%, rgba(255, 255, 255, 0.12), transparent 22%),
+    linear-gradient(180deg, rgba(6, 10, 18, 0.16), rgba(6, 10, 18, 0.22)),
+    url('/assets/images/shootingstar.jpg') center top / cover no-repeat;
+  background-attachment: scroll;
+}
+
+.home-stage {
+  position: relative;
+  min-height: 100vh;
+  padding: clamp(5.25rem, 9vw, 6.75rem) clamp(1rem, 3vw, 2rem) clamp(2rem, 4vw, 3rem);
+}
+
+.home-stage::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, var(--home-grid-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--home-grid-line) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.36), transparent 88%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.home-shell {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 88rem);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18.5rem;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.home-content-shell {
+  width: auto;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  box-shadow: none;
+  backdrop-filter: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.home-sidebar {
+  position: sticky;
+  top: 5.25rem;
+}
+
+.home-hero,
+.home-panel,
+.links-panel {
+  position: relative;
+  overflow: hidden;
+  border-radius: 28px;
+  border: 1px solid var(--home-shell-border);
+  background: var(--home-shell-surface);
+  box-shadow: var(--home-shell-shadow);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.home-hero::before,
+.home-panel::before,
+.links-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 42%);
+  pointer-events: none;
+}
+
+.home-hero,
+.home-panel,
+.links-panel,
+.links-panel-stack,
+.home-story-grid,
+.home-collection-grid,
+.home-shelf-grid {
+  position: relative;
+  z-index: 1;
+}
+
+.home-hero {
+  padding: clamp(1.4rem, 2.2vw, 1.8rem);
+}
+
+.home-hero__bar,
+.home-hero__content,
+.home-shelf__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.home-hero__bar {
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.home-kicker,
+.home-panel__eyebrow,
+.links-panel__eyebrow,
+.home-collection-card__command,
+.home-collection-card__count,
+.home-meta-panel__label,
+.home-post-list small {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.home-kicker,
+.home-panel__eyebrow,
+.links-panel__eyebrow,
+.home-meta-panel__label {
+  color: var(--home-shell-accent);
+}
+
+.home-command-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.home-command-bar a,
+.home-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.85rem;
+  padding: 0 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--home-shell-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--home-shell-strong);
+  text-decoration: none;
+}
+
+.home-command-bar a {
+  min-height: 2.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+}
+
+.home-command-bar a:hover,
+.home-action:hover {
+  background: var(--home-shell-accent-soft);
+  text-decoration: none;
+}
+
+.home-hero__content {
+  align-items: stretch;
+}
+
+.home-hero__copy {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.home-title,
+.home-section-heading h2,
+.home-collection-card h3,
+.home-shelf__header h3,
+.home-panel--footer-note h2,
+.links-panel__title {
+  margin: 0;
+  font-family: var(--font-reading);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  color: var(--home-shell-strong);
+}
+
+.home-title {
+  margin-bottom: 0.75rem;
+  font-size: clamp(2.5rem, 5vw, 4.4rem);
+  line-height: 0.92;
+}
+
+.lead,
+.intro-text,
+.home-section-map p,
+.home-collection-card p,
+.home-panel--footer-note > p,
+.home-empty-state {
+  color: var(--home-shell-strong);
+}
+
+.lead {
+  max-width: 38rem;
+  font-size: clamp(1.05rem, 1.4vw, 1.18rem);
+}
+
+.home-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.4rem;
+}
+
+.home-action--primary {
+  background: var(--home-shell-accent);
+  border-color: transparent;
+  color: #0b1020;
+}
+
+:root[data-theme="light"] .home-action--primary {
+  color: #f8fbff;
+}
+
+.home-meta-panel {
+  display: grid;
+  gap: 0.8rem;
+  width: min(100%, 18rem);
+}
+
+.home-meta-panel__item,
+.home-section-map li,
+.home-collection-card {
+  border-radius: 22px;
+  border: 1px solid var(--home-shell-border);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.home-meta-panel__item {
+  padding: 1rem;
+}
+
+.home-meta-panel__item strong {
+  display: block;
+  margin-top: 0.4rem;
+  color: var(--home-shell-strong);
+  font-family: var(--font-reading);
+  font-size: 1.85rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.home-meta-panel__item p {
+  margin: 0.45rem 0 0;
+  color: var(--home-shell-muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.6;
+}
+
+.home-story-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.85fr);
+  gap: 1.25rem;
+}
+
+.home-panel {
+  padding: clamp(1.3rem, 2vw, 1.7rem);
+}
+
+.home-panel__eyebrow {
+  margin-bottom: 0.85rem;
+}
+
+.intro-text {
+  margin: 0 0 1rem;
+  text-align: left;
+  max-width: 72ch;
+}
+
+.intro-text:last-child {
+  margin-bottom: 0;
+}
+
+.home-section-map,
+.home-post-list,
+.link-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.home-section-map {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.home-section-map li {
+  padding: 0.95rem 1rem;
+}
+
+.home-section-map a,
+.home-post-list a,
+.links-panel a {
+  color: var(--home-shell-strong) !important;
+}
+
+.home-section-map a:visited,
+.home-post-list a:visited,
+.links-panel a:visited,
+.links-panel a:hover {
+  color: var(--home-shell-strong) !important;
+}
+
+.home-section-map p,
+.home-collection-card p,
+.home-empty-state,
+.links-panel__title + p,
+.home-panel--footer-note > p,
+.home-post-list small {
+  color: var(--home-shell-muted);
+}
+
+.home-library,
+.home-shelves {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.home-section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.home-collection-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.home-collection-card {
+  display: block;
+  padding: 1.1rem;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.home-collection-card:hover {
+  transform: translateY(-2px);
+  background: var(--home-shell-accent-soft);
+  border-color: var(--home-shell-accent);
+}
+
+.home-collection-card__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.home-collection-card__count {
+  color: var(--home-shell-muted);
+}
+
+.home-collection-card h3 {
+  margin-top: 0.95rem;
+  margin-bottom: 0.55rem;
+  font-size: 1.35rem;
+}
+
+.home-collection-card p {
+  margin: 0;
+  line-height: 1.65;
+}
+
+.home-shelf-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.home-panel--shelf,
+.home-panel--footer-note {
+  min-height: 100%;
+}
+
+.home-shelf__header {
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.home-shelf__header h3,
+.home-panel--footer-note h2 {
+  font-size: 1.28rem;
+}
+
+.home-post-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.home-post-list li {
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--home-shell-border);
+}
+
+.home-post-list li:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.home-post-list a {
+  display: block;
+  margin-bottom: 0.3rem;
+}
+
+.links-panel-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.links-panel {
+  position: relative;
+  right: auto;
+  bottom: auto;
+  width: auto;
+  padding: 1.2rem;
+  color: inherit;
+}
+
+.links-panel__title {
+  margin-top: 0.35rem;
+  margin-bottom: 0.85rem;
+  font-size: 1.45rem;
+}
+
+.link-list {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.link-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.contact-icon {
+  width: 1rem;
+  height: 1rem;
+  color: var(--home-shell-accent);
+  flex-shrink: 0;
+}
+
+.link-list--compact li {
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--home-shell-border);
+}
+
+.link-list--compact li:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+@media (min-width: 1100px) {
+  .home-stage {
+    padding-right: clamp(1rem, 3vw, 2rem);
+  }
+}
+
+@media (max-width: 1099px) {
+  .home-shell,
+  .home-story-grid,
+  .home-hero__content {
+    grid-template-columns: 1fr;
+  }
+
+  .home-sidebar {
+    position: static;
+  }
+
+  .home-meta-panel {
+    width: 100%;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .home-shelf-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .links-panel {
+    margin-top: 0;
+    box-shadow: var(--home-shell-shadow);
+  }
+}
+
+@media (max-width: 820px) {
+  .home-stage {
+    padding-top: 5rem;
+  }
+
+  .home-hero__bar,
+  .home-hero__content,
+  .home-shelf__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .home-collection-grid,
+  .home-shelf-grid,
+  .home-meta-panel {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .home-stage {
+    padding-left: 0.85rem;
+    padding-right: 0.85rem;
+  }
+
+  .home-hero,
+  .home-panel,
+  .links-panel {
+    border-radius: 22px;
+  }
+
+  .home-actions {
+    flex-direction: column;
+  }
+
+  .home-action {
+    width: 100%;
+  }
+}

--- a/src/components/LinksPanel.astro
+++ b/src/components/LinksPanel.astro
@@ -1,22 +1,44 @@
 ---
 import Icon from './Icon.astro';
 import { CONTACT_LINKS } from '../lib/site';
+
+const QUICK_LINKS = [
+  { href: '/paper_summaries_field.html', label: 'Arxiv Notes' },
+  { href: '/ponderings.html', label: 'Ponderings' },
+  { href: '/revision_notes.html', label: 'Revision Notes' },
+  { href: '/ai_generated_reports.html', label: 'AI Reports' },
+] as const;
 ---
 
-<div class="links-panel">
-  <h2 class="links-panel__title">Contact Me</h2>
-  <ul class="link-list">
-    {CONTACT_LINKS.map((link) => (
-      <li>
-        <Icon name={link.iconName} class="contact-icon" />
-        <a
-          href={link.href}
-          target={link.href.startsWith('mailto:') ? undefined : '_blank'}
-          rel={link.href.startsWith('mailto:') ? undefined : 'noreferrer'}
-        >
-          {link.label}
-        </a>
-      </li>
-    ))}
-  </ul>
+<div class="links-panel-stack">
+  <section class="links-panel">
+    <p class="links-panel__eyebrow">Connect</p>
+    <h2 class="links-panel__title">Contact Me</h2>
+    <ul class="link-list">
+      {CONTACT_LINKS.map((link) => (
+        <li>
+          <Icon name={link.iconName} class="contact-icon" />
+          <a
+            href={link.href}
+            target={link.href.startsWith('mailto:') ? undefined : '_blank'}
+            rel={link.href.startsWith('mailto:') ? undefined : 'noreferrer'}
+          >
+            {link.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <section class="links-panel links-panel--secondary">
+    <p class="links-panel__eyebrow">Browse</p>
+    <h2 class="links-panel__title">Quick Access</h2>
+    <ul class="link-list link-list--compact">
+      {QUICK_LINKS.map((link) => (
+        <li>
+          <a href={link.href}>{link.label}</a>
+        </li>
+      ))}
+    </ul>
+  </section>
 </div>

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -20,10 +20,13 @@ const { title, description } = Astro.props;
   <PageControls />
   <MusicLauncher />
   <main class="home-stage">
-    <div class="home-content-shell">
-      <h1 class="home-title">Arunabh.BLOG</h1>
-      <slot />
+    <div class="home-shell">
+      <div class="home-content-shell">
+        <slot />
+      </div>
+      <aside class="home-sidebar">
+        <LinksPanel />
+      </aside>
     </div>
-    <LinksPanel />
   </main>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,62 +1,227 @@
 ---
 import HomeLayout from '../layouts/HomeLayout.astro';
-import PostList from '../components/PostList.astro';
 import { getPostsBySection } from '../lib/content';
 
-const revisionPosts = (await getPostsBySection('revision-notes', 'asc')).filter(
+const paperPosts = await getPostsBySection('paper-shorts', 'desc');
+const revisionPosts = (await getPostsBySection('revision-notes', 'desc')).filter(
   (post) => post.data.postSlug !== 'cs336-revision-notes',
 );
-const aiPosts = await getPostsBySection('ai-generated-reports', 'asc');
+const ponderingPosts = await getPostsBySection('ponderings', 'desc');
+const aiPosts = await getPostsBySection('ai-generated-reports', 'desc');
+
+const storyHref = '/my journey so far/2025/02/08/my-journey-so-far-full-story.html';
+const totalEntries =
+  paperPosts.length + ponderingPosts.length + revisionPosts.length + aiPosts.length;
+
+const sectionCards = [
+  {
+    id: 'arxiv-notes',
+    href: '/paper_summaries_field.html',
+    command: 'arxiv-notes',
+    title: 'Arxiv Notes',
+    description: 'Summaries of research papers organized by broad interests.',
+    count: paperPosts.length,
+  },
+  {
+    id: 'ponderings',
+    href: '/ponderings.html',
+    command: 'ponderings',
+    title: 'Ponderings',
+    description: 'Notes on topics I find myself revisiting.',
+    count: ponderingPosts.length,
+  },
+  {
+    id: 'revision-notes',
+    href: '/revision_notes.html',
+    command: 'revision-notes',
+    title: 'Revision Notes',
+    description: 'Detailed revision notes from long-form content online.',
+    count: revisionPosts.length,
+  },
+  {
+    id: 'ai-generated-reports',
+    href: '/ai_generated_reports.html',
+    command: 'ai-reports',
+    title: 'AI Generated Reports',
+    description: 'Audio or text reports created by AI.',
+    count: aiPosts.length,
+  },
+] as const;
+
+const recentShelves = [
+  {
+    title: 'Arxiv Notes',
+    href: '/paper_summaries_field.html',
+    posts: paperPosts.slice(0, 3),
+    emptyMessage: 'New research notes will show up here.',
+  },
+  {
+    title: 'Ponderings',
+    href: '/ponderings.html',
+    posts: ponderingPosts.slice(0, 3),
+    emptyMessage: 'Ponderings will show up here.',
+  },
+  {
+    title: 'Revision Notes',
+    href: '/revision_notes.html',
+    posts: revisionPosts.slice(0, 3),
+    emptyMessage: 'Revision notes will show up here.',
+  },
+] as const;
+
+const formatDate = (date: Date) =>
+  date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  });
 ---
 
 <HomeLayout title="Home">
-  <article>
-    <p class="lead">Hello, I'm Arunabh, and welcome to my personal space.</p>
+  <section class="home-hero" id="top">
+    <div class="home-hero__bar">
+      <p class="home-kicker">Arunabh.BLOG</p>
+      <nav class="home-command-bar" aria-label="Homepage sections">
+        <a href="#about">/about</a>
+        <a href="#collections">/collections</a>
+        <a href="#latest">/latest</a>
+      </nav>
+    </div>
 
-    <p class="intro-text">
-      I currently work in computer vision research at Zoox developing models to interpret driving
-      scenes. I also organize the perception research group at Zoox, where we explore
-      state-of-the-art research and bring promising ideas into production. Previously, I led part
-      of the perception team at DEKA, focusing on short-range perception and traffic light
-      detection for Roxo, FedEx's last-mile delivery robot.
-    </p>
+    <div class="home-hero__content">
+      <div class="home-hero__copy">
+        <h1 class="home-title">Arunabh.BLOG</h1>
+        <p class="lead">Hello, I'm Arunabh, and welcome to my personal space.</p>
+        <div class="home-actions">
+          <a class="home-action home-action--primary" href={storyHref}>Read the full story</a>
+          <a class="home-action" href="/paper_summaries_field.html">Browse Arxiv Notes</a>
+        </div>
+      </div>
 
-    <p class="intro-text">
-      My robotics journey began in India, where I earned my undergraduate degree at MIT, Manipal.
-      Although I stumbled upon robotics somewhat by chance, choosing to focus on autonomous driving
-      technology was intentional; I believe it can transform the world by saving tons of lives!
-      This conviction brought me to the U.S. nearly a decade ago for graduate studies at the
-      Colorado School of Mines.
-    </p>
-
-    <p class="intro-text">
-      I'm driven to keep building and keep learning. Like a shooting star blazing across the sky,
-      I hope to leave my own "Arunabh-sized" dent in the world!
-      <a href="/my journey so far/2025/02/08/my-journey-so-far-full-story.html"
-        >Read the full story.</a
-      >
-    </p>
-  </article>
-
-  <section class="section">
-    <h2 id="arxiv-notes"><a href="/paper_summaries_field.html">Arxiv Notes</a></h2>
-    <p>Summaries of research papers organized by broad interests.</p>
+      <div class="home-meta-panel" aria-label="Site overview">
+        <div class="home-meta-panel__item">
+          <span class="home-meta-panel__label">Sections</span>
+          <strong>04</strong>
+        </div>
+        <div class="home-meta-panel__item">
+          <span class="home-meta-panel__label">Entries</span>
+          <strong>{totalEntries}</strong>
+        </div>
+        <div class="home-meta-panel__item">
+          <span class="home-meta-panel__label">Latest Paths</span>
+          <p>/paper_summaries_field.html /ponderings.html /revision_notes.html</p>
+        </div>
+      </div>
+    </div>
   </section>
 
-  <section class="section">
-    <h2 id="ponderings"><a href="/ponderings.html">Ponderings</a></h2>
-    <p>Notes on topics I find myself revisiting.</p>
+  <section class="home-story-grid" id="about">
+    <article class="home-panel home-panel--story">
+      <p class="home-panel__eyebrow">About</p>
+      <p class="intro-text">
+        I currently work in computer vision research at Zoox developing models to interpret driving
+        scenes. I also organize the perception research group at Zoox, where we explore
+        state-of-the-art research and bring promising ideas into production. Previously, I led part
+        of the perception team at DEKA, focusing on short-range perception and traffic light
+        detection for Roxo, FedEx's last-mile delivery robot.
+      </p>
+
+      <p class="intro-text">
+        My robotics journey began in India, where I earned my undergraduate degree at MIT, Manipal.
+        Although I stumbled upon robotics somewhat by chance, choosing to focus on autonomous
+        driving technology was intentional; I believe it can transform the world by saving tons of
+        lives! This conviction brought me to the U.S. nearly a decade ago for graduate studies at
+        the Colorado School of Mines.
+      </p>
+
+      <p class="intro-text">
+        I'm driven to keep building and keep learning. Like a shooting star blazing across the sky,
+        I hope to leave my own "Arunabh-sized" dent in the world!
+        <a href={storyHref}>Read the full story.</a>
+      </p>
+    </article>
+
+    <article class="home-panel home-panel--map">
+      <p class="home-panel__eyebrow">Sections</p>
+      <ul class="home-section-map">
+        {sectionCards.map((section) => (
+          <li>
+            <a href={section.href}>{section.title}</a>
+            <p>{section.description}</p>
+          </li>
+        ))}
+      </ul>
+    </article>
   </section>
 
-  <section class="section">
-    <h2 id="revision-notes"><a href="/revision_notes.html">Revision Notes</a></h2>
-    <p>Detailed revision notes from long-form content online.</p>
-    <PostList posts={revisionPosts} />
+  <section class="home-library" id="collections">
+    <div class="home-section-heading">
+      <p class="home-panel__eyebrow">Collections</p>
+      <h2>Browse by section</h2>
+    </div>
+
+    <div class="home-collection-grid">
+      {sectionCards.map((section) => (
+        <a class="home-collection-card" id={section.id} href={section.href}>
+          <div class="home-collection-card__head">
+            <span class="home-collection-card__command">/{section.command}</span>
+            <span class="home-collection-card__count">{section.count}</span>
+          </div>
+          <h3>{section.title}</h3>
+          <p>{section.description}</p>
+        </a>
+      ))}
+    </div>
   </section>
 
-  <section class="section">
-    <h2 id="ml-deep"><a href="/ai_generated_reports.html">AI Generated Reports</a></h2>
+  <section class="home-shelves" id="latest">
+    <div class="home-section-heading">
+      <p class="home-panel__eyebrow">Latest</p>
+      <h2>Recent entries</h2>
+    </div>
+
+    <div class="home-shelf-grid">
+      {recentShelves.map((shelf) => (
+        <article class="home-panel home-panel--shelf">
+          <div class="home-shelf__header">
+            <h3>{shelf.title}</h3>
+            <a href={shelf.href}>View all</a>
+          </div>
+
+          {shelf.posts.length > 0 ? (
+            <ul class="home-post-list">
+              {shelf.posts.map((post) => (
+                <li>
+                  <a href={post.data.legacyPath}>{post.data.title}</a>
+                  <small>{formatDate(post.data.date)}</small>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p class="home-empty-state">{shelf.emptyMessage}</p>
+          )}
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="home-panel home-panel--footer-note">
+    <div class="home-shelf__header">
+      <h2>AI Generated Reports</h2>
+      <a href="/ai_generated_reports.html">Open section</a>
+    </div>
     <p>Audio or text reports created by AI.</p>
-    {aiPosts.length > 0 && <PostList posts={aiPosts} />}
+    {aiPosts.length > 0 ? (
+      <ul class="home-post-list">
+        {aiPosts.slice(0, 3).map((post) => (
+          <li>
+            <a href={post.data.legacyPath}>{post.data.title}</a>
+            <small>{formatDate(post.data.date)}</small>
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p class="home-empty-state">This section is ready for future reports.</p>
+    )}
   </section>
 </HomeLayout>


### PR DESCRIPTION
## What changed
- reorganized the landing page into a cleaner hero, section grid, recent-entry shelves, and an integrated sidebar
- kept the existing homepage copy and section destinations while restoring the shooting-star image as a subtle static backdrop
- updated the contact panel so it sits within the layout instead of floating separately

## Why
- make the homepage feel more polished and easier to scan without adding animated background elements

## Testing
- npm run ci