### PR TITLE
Rename ponderings to blog and add build intuition

### DIFF
--- a/scripts/migrate-jekyll-content.mjs
+++ b/scripts/migrate-jekyll-content.mjs
@@ -12,10 +12,11 @@ const sourceRoot = process.env.JEKYLL_SOURCE
 
 const sectionByCategory = {
   'Paper Shorts': 'paper-shorts',
-  Ponderings: 'ponderings',
+  Ponderings: 'blog',
+  'Build Intuition': 'build-intuition',
   'Revision Notes': 'revision-notes',
   'Machine Learning Deep-Dives': 'ai-generated-reports',
-  'My Journey So Far': 'my-journey',
+  'My Journey So Far': 'blog',
 };
 
 function deriveSummary(content) {

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -14,7 +14,8 @@ const postsDir = path.join(projectRoot, 'src', 'content', 'posts');
 const criticalPages = [
   'index.html',
   'archive.html',
-  'ponderings.html',
+  'blog.html',
+  'build_intuition.html',
   'revision_notes.html',
   'ai_generated_reports.html',
   'paper_summaries.html',
@@ -66,7 +67,7 @@ async function main() {
 
   const attentionPagePath = path.join(
     distDir,
-    'ponderings',
+    'build intuition',
     '2025',
     '05',
     '25',

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -12,10 +12,10 @@ const posts = defineCollection({
     date: z.coerce.date(),
     section: z.enum([
       'paper-shorts',
-      'ponderings',
+      'blog',
+      'build-intuition',
       'revision-notes',
       'ai-generated-reports',
-      'my-journey',
     ]),
     postSlug: z.string(),
     legacyPath: z.string(),

--- a/src/content/migration-manifest.json
+++ b/src/content/migration-manifest.json
@@ -1,9 +1,9 @@
 [
   {
     "title": "My Journey So Far - The Full Story",
-    "section": "my-journey",
+    "section": "blog",
     "postSlug": "my-journey-so-far-full-story",
-    "legacyPath": "/my journey so far/2025/02/08/my-journey-so-far-full-story.html",
+    "legacyPath": "/blog/2025/02/08/my-journey-so-far-full-story.html",
     "date": "2025-02-08T05:00:00.000Z",
     "field": null
   },
@@ -161,9 +161,9 @@
   },
   {
     "title": "Attention Mechanisms Demystified",
-    "section": "ponderings",
+    "section": "build-intuition",
     "postSlug": "attention-mechanisms-demystified",
-    "legacyPath": "/ponderings/2025/05/25/attention-mechanisms-demystified.html",
+    "legacyPath": "/build intuition/2025/05/25/attention-mechanisms-demystified.html",
     "date": "2025-05-25T04:00:00.000Z",
     "field": null
   },

--- a/src/content/posts/attention-mechanisms-demystified.md
+++ b/src/content/posts/attention-mechanisms-demystified.md
@@ -1,9 +1,9 @@
 ---
 title: Attention Mechanisms Demystified
 date: '2025-05-25T04:00:00.000Z'
-section: ponderings
+section: build-intuition
 postSlug: attention-mechanisms-demystified
-legacyPath: /ponderings/2025/05/25/attention-mechanisms-demystified.html
+legacyPath: /build intuition/2025/05/25/attention-mechanisms-demystified.html
 tags:
   - Other
 summary: >-

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -1,9 +1,9 @@
 ---
 title: My Journey So Far - The Full Story
 date: '2025-02-08T05:00:00.000Z'
-section: my-journey
+section: blog
 postSlug: my-journey-so-far-full-story
-legacyPath: /my journey so far/2025/02/08/my-journey-so-far-full-story.html
+legacyPath: /blog/2025/02/08/my-journey-so-far-full-story.html
 tags:
   - Other
 summary: >-

--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -1,9 +1,9 @@
 ---
 title: Thoughts on Good Research in Industry
 date: '2026-03-22T04:00:00.000Z'
-section: ponderings
+section: blog
 postSlug: thoughts-on-good-research-in-industry
-legacyPath: /ponderings/2026/03/22/thoughts-on-good-research-in-industry.html
+legacyPath: /blog/2026/03/22/thoughts-on-good-research-in-industry.html
 tags:
   - Research
   - Career

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,0 +1,11 @@
+---
+import PostLayout from '../layouts/PostLayout.astro';
+import PostList from '../components/PostList.astro';
+import { getPostsBySection } from '../lib/content';
+
+const posts = await getPostsBySection('blog', 'asc');
+---
+
+<PostLayout title="Blog">
+  <PostList posts={posts} />
+</PostLayout>

--- a/src/pages/build_intuition.astro
+++ b/src/pages/build_intuition.astro
@@ -3,9 +3,9 @@ import PostLayout from '../layouts/PostLayout.astro';
 import PostList from '../components/PostList.astro';
 import { getPostsBySection } from '../lib/content';
 
-const posts = await getPostsBySection('ponderings', 'asc');
+const posts = await getPostsBySection('build-intuition', 'asc');
 ---
 
-<PostLayout title="Ponderings">
+<PostLayout title="Build Intuition">
   <PostList posts={posts} />
 </PostLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,11 +6,16 @@ const paperPosts = await getPostsBySection('paper-shorts', 'desc');
 const revisionPosts = (await getPostsBySection('revision-notes', 'desc')).filter(
   (post) => post.data.postSlug !== 'cs336-revision-notes',
 );
-const ponderingPosts = await getPostsBySection('ponderings', 'desc');
+const blogPosts = await getPostsBySection('blog', 'desc');
+const buildIntuitionPosts = await getPostsBySection('build-intuition', 'desc');
 const aiPosts = await getPostsBySection('ai-generated-reports', 'desc');
 
 const totalEntries =
-  paperPosts.length + ponderingPosts.length + revisionPosts.length + aiPosts.length;
+  paperPosts.length +
+  blogPosts.length +
+  buildIntuitionPosts.length +
+  revisionPosts.length +
+  aiPosts.length;
 
 const sectionCards = [
   {
@@ -22,12 +27,20 @@ const sectionCards = [
     count: paperPosts.length,
   },
   {
-    id: 'ponderings',
-    href: '/ponderings.html',
-    command: 'ponderings',
-    title: 'Ponderings',
-    description: 'Notes on topics I find myself revisiting.',
-    count: ponderingPosts.length,
+    id: 'blog',
+    href: '/blog.html',
+    command: 'blog',
+    title: 'Blog',
+    description: 'Longer reflections on research, work, and the path so far.',
+    count: blogPosts.length,
+  },
+  {
+    id: 'build-intuition',
+    href: '/build_intuition.html',
+    command: 'build-intuition',
+    title: 'Build Intuition',
+    description: 'Intuition-first explainers for foundational ideas worth understanding deeply.',
+    count: buildIntuitionPosts.length,
   },
   {
     id: 'revision-notes',
@@ -55,10 +68,16 @@ const recentShelves = [
     emptyMessage: 'New research notes will show up here.',
   },
   {
-    title: 'Ponderings',
-    href: '/ponderings.html',
-    posts: ponderingPosts.slice(0, 3),
-    emptyMessage: 'Ponderings will show up here.',
+    title: 'Blog',
+    href: '/blog.html',
+    posts: blogPosts.slice(0, 3),
+    emptyMessage: 'Blog posts will show up here.',
+  },
+  {
+    title: 'Build Intuition',
+    href: '/build_intuition.html',
+    posts: buildIntuitionPosts.slice(0, 3),
+    emptyMessage: 'Intuition-first explainers will show up here.',
   },
   {
     title: 'Revision Notes',
@@ -131,7 +150,7 @@ const formatDate = (date: Date) =>
       <div class="home-meta-panel" aria-label="Site overview">
         <div class="home-meta-panel__item">
           <span class="home-meta-panel__label">Sections</span>
-          <strong>04</strong>
+          <strong>05</strong>
         </div>
         <div class="home-meta-panel__item">
           <span class="home-meta-panel__label">Entries</span>
@@ -139,7 +158,7 @@ const formatDate = (date: Date) =>
         </div>
         <div class="home-meta-panel__item">
           <span class="home-meta-panel__label">Latest Paths</span>
-          <p>/paper_summaries_field.html /ponderings.html /revision_notes.html</p>
+          <p>/paper_summaries_field.html /blog.html /build_intuition.html /revision_notes.html</p>
         </div>
       </div>
     </div>

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -61,9 +61,9 @@ describe('migration manifest', () => {
     expect(sections).toEqual(
       new Set([
         'paper-shorts',
-        'ponderings',
+        'blog',
+        'build-intuition',
         'revision-notes',
-        'my-journey',
       ]),
     );
   });


### PR DESCRIPTION
## What changed
- renamed the `ponderings` section to `blog`
- moved `Thoughts on Good Research in Industry` and `My Journey So Far - The Full Story` onto the blog
- created a new `Build Intuition` section and moved `Attention Mechanisms Demystified` there
- updated the homepage, content schema, migration manifest, and build/test expectations for the new sections and routes

## Why it changed
- aligns the site structure with the requested section names and post organization

## Testing
- npm run ci