### PR TITLE
Remove latest paths panel from landing page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -156,10 +156,6 @@ const formatDate = (date: Date) =>
           <span class="home-meta-panel__label">Entries</span>
           <strong>{totalEntries}</strong>
         </div>
-        <div class="home-meta-panel__item">
-          <span class="home-meta-panel__label">Latest Paths</span>
-          <p>/paper_summaries_field.html /blog.html /build_intuition.html /revision_notes.html</p>
-        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What changed
- removed the "Latest Paths" item from the homepage hero metadata panel
- left the other landing page hero stats intact

## Why
- the landing page no longer needs the latest path panel

## Testing
- npm run ci