### PR TITLE
Add blog post on good research in industry

### DIFF
--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -1,0 +1,60 @@
+---
+title: Thoughts on Good Research in Industry
+date: '2026-03-22T04:00:00.000Z'
+section: ponderings
+postSlug: thoughts-on-good-research-in-industry
+legacyPath: /ponderings/2026/03/22/thoughts-on-good-research-in-industry.html
+tags:
+  - Research
+  - Career
+summary: >-
+  Notes on research taste, collaboration, visibility, experimentation, and
+  staying unblocked in industry.
+---
+# Thoughts on Good Research in Industry
+
+Came across [this amazing post](https://emerge-lab.github.io/papers/an-unsolicited-guide-to-good-research.pdf) from Eugene Vinitsky. Eugene also has a [personal site](https://www.eugenevinitsky.com/) and leads the [EMERGE Lab](https://emerge-lab.github.io/). It maps surprisingly well to how I think about research in industry. The setting is different, but many of the underlying principles are the same: developing taste, staying unblocked, building in public, and learning how to move with both rigor and speed.
+
+## Develop your own research taste
+
+One of the most important things a researcher can build is a unique worldview. Not a contrarian worldview for its own sake, but a real point of view about what matters, what is noise, and what kinds of questions are worth spending time on. In practice, this comes from spending enough time in a field that you begin to notice patterns. You start to separate the seminal from the forgettable. You learn which researchers and labs consistently produce clear, durable ideas, and which trends are mostly artifacts of the moment.
+
+This is especially important because modern research is overwhelming by default. There is too much literature to stay fully on top of, and truly foundational work is rarer than the volume of papers might suggest. The only way through is to build the right abstractions. You need mental compression schemes that help you quickly tell what is deep, what is incremental, and what is simply fashionable. That muscle feels weak at first, but it gets stronger with use.
+
+Part of developing taste also means resisting homogenization. Virality-driven social media tends to flatten differences in judgment. It rewards what is legible, immediate, and broadly agreeable. Good research often asks for the opposite: patience, independent evaluation, and the willingness to hold a view before it becomes popular.
+
+## Make the work sustainable and intrinsically motivating
+
+The best research usually comes from a place that feels at least a little like play. There should be some part of the work that pulls you in naturally, where curiosity is doing more of the driving than discipline alone. That does not mean the work is easy. It just means that the energy is self-renewing. Over a long enough time horizon, that matters a lot.
+
+At the same time, the best work is rarely done from a place of comfort. There is a sweet spot where you are stretched enough to keep growing, but not so overwhelmed that you shut down. Being a little uncomfortable is often a sign that you are operating near your edge, and that is where a lot of meaningful progress happens. The trick is to make sure the pressure sharpens you rather than drains you.
+
+## Collaboration is a research superpower
+
+It is very hard to do serious engineering alone, and increasingly hard to do serious research alone too. Collaboration is not just a productivity multiplier. It is often the thing that makes ambitious work possible in the first place. But good collaboration has a few simple rules.
+
+The biggest one is: do not block. In large organizations especially, being someone who keeps momentum alive is a genuine superpower. A surprising amount of leverage comes from unblocking others, being explicit about dependencies, and never letting uncertainty silently stall a piece of work. Timing matters. Context matters. If you are waiting on something, say so early. If your constraints have changed, over-communicate them. People can work around many things, but they cannot work around hidden information.
+
+There is also a second rule that matters just as much: ask for help before the cost of being stuck compounds. If you are new to a task, missing context, or working through something others have likely seen before, do not spend days silently suffering. Ask. And when the problem is genuinely hard and you know it is your bug to solve, sometimes the right move is not more force. It is a walk, a reset, or a night of sleep.
+
+## Show your work
+
+Research benefits enormously from visibility. Keep track of what you are working on, what you tried, what failed, and what you learned. This is useful for others, but it is even more useful for future you. A weekly log works well because it creates just enough structure to force reflection without becoming oppressive. Daily notes can be too granular for some people, but a weekly rhythm often captures the arc of the work.
+
+This kind of documentation has second-order benefits. It makes collaboration easier. It makes performance reviews less painful. It gives you a running record of what you are actually proud of. A brag document may sound self-conscious, but it is often just a practical way to avoid forgetting your own progress. In research especially, where impact is often delayed and nonlinear, keeping a record matters.
+
+Visibility also matters when presenting. Showing your work is not the same as dumping your work. The goal is not to maximize detail. It is to maximize understanding. When you present, optimize for clarity in the mind of the other person. The value of the work is much higher when others can actually follow the reasoning behind it.
+
+## Be rigorous about experimentation
+
+Machine learning is an empirical science, which means that experimentation is not peripheral to the work. It is the work. The only way to build trustworthy intuition is to run disciplined experiments and document them carefully. Every experiment should test one thing. If an outcome changes, you should know what changed with it. Ablations are not busywork. They are the grammar of rigorous empirical reasoning.
+
+This sounds obvious, but it is surprisingly easy to drift into sloppy iteration, especially when the pace is high and infrastructure makes it easy to launch many jobs. Rigor is what protects you from fooling yourself. Clean experiment design, good note-taking, and careful comparisons are how you compound knowledge instead of just generating activity.
+
+And of course, use the hardware. If you are lucky enough to have access to serious compute, keep it busy. Underutilized clusters are often a sign that you are not exploring enough, not parallelizing enough, or not setting up the pipeline to learn fast enough. The goal is not wasteful experimentation. It is high-throughput learning.
+
+## A practical operating principle: never stay blocked
+
+If there is one idea worth repeating, it is this: never stay blocked. Not forever, not silently, and not for avoidable reasons. Some problems are genuinely difficult, and some amount of stuckness is part of the job. But there is a big difference between productive struggle and needless stagnation.
+
+In healthy research environments, progress often comes less from heroic solo effort and more from maintaining motion. That means breaking problems down, asking for context early, keeping others informed, and knowing when to step away and come back with fresh eyes. Over time, this becomes less of a tactic and more of an operating philosophy.


### PR DESCRIPTION
## What changed
- added a new `ponderings` blog post: `Thoughts on Good Research in Industry`
- preserved the original PDF link and added links to Eugene Vinitsky's personal site and EMERGE Lab
- published the post at `/ponderings/2026/03/22/thoughts-on-good-research-in-industry.html`

## Why it changed
- to add the requested blog post to the site in the existing Astro content format

## How it was tested
- `npm run ci`
- pre-push hook reran `npm run ci`
