### PR TITLE
Clean up homepage hero spacing

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1297,12 +1297,16 @@ body.home-page {
 }
 
 .home-hero__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(13.5rem, 15rem);
+  gap: 1.5rem;
   align-items: stretch;
 }
 
 .home-hero__copy {
   flex: 1 1 auto;
   min-width: 0;
+  padding-right: 0.5rem;
 }
 
 .home-title,
@@ -1322,8 +1326,10 @@ body.home-page {
 
 .home-title {
   margin-bottom: 0.75rem;
-  font-size: clamp(2.5rem, 5vw, 4.4rem);
+  max-width: 8.4ch;
+  font-size: clamp(2.7rem, 4.5vw, 4rem);
   line-height: 0.92;
+  text-wrap: balance;
 }
 
 .lead,
@@ -1360,8 +1366,8 @@ body.home-page {
 .home-meta-panel {
   display: grid;
   gap: 0.8rem;
-  width: min(100%, 16rem);
-  margin-right: 1rem;
+  width: 100%;
+  margin-right: 0;
 }
 
 .home-meta-panel__item,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -124,7 +124,6 @@ const formatDate = (date: Date) =>
         </p>
         <nav class="home-command-bar home-command-bar--hero" aria-label="Homepage sections">
           <a href="#about">/about</a>
-          <a href="#collections">/collections</a>
           <a href="#latest">/latest</a>
         </nav>
       </div>
@@ -182,26 +181,6 @@ const formatDate = (date: Date) =>
         ))}
       </ul>
     </article>
-  </section>
-
-  <section class="home-library" id="collections">
-    <div class="home-section-heading">
-      <p class="home-panel__eyebrow">Collections</p>
-      <h2>Browse by section</h2>
-    </div>
-
-    <div class="home-collection-grid">
-      {sectionCards.map((section) => (
-        <a class="home-collection-card" id={section.id} href={section.href}>
-          <div class="home-collection-card__head">
-            <span class="home-collection-card__command">/{section.command}</span>
-            <span class="home-collection-card__count">{section.count}</span>
-          </div>
-          <h3>{section.title}</h3>
-          <p>{section.description}</p>
-        </a>
-      ))}
-    </div>
   </section>
 
   <section class="home-shelves" id="latest">


### PR DESCRIPTION
## What changed
- removed the redundant Browse by section block from the homepage
- removed the matching `/collections` hero link
- tightened the hero layout so the large title no longer overlaps the stats panel

## Why it changed
- fixes the layout collision in the first section and removes duplicated navigation content

## Testing
- npm run ci