### PR TITLE
Add sections sidebar for content pages

### DIFF
--- a/public/assets/js/site-controls.js
+++ b/public/assets/js/site-controls.js
@@ -70,6 +70,98 @@ function openMusicPlayer(provider) {
   }
 }
 
+function slugifyHeading(text) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/['".,!?()[\]{}:;]+/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function ensureHeadingIds(headings) {
+  const usedIds = new Set(
+    Array.from(document.querySelectorAll('[id]'))
+      .map((element) => element.id)
+      .filter(Boolean),
+  );
+
+  headings.forEach((heading) => {
+    if (heading.id) {
+      usedIds.add(heading.id);
+      return;
+    }
+
+    const baseId = slugifyHeading(heading.textContent || '') || 'section';
+    let nextId = baseId;
+    let suffix = 2;
+
+    while (usedIds.has(nextId)) {
+      nextId = `${baseId}-${suffix}`;
+      suffix += 1;
+    }
+
+    heading.id = nextId;
+    usedIds.add(nextId);
+  });
+}
+
+function buildSectionsNav() {
+  const root = document.querySelector('[data-sections-root]');
+  const aside = document.querySelector('[data-sections-nav]');
+  const list = document.querySelector('[data-sections-list]');
+
+  if (!(root instanceof HTMLElement) || !(aside instanceof HTMLElement) || !(list instanceof HTMLElement)) {
+    return;
+  }
+
+  const headings = Array.from(root.querySelectorAll('h2, h3, h4')).filter(
+    (heading) => heading instanceof HTMLHeadingElement && heading.textContent?.trim(),
+  );
+
+  if (headings.length === 0) {
+    aside.hidden = true;
+    return;
+  }
+
+  ensureHeadingIds(headings);
+  list.replaceChildren();
+
+  const linkEntries = headings.map((heading) => {
+    const link = document.createElement('a');
+    link.href = `#${heading.id}`;
+    link.textContent = heading.textContent?.trim() ?? heading.id;
+    link.className = 'sections-nav__link';
+    link.dataset.level = heading.tagName.slice(1);
+    list.append(link);
+
+    return { heading, link };
+  });
+
+  aside.hidden = false;
+
+  const updateActiveSection = () => {
+    const offset = 140;
+    let current = linkEntries[0];
+
+    linkEntries.forEach((entry) => {
+      if (entry.heading.getBoundingClientRect().top - offset <= 0) {
+        current = entry;
+      }
+    });
+
+    linkEntries.forEach((entry) => {
+      entry.link.classList.toggle('sections-nav__link--active', entry === current);
+      entry.link.setAttribute('aria-current', entry === current ? 'true' : 'false');
+    });
+  };
+
+  updateActiveSection();
+  window.addEventListener('scroll', updateActiveSection, { passive: true });
+  window.addEventListener('resize', updateActiveSection, { passive: true });
+}
+
 function initSiteControls() {
   const html = document.documentElement;
   const savedProvider = normalizeProvider(localStorage.getItem(MUSIC_PROVIDER_KEY));
@@ -133,6 +225,8 @@ function initSiteControls() {
       closeMusicMenus();
     }
   });
+
+  buildSectionsNav();
 }
 
 if (document.readyState === 'loading') {

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -199,9 +199,103 @@ body.home-page small {
   padding: 5.75rem 1.5rem 2.5rem;
 }
 
+.page-layout {
+  width: min(100%, 72rem);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .page-content--narrow {
   max-width: 800px;
   margin: 2rem auto;
+}
+
+.sections-nav {
+  display: none;
+}
+
+.sections-nav__inner {
+  position: sticky;
+  top: 6.25rem;
+  padding: 1rem 1rem 1.1rem;
+  border-radius: 22px;
+  background: var(--panel-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+:root[data-theme="light"] .sections-nav__inner {
+  border: 1px solid rgba(53, 109, 255, 0.16);
+  box-shadow:
+    0 0 0 1px rgba(53, 109, 255, 0.06),
+    0 16px 40px rgba(53, 85, 150, 0.1);
+}
+
+:root[data-theme="dark"] .sections-nav__inner {
+  border: 1px solid rgba(255, 228, 92, 0.24);
+  box-shadow:
+    0 0 0 1px rgba(255, 228, 92, 0.08),
+    0 16px 40px rgba(0, 0, 0, 0.5);
+}
+
+.sections-nav__eyebrow {
+  margin: 0 0 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-secondary-color);
+}
+
+.sections-nav__links {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.sections-nav__link {
+  display: block;
+  padding: 0.45rem 0.7rem;
+  border-radius: 12px;
+  color: var(--text-secondary-color);
+  font-family: var(--font-reading);
+  font-size: 0.98rem;
+  line-height: 1.35;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.sections-nav__link:hover {
+  color: var(--text-color);
+  text-decoration: none;
+  transform: translateX(2px);
+}
+
+.sections-nav__link[data-level="3"] {
+  padding-left: 1.35rem;
+  font-size: 0.92rem;
+}
+
+.sections-nav__link[data-level="4"] {
+  padding-left: 2rem;
+  font-size: 0.88rem;
+}
+
+.sections-nav__link--active {
+  color: var(--text-color);
+  font-weight: 600;
+}
+
+:root[data-theme="light"] .sections-nav__link:hover,
+:root[data-theme="light"] .sections-nav__link--active {
+  background: rgba(53, 109, 255, 0.1);
+}
+
+:root[data-theme="dark"] .sections-nav__link:hover,
+:root[data-theme="dark"] .sections-nav__link--active {
+  background: rgba(255, 228, 92, 0.1);
 }
 
 .home-title {
@@ -761,6 +855,9 @@ a:visited {
   .page-content {
     padding: 5rem 1rem 2rem;
   }
+  .page-layout {
+    width: 100%;
+  }
   .main-container {
     margin: 1rem;
   }
@@ -797,6 +894,24 @@ a:visited {
     bottom: auto;
     width: min(100%, 220px);
     margin-top: 1rem;
+  }
+}
+
+@media (min-width: 1100px) {
+  .page-layout {
+    grid-template-columns: minmax(0, 1fr) 16rem;
+    gap: 1.5rem;
+    align-items: start;
+  }
+
+  .page-content--narrow {
+    width: 100%;
+    margin: 2rem 0;
+  }
+
+  .sections-nav:not([hidden]) {
+    display: block;
+    margin-top: 7.75rem;
   }
 }
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -23,8 +23,16 @@ const {
 
 <BaseLayout title={title} description={description}>
   <PageControls showHomeButton={true} />
-  <main class="page-content page-content--narrow" aria-label="Content">
-    <slot />
-    {showNavigation && <PostNavigation previous={previous} next={next} />}
-  </main>
+  <div class="page-layout">
+    <main class="page-content page-content--narrow" aria-label="Content" data-sections-root>
+      <slot />
+      {showNavigation && <PostNavigation previous={previous} next={next} />}
+    </main>
+    <aside class="sections-nav" aria-label="Sections" data-sections-nav hidden>
+      <div class="sections-nav__inner">
+        <p class="sections-nav__eyebrow">Sections</p>
+        <nav class="sections-nav__links" data-sections-list></nav>
+      </div>
+    </aside>
+  </div>
 </BaseLayout>


### PR DESCRIPTION
## What changed
- add a reusable sections rail to the shared post layout
- build heading links client-side for pages with h2/h3/h4 headings and hide the rail when none exist
- style the sidebar as a sticky desktop-only navigation with active section highlighting

## Why
This makes long posts and sectioned pages easier to navigate with quick access links on the side.

## Testing
- npm run ci
- pre-push hook ran npm run ci before push