### PR TITLE
Refresh homepage layout and add career timeline

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1154,7 +1154,7 @@ body.home-page {
   width: min(100%, 88rem);
   margin: 0 auto;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 18.5rem;
+  grid-template-columns: minmax(0, 1fr) minmax(15rem, 18rem) 16rem;
   gap: 1.25rem;
   align-items: start;
 }
@@ -1173,14 +1173,20 @@ body.home-page {
   gap: 1.25rem;
 }
 
-.home-sidebar {
+.home-timeline-rail {
   position: sticky;
   top: 5.25rem;
+  align-self: start;
+}
+
+.home-sidebar {
+  align-self: start;
 }
 
 .home-hero,
 .home-panel,
-.links-panel {
+.links-panel,
+.timeline-panel {
   position: relative;
   overflow: hidden;
   border-radius: 28px;
@@ -1193,7 +1199,8 @@ body.home-page {
 
 .home-hero::before,
 .home-panel::before,
-.links-panel::before {
+.links-panel::before,
+.timeline-panel::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -1204,7 +1211,7 @@ body.home-page {
 .home-hero,
 .home-panel,
 .links-panel,
-.links-panel-stack,
+.timeline-panel,
 .home-story-grid,
 .home-collection-grid,
 .home-shelf-grid {
@@ -1226,12 +1233,13 @@ body.home-page {
 
 .home-hero__bar {
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .home-kicker,
 .home-panel__eyebrow,
 .links-panel__eyebrow,
+.timeline-panel__eyebrow,
 .home-collection-card__command,
 .home-collection-card__count,
 .home-meta-panel__label,
@@ -1246,6 +1254,7 @@ body.home-page {
 .home-kicker,
 .home-panel__eyebrow,
 .links-panel__eyebrow,
+.timeline-panel__eyebrow,
 .home-meta-panel__label {
   color: var(--home-shell-accent);
 }
@@ -1277,6 +1286,10 @@ body.home-page {
   letter-spacing: 0.08em;
 }
 
+.home-command-bar--hero {
+  margin-top: 1.4rem;
+}
+
 .home-command-bar a:hover,
 .home-action:hover {
   background: var(--home-shell-accent-soft);
@@ -1297,7 +1310,9 @@ body.home-page {
 .home-collection-card h3,
 .home-shelf__header h3,
 .home-panel--footer-note h2,
-.links-panel__title {
+.links-panel__title,
+.timeline-panel__title,
+.timeline-item h3 {
   margin: 0;
   font-family: var(--font-reading);
   font-weight: 500;
@@ -1345,7 +1360,8 @@ body.home-page {
 .home-meta-panel {
   display: grid;
   gap: 0.8rem;
-  width: min(100%, 18rem);
+  width: min(100%, 16rem);
+  margin-right: 1rem;
 }
 
 .home-meta-panel__item,
@@ -1538,12 +1554,8 @@ body.home-page {
   margin-bottom: 0.3rem;
 }
 
-.links-panel-stack {
-  display: grid;
-  gap: 1rem;
-}
-
-.links-panel {
+.links-panel,
+.timeline-panel {
   position: relative;
   right: auto;
   bottom: auto;
@@ -1552,10 +1564,74 @@ body.home-page {
   color: inherit;
 }
 
-.links-panel__title {
+.links-panel__title,
+.timeline-panel__title {
   margin-top: 0.35rem;
   margin-bottom: 0.85rem;
   font-size: 1.45rem;
+}
+
+.timeline-panel {
+  min-height: calc(100vh - 5.25rem);
+}
+
+.timeline-list {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem 0 0.35rem 1.4rem;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.timeline-list::before {
+  content: "";
+  position: absolute;
+  top: 0.55rem;
+  bottom: 0.55rem;
+  left: 0.3rem;
+  width: 1px;
+  background:
+    linear-gradient(180deg, transparent, var(--home-shell-accent) 10%, var(--home-shell-accent) 90%, transparent);
+  opacity: 0.8;
+}
+
+.timeline-item {
+  position: relative;
+  padding: 0.15rem 0 0.2rem;
+}
+
+.timeline-item::before {
+  content: "";
+  position: absolute;
+  top: 0.38rem;
+  left: -1.4rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--home-shell-border);
+  background: radial-gradient(circle at 35% 35%, #ffffff, var(--home-shell-accent));
+  box-shadow: 0 0 0 6px var(--home-shell-accent-soft);
+}
+
+.timeline-item__years {
+  margin: 0 0 0.3rem;
+  color: var(--home-shell-accent);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.timeline-item h3 {
+  margin-bottom: 0.45rem;
+  font-size: 1.02rem;
+}
+
+.timeline-item p:last-child {
+  margin: 0;
+  color: var(--home-shell-muted);
+  line-height: 1.65;
 }
 
 .link-list {
@@ -1599,6 +1675,7 @@ body.home-page {
     grid-template-columns: 1fr;
   }
 
+  .home-timeline-rail,
   .home-sidebar {
     position: static;
   }
@@ -1615,6 +1692,10 @@ body.home-page {
   .links-panel {
     margin-top: 0;
     box-shadow: var(--home-shell-shadow);
+  }
+
+  .timeline-panel {
+    min-height: auto;
   }
 }
 

--- a/src/components/LinksPanel.astro
+++ b/src/components/LinksPanel.astro
@@ -1,44 +1,23 @@
 ---
 import Icon from './Icon.astro';
 import { CONTACT_LINKS } from '../lib/site';
-
-const QUICK_LINKS = [
-  { href: '/paper_summaries_field.html', label: 'Arxiv Notes' },
-  { href: '/ponderings.html', label: 'Ponderings' },
-  { href: '/revision_notes.html', label: 'Revision Notes' },
-  { href: '/ai_generated_reports.html', label: 'AI Reports' },
-] as const;
 ---
 
-<div class="links-panel-stack">
-  <section class="links-panel">
-    <p class="links-panel__eyebrow">Connect</p>
-    <h2 class="links-panel__title">Contact Me</h2>
-    <ul class="link-list">
-      {CONTACT_LINKS.map((link) => (
-        <li>
-          <Icon name={link.iconName} class="contact-icon" />
-          <a
-            href={link.href}
-            target={link.href.startsWith('mailto:') ? undefined : '_blank'}
-            rel={link.href.startsWith('mailto:') ? undefined : 'noreferrer'}
-          >
-            {link.label}
-          </a>
-        </li>
-      ))}
-    </ul>
-  </section>
-
-  <section class="links-panel links-panel--secondary">
-    <p class="links-panel__eyebrow">Browse</p>
-    <h2 class="links-panel__title">Quick Access</h2>
-    <ul class="link-list link-list--compact">
-      {QUICK_LINKS.map((link) => (
-        <li>
-          <a href={link.href}>{link.label}</a>
-        </li>
-      ))}
-    </ul>
-  </section>
-</div>
+<section class="links-panel">
+  <p class="links-panel__eyebrow">Connect</p>
+  <h2 class="links-panel__title">Contact Me</h2>
+  <ul class="link-list">
+    {CONTACT_LINKS.map((link) => (
+      <li>
+        <Icon name={link.iconName} class="contact-icon" />
+        <a
+          href={link.href}
+          target={link.href.startsWith('mailto:') ? undefined : '_blank'}
+          rel={link.href.startsWith('mailto:') ? undefined : 'noreferrer'}
+        >
+          {link.label}
+        </a>
+      </li>
+    ))}
+  </ul>
+</section>

--- a/src/components/TimelinePanel.astro
+++ b/src/components/TimelinePanel.astro
@@ -1,0 +1,27 @@
+---
+interface TimelineEntry {
+  years: string;
+  title: string;
+  summary: string;
+}
+
+interface Props {
+  entries: readonly TimelineEntry[];
+}
+
+const { entries } = Astro.props;
+---
+
+<section class="timeline-panel" aria-labelledby="timeline-title">
+  <p class="timeline-panel__eyebrow">Timeline</p>
+  <h2 class="timeline-panel__title" id="timeline-title">Journey Through Robotics</h2>
+  <ol class="timeline-list">
+    {entries.map((entry) => (
+      <li class="timeline-item">
+        <p class="timeline-item__years">{entry.years}</p>
+        <h3>{entry.title}</h3>
+        <p>{entry.summary}</p>
+      </li>
+    ))}
+  </ol>
+</section>

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -2,13 +2,19 @@
 import LinksPanel from '../components/LinksPanel.astro';
 import PageControls from '../components/PageControls.astro';
 import BaseLayout from './BaseLayout.astro';
+import TimelinePanel from '../components/TimelinePanel.astro';
 
 interface Props {
   title: string;
   description?: string;
+  timelineEntries?: readonly {
+    years: string;
+    title: string;
+    summary: string;
+  }[];
 }
 
-const { title, description } = Astro.props;
+const { title, description, timelineEntries = [] } = Astro.props;
 ---
 
 <BaseLayout
@@ -22,6 +28,9 @@ const { title, description } = Astro.props;
       <div class="home-content-shell">
         <slot />
       </div>
+      <aside class="home-timeline-rail">
+        <TimelinePanel entries={timelineEntries} />
+      </aside>
       <aside class="home-sidebar">
         <LinksPanel />
       </aside>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,6 @@ const revisionPosts = (await getPostsBySection('revision-notes', 'desc')).filter
 const ponderingPosts = await getPostsBySection('ponderings', 'desc');
 const aiPosts = await getPostsBySection('ai-generated-reports', 'desc');
 
-const storyHref = '/my journey so far/2025/02/08/my-journey-so-far-full-story.html';
 const totalEntries =
   paperPosts.length + ponderingPosts.length + revisionPosts.length + aiPosts.length;
 
@@ -69,6 +68,39 @@ const recentShelves = [
   },
 ] as const;
 
+const timelineEntries = [
+  {
+    years: '2010 - 2014',
+    title: 'MIT, Manipal',
+    summary:
+      'I studied Mechatronics Engineering at MIT, Manipal, where I fell in love with robotics through hands-on projects. For my thesis, my team built an areca-nut harvesting robot that could climb tall trees and help make a dangerous job safer for farmers.',
+  },
+  {
+    years: '2015',
+    title: 'Reset And Recommit',
+    summary:
+      'A difficult year became a turning point. After setbacks and a period of depression, I found a clearer sense of purpose, strengthened my technical foundations, and decided to pursue robotics graduate school in the United States.',
+  },
+  {
+    years: '2016 - 2018',
+    title: 'Colorado School Of Mines',
+    summary:
+      'I completed my graduate degree in Mechanical Engineering with a robotics specialization at the Colorado School of Mines. At the M3 Robotics Lab, I worked on robots for GPS-denied navigation, built a novel MPC-based autonomy stack, and learned to integrate a wide range of sensors and robotic systems.',
+  },
+  {
+    years: '2018 - 2022',
+    title: 'DEKA',
+    summary:
+      'At DEKA, I led part of the perception stack for last-mile autonomous robots. My work ranged from training and deploying real-time computer vision models to writing CUDA kernels and porting major parts of the stack to OpenCL and OpenVINO.',
+  },
+  {
+    years: '2022 - 2026',
+    title: 'Zoox',
+    summary:
+      'At Zoox, I have focused on computer vision research for autonomous navigation, building learned representations that encode scene semantics and support downstream planning. I currently lead efforts on a generalized scene embedding designed to scale across diverse driving contexts.',
+  },
+] as const;
+
 const formatDate = (date: Date) =>
   date.toLocaleDateString('en-US', {
     month: 'short',
@@ -77,25 +109,24 @@ const formatDate = (date: Date) =>
   });
 ---
 
-<HomeLayout title="Home">
+<HomeLayout title="Home" timelineEntries={timelineEntries}>
   <section class="home-hero" id="top">
     <div class="home-hero__bar">
       <p class="home-kicker">Arunabh.BLOG</p>
-      <nav class="home-command-bar" aria-label="Homepage sections">
-        <a href="#about">/about</a>
-        <a href="#collections">/collections</a>
-        <a href="#latest">/latest</a>
-      </nav>
     </div>
 
     <div class="home-hero__content">
       <div class="home-hero__copy">
         <h1 class="home-title">Arunabh.BLOG</h1>
-        <p class="lead">Hello, I'm Arunabh, and welcome to my personal space.</p>
-        <div class="home-actions">
-          <a class="home-action home-action--primary" href={storyHref}>Read the full story</a>
-          <a class="home-action" href="/paper_summaries_field.html">Browse Arxiv Notes</a>
-        </div>
+        <p class="lead">
+          I work on computer vision and robotics for autonomous systems, and this is where I write
+          about the ideas, papers, and experiences that have shaped that journey.
+        </p>
+        <nav class="home-command-bar home-command-bar--hero" aria-label="Homepage sections">
+          <a href="#about">/about</a>
+          <a href="#collections">/collections</a>
+          <a href="#latest">/latest</a>
+        </nav>
       </div>
 
       <div class="home-meta-panel" aria-label="Site overview">
@@ -119,25 +150,24 @@ const formatDate = (date: Date) =>
     <article class="home-panel home-panel--story">
       <p class="home-panel__eyebrow">About</p>
       <p class="intro-text">
-        I currently work in computer vision research at Zoox developing models to interpret driving
-        scenes. I also organize the perception research group at Zoox, where we explore
-        state-of-the-art research and bring promising ideas into production. Previously, I led part
-        of the perception team at DEKA, focusing on short-range perception and traffic light
-        detection for Roxo, FedEx's last-mile delivery robot.
+        I currently work in computer vision research at Zoox, where I build learned
+        representations for autonomous driving scenes and help shape research directions for
+        perception. Before that, I led parts of the perception stack at DEKA for Roxo, FedEx&apos;s
+        last-mile delivery robot, with a focus on short-range perception and traffic-light
+        understanding.
       </p>
 
       <p class="intro-text">
-        My robotics journey began in India, where I earned my undergraduate degree at MIT, Manipal.
-        Although I stumbled upon robotics somewhat by chance, choosing to focus on autonomous
-        driving technology was intentional; I believe it can transform the world by saving tons of
-        lives! This conviction brought me to the U.S. nearly a decade ago for graduate studies at
-        the Colorado School of Mines.
+        My path into robotics started in India during my undergraduate years at MIT, Manipal, where
+        building projects made the field feel instantly alive. That early fascination grew into a
+        deliberate commitment to autonomous systems and eventually brought me to the United States
+        for graduate school at the Colorado School of Mines.
       </p>
 
       <p class="intro-text">
-        I'm driven to keep building and keep learning. Like a shooting star blazing across the sky,
-        I hope to leave my own "Arunabh-sized" dent in the world!
-        <a href={storyHref}>Read the full story.</a>
+        I care deeply about building systems that make the physical world safer, more capable, and
+        easier to navigate. This site is part notebook, part archive, and part ongoing conversation
+        with the work I want to keep doing.
       </p>
     </article>
 


### PR DESCRIPTION
## What changed
- removed the two hero CTA buttons and moved the section links into the hero action area
- removed the Quick Access panel and kept the contact panel as a standalone sidebar
- added a styled career timeline rail based on the about-me story and supplied highlights
- refreshed the homepage intro copy and adjusted the hero stats spacing

## Why it changed
- simplifies the landing page and gives the career journey a more prominent, structured presentation

## Testing
- npm run ci