### PR TITLE
Add interactive Python playgrounds to teaching posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "arunabh-blog-v2",
+  "name": "arunabh1904.github.io",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "arunabh-blog-v2",
+      "name": "arunabh1904.github.io",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^5.0.1",
@@ -27,11 +27,53 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
         "@types/node": "^25.5.0",
+        "jsdom": "^29.0.1",
         "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22.12.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
+      "integrity": "sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.8",
@@ -575,6 +617,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
@@ -604,6 +659,146 @@
       "dependencies": {
         "@clack/core": "1.1.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -1092,6 +1287,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@img/colour": {
@@ -2833,6 +3046,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3191,6 +3414,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3207,6 +3444,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -4183,6 +4427,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -4358,6 +4615,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -4389,6 +4653,60 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -5996,6 +6314,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6571,6 +6899,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -6893,6 +7234,13 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -6950,6 +7298,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6960,6 +7328,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -7058,6 +7452,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -7829,6 +8233,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -7837,6 +8254,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which-pm-runs": {
@@ -7882,6 +8334,23 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
     "@types/node": "^25.5.0",
+    "jsdom": "^29.0.1",
     "vitest": "^4.1.0"
   }
 }

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1859,3 +1859,287 @@ body.home-page {
     width: 100%;
   }
 }
+
+.python-playground {
+  margin: 2rem 0;
+  padding: 1.35rem;
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgba(12, 20, 40, 0.97), rgba(8, 14, 28, 0.99));
+  border: 1px solid rgba(118, 169, 255, 0.18);
+  box-shadow: 0 24px 48px rgba(7, 20, 48, 0.2);
+  color: #dff0ff;
+}
+
+:root[data-theme="dark"] .python-playground {
+  background:
+    linear-gradient(180deg, rgba(10, 10, 10, 0.98), rgba(18, 15, 3, 0.98));
+  border-color: rgba(255, 228, 92, 0.22);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  color: #fff7cf;
+}
+
+.python-playground h3,
+.python-playground h4,
+.python-playground p,
+.python-playground code,
+.python-playground button,
+.python-playground textarea,
+.python-playground pre {
+  font-family: var(--font-mono);
+}
+
+.python-playground__header,
+.python-playground__walkthrough-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.python-playground__eyebrow {
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  color: #7fc5ff;
+}
+
+:root[data-theme="dark"] .python-playground__eyebrow {
+  color: #ffe45c;
+}
+
+.python-playground__header h3,
+.python-playground__walkthrough-header h4 {
+  margin: 0;
+}
+
+.python-playground__status,
+.python-playground__walkthrough-header > p,
+.python-playground__sample-description,
+.python-playground__notes,
+.python-playground__walkthrough-note {
+  color: rgba(223, 240, 255, 0.82);
+}
+
+:root[data-theme="dark"] .python-playground__status,
+:root[data-theme="dark"] .python-playground__walkthrough-header > p,
+:root[data-theme="dark"] .python-playground__sample-description,
+:root[data-theme="dark"] .python-playground__notes,
+:root[data-theme="dark"] .python-playground__walkthrough-note {
+  color: rgba(255, 247, 207, 0.82);
+}
+
+.python-playground__status {
+  margin: 0;
+  max-width: 22rem;
+  font-size: 0.85rem;
+}
+
+.python-playground__status--ready {
+  color: #86f7c0;
+}
+
+.python-playground__status--error {
+  color: #ff8e8e;
+}
+
+.python-playground__samples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin: 1rem 0 0.75rem;
+}
+
+.python-playground__samples button,
+.python-playground__actions button,
+.python-playground__walkthrough-actions button {
+  appearance: none;
+  border: 1px solid rgba(127, 197, 255, 0.25);
+  background: rgba(15, 30, 58, 0.72);
+  color: inherit;
+  padding: 0.65rem 0.95rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
+}
+
+:root[data-theme="dark"] .python-playground__samples button,
+:root[data-theme="dark"] .python-playground__actions button,
+:root[data-theme="dark"] .python-playground__walkthrough-actions button {
+  border-color: rgba(255, 228, 92, 0.24);
+  background: rgba(35, 28, 2, 0.72);
+}
+
+.python-playground__samples button:hover,
+.python-playground__actions button:hover,
+.python-playground__walkthrough-actions button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(127, 197, 255, 0.52);
+}
+
+:root[data-theme="dark"] .python-playground__samples button:hover,
+:root[data-theme="dark"] .python-playground__actions button:hover,
+:root[data-theme="dark"] .python-playground__walkthrough-actions button:hover {
+  border-color: rgba(255, 228, 92, 0.5);
+}
+
+.python-playground__samples button.is-active {
+  background: rgba(38, 84, 165, 0.86);
+  border-color: rgba(151, 208, 255, 0.6);
+}
+
+:root[data-theme="dark"] .python-playground__samples button.is-active {
+  background: rgba(91, 73, 5, 0.86);
+  border-color: rgba(255, 228, 92, 0.55);
+}
+
+.python-playground__samples button:disabled,
+.python-playground__actions button:disabled,
+.python-playground__walkthrough-actions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.python-playground__terminal,
+.python-playground__walkthrough {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(127, 197, 255, 0.16);
+  background: rgba(5, 15, 30, 0.65);
+}
+
+:root[data-theme="dark"] .python-playground__terminal,
+:root[data-theme="dark"] .python-playground__walkthrough {
+  border-color: rgba(255, 228, 92, 0.18);
+  background: rgba(12, 10, 2, 0.72);
+}
+
+.python-playground__promptbar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.85rem;
+}
+
+.python-playground__dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: #ff7c7c;
+}
+
+.python-playground__dot:nth-child(2) {
+  background: #ffd76e;
+}
+
+.python-playground__dot:nth-child(3) {
+  background: #81f0b0;
+}
+
+.python-playground__prompt {
+  margin-left: 0.4rem;
+  color: rgba(223, 240, 255, 0.7);
+}
+
+:root[data-theme="dark"] .python-playground__prompt {
+  color: rgba(255, 247, 207, 0.7);
+}
+
+.python-playground__editor-label {
+  display: block;
+  margin-bottom: 0.6rem;
+  font-size: 0.84rem;
+}
+
+.python-playground__editor {
+  width: 100%;
+  min-height: 22rem;
+  resize: vertical;
+  box-sizing: border-box;
+  border-radius: 16px;
+  border: 1px solid rgba(127, 197, 255, 0.18);
+  background: rgba(3, 10, 20, 0.82);
+  color: inherit;
+  padding: 1rem;
+  line-height: 1.55;
+  font-size: 0.95rem;
+}
+
+:root[data-theme="dark"] .python-playground__editor {
+  border-color: rgba(255, 228, 92, 0.2);
+  background: rgba(7, 7, 7, 0.9);
+}
+
+.python-playground__actions,
+.python-playground__walkthrough-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.9rem;
+}
+
+.python-playground__output {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.python-playground__output > div,
+.python-playground__variable-card {
+  border-radius: 16px;
+  border: 1px solid rgba(127, 197, 255, 0.14);
+  background: rgba(2, 9, 18, 0.72);
+  padding: 0.9rem;
+}
+
+:root[data-theme="dark"] .python-playground__output > div,
+:root[data-theme="dark"] .python-playground__variable-card {
+  border-color: rgba(255, 228, 92, 0.16);
+  background: rgba(8, 8, 8, 0.78);
+}
+
+.python-playground__output p,
+.python-playground__variable-card p {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.python-playground__output pre,
+.python-playground__variable-card code {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.python-playground__variables {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.python-playground__notes {
+  margin-bottom: 0;
+}
+
+@media (max-width: 820px) {
+  .python-playground__header,
+  .python-playground__walkthrough-header,
+  .python-playground__output,
+  .python-playground__variables {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+
+  .python-playground__output,
+  .python-playground__variables {
+    display: grid;
+  }
+}

--- a/src/components/PythonPlayground.tsx
+++ b/src/components/PythonPlayground.tsx
@@ -1,0 +1,304 @@
+import React, { startTransition, useEffect, useRef, useState } from 'react';
+import { loadPyodideRuntime } from '../lib/pyodide-loader';
+import type { PyodideRuntime } from '../lib/pyodide-loader';
+import type { PythonPlaygroundProps } from '../lib/python-playground';
+
+const EXECUTION_PREFIX = `
+import contextlib
+import io
+import traceback
+`;
+
+function escapePythonTripleQuotedString(source: string) {
+  return source.replace(/\\/g, '\\\\').replace(/"""/g, '\\"""');
+}
+
+async function runCode(runtime: PyodideRuntime, code: string) {
+  const escapedCode = escapePythonTripleQuotedString(code);
+  const result = await runtime.runPythonAsync(`
+${EXECUTION_PREFIX}
+_stdout_buffer = io.StringIO()
+_stderr_buffer = io.StringIO()
+_execution_result = None
+
+with contextlib.redirect_stdout(_stdout_buffer), contextlib.redirect_stderr(_stderr_buffer):
+    try:
+        exec("""${escapedCode}""", {})
+    except Exception:
+        traceback.print_exc()
+
+(_stdout_buffer.getvalue(), _stderr_buffer.getvalue())
+`);
+
+  const normalizedResult =
+    typeof result === 'object' &&
+    result !== null &&
+    'toJs' in result &&
+    typeof result.toJs === 'function'
+      ? result.toJs()
+      : result;
+
+  if (!Array.isArray(normalizedResult)) {
+    return { stdout: '', stderr: 'Unexpected result returned from Python runtime.' };
+  }
+
+  return {
+    stdout: String(normalizedResult[0] ?? ''),
+    stderr: String(normalizedResult[1] ?? ''),
+  };
+}
+
+export default function PythonPlayground({
+  title,
+  initialCode,
+  samples,
+  walkthroughSteps = [],
+  notes,
+}: PythonPlaygroundProps) {
+  const containerRef = useRef<HTMLElement | null>(null);
+  const runtimeRef = useRef<PyodideRuntime | null>(null);
+  const [code, setCode] = useState(initialCode);
+  const [output, setOutput] = useState('');
+  const [errorOutput, setErrorOutput] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [statusMessage, setStatusMessage] = useState('Python runtime will load when this block scrolls into view.');
+  const [isRunning, setIsRunning] = useState(false);
+  const [selectedSample, setSelectedSample] = useState(0);
+  const [activeStep, setActiveStep] = useState(0);
+
+  useEffect(() => {
+    let didCancel = false;
+
+    async function bootstrapRuntime() {
+      if (runtimeRef.current || status === 'loading') {
+        return;
+      }
+
+      setStatus('loading');
+      setStatusMessage('Preparing the in-browser Python runtime...');
+
+      try {
+        const runtime = await loadPyodideRuntime();
+        if (didCancel) {
+          return;
+        }
+        runtimeRef.current = runtime;
+        setStatus('ready');
+        setStatusMessage('Python is ready. Edit the code and run it.');
+      } catch (error) {
+        if (didCancel) {
+          return;
+        }
+        setStatus('error');
+        setStatusMessage(
+          error instanceof Error ? error.message : 'The Python runtime failed to load.',
+        );
+      }
+    }
+
+    if (typeof window === 'undefined') {
+      return () => {
+        didCancel = true;
+      };
+    }
+
+    const node = containerRef.current;
+    if (!node) {
+      return () => {
+        didCancel = true;
+      };
+    }
+
+    if (typeof window.IntersectionObserver !== 'function') {
+      void bootstrapRuntime();
+      return () => {
+        didCancel = true;
+      };
+    }
+
+    const observer = new window.IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry?.isIntersecting) {
+          observer.disconnect();
+          void bootstrapRuntime();
+        }
+      },
+      { rootMargin: '160px 0px' },
+    );
+
+    observer.observe(node);
+
+    return () => {
+      didCancel = true;
+      observer.disconnect();
+    };
+  }, []);
+
+  const currentStep = walkthroughSteps[activeStep];
+
+  async function handleRun() {
+    if (!runtimeRef.current) {
+      setStatusMessage('Python is still loading. Try again in a moment.');
+      return;
+    }
+
+    setIsRunning(true);
+    setOutput('');
+    setErrorOutput('');
+
+    try {
+      const result = await runCode(runtimeRef.current, code);
+      startTransition(() => {
+        setOutput(result.stdout.trimEnd());
+        setErrorOutput(result.stderr.trimEnd());
+      });
+    } catch (error) {
+      setErrorOutput(error instanceof Error ? error.message : 'Unknown execution error.');
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  function handleReset() {
+    setCode(initialCode);
+    setOutput('');
+    setErrorOutput('');
+    setSelectedSample(0);
+    setActiveStep(0);
+  }
+
+  function handleLoadSample(index: number) {
+    setSelectedSample(index);
+    setCode(samples[index]?.code ?? initialCode);
+    setOutput('');
+    setErrorOutput('');
+    setActiveStep(0);
+  }
+
+  return (
+    <section className="python-playground" ref={containerRef}>
+      <div className="python-playground__header">
+        <div>
+          <p className="python-playground__eyebrow">Interactive Python</p>
+          <h3>{title}</h3>
+        </div>
+        <p
+          className={`python-playground__status python-playground__status--${status}`}
+          aria-live="polite"
+        >
+          {statusMessage}
+        </p>
+      </div>
+
+      <div className="python-playground__samples" aria-label="Example presets">
+        {samples.map((sample, index) => (
+          <button
+            key={sample.label}
+            className={index === selectedSample ? 'is-active' : undefined}
+            type="button"
+            onClick={() => handleLoadSample(index)}
+          >
+            {sample.label}
+          </button>
+        ))}
+      </div>
+
+      {samples[selectedSample]?.description && (
+        <p className="python-playground__sample-description">
+          {samples[selectedSample].description}
+        </p>
+      )}
+
+      <div className="python-playground__terminal">
+        <div className="python-playground__promptbar">
+          <span className="python-playground__dot" />
+          <span className="python-playground__dot" />
+          <span className="python-playground__dot" />
+          <span className="python-playground__prompt">python lesson.py</span>
+        </div>
+
+        <label className="python-playground__editor-label" htmlFor={title}>
+          Editable Python snippet
+        </label>
+        <textarea
+          id={title}
+          className="python-playground__editor"
+          spellCheck={false}
+          value={code}
+          onChange={(event) => setCode(event.target.value)}
+        />
+
+        <div className="python-playground__actions">
+          <button type="button" onClick={() => void handleRun()} disabled={status !== 'ready' || isRunning}>
+            {isRunning ? 'Running...' : 'Run'}
+          </button>
+          <button type="button" onClick={handleReset}>
+            Reset
+          </button>
+          <button type="button" onClick={() => handleLoadSample(selectedSample)}>
+            Load Example
+          </button>
+        </div>
+
+        <div className="python-playground__output">
+          <div>
+            <p>stdout</p>
+            <pre>{output || 'Run the snippet to see printed output here.'}</pre>
+          </div>
+          <div>
+            <p>stderr</p>
+            <pre>{errorOutput || 'Execution errors will appear here.'}</pre>
+          </div>
+        </div>
+      </div>
+
+      {walkthroughSteps.length > 0 && currentStep && (
+        <div className="python-playground__walkthrough">
+          <div className="python-playground__walkthrough-header">
+            <div>
+              <p className="python-playground__eyebrow">Guided Trace</p>
+              <h4>{currentStep.label}</h4>
+            </div>
+            <p>
+              Step {activeStep + 1} of {walkthroughSteps.length}
+              {currentStep.lineHint ? ` · line ${currentStep.lineHint}` : ''}
+            </p>
+          </div>
+
+          <div className="python-playground__variables">
+            {Object.entries(currentStep.variables).map(([name, value]) => (
+              <div key={name} className="python-playground__variable-card">
+                <p>{name}</p>
+                <code>{value}</code>
+              </div>
+            ))}
+          </div>
+
+          {currentStep.output && <p className="python-playground__walkthrough-note">{currentStep.output}</p>}
+
+          <div className="python-playground__walkthrough-actions">
+            <button
+              type="button"
+              onClick={() => setActiveStep((step) => Math.max(step - 1, 0))}
+              disabled={activeStep === 0}
+            >
+              Previous Step
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setActiveStep((step) => Math.min(step + 1, walkthroughSteps.length - 1))
+              }
+              disabled={activeStep === walkthroughSteps.length - 1}
+            >
+              Next Step
+            </button>
+          </div>
+        </div>
+      )}
+
+      {notes && <p className="python-playground__notes">{notes}</p>}
+    </section>
+  );
+}

--- a/src/content/posts/attention-is-all-you-need.mdx
+++ b/src/content/posts/attention-is-all-you-need.mdx
@@ -9,6 +9,9 @@ tags:
 field: Natural Language Processing
 summary: 2017 – Attention Is All You Need
 ---
+import PythonPlayground from '../../components/PythonPlayground';
+import { attentionIsAllYouNeedPlayground } from '../../lib/python-playground-examples';
+
 ## 2017 – Attention Is All You Need
 
 **arXiv:** [1706.03762](https://arxiv.org/abs/1706.03762)
@@ -54,7 +57,13 @@ The additive mask inserts $-\infty$ so the softmax cleanly ignores blocked posit
 Multi-head attention, typically eight heads with $d_k = d_v = 64$,
 preserves information that a single head would compress.
 
-<img src="/assets/images/attention.png" alt="Transformer" style="max-width:60%;margin:1rem auto;display:block;">
+The paper’s core math lands more quickly when you can poke at small numbers yourself.
+This playground gives you a toy scaled-dot-product attention computation plus a positional-encoding helper.
+Run the default code first, then change the query or the position index and watch how the values shift.
+
+<PythonPlayground client:visible {...attentionIsAllYouNeedPlayground} />
+
+<img src="/assets/images/attention.png" alt="Transformer" style="max-width:60%;margin:1rem auto;display:block;" />
 
 ### Positional encoding
 

--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -11,6 +11,9 @@ summary: >-
   multi-head attention, and cross-attention, with equations, examples, and
   visual explanations.
 ---
+import PythonPlayground from '../../components/PythonPlayground';
+import { attentionMechanismsPlayground } from '../../lib/python-playground-examples';
+
 ## 2025 - Attention Mechanisms Demystified: Building Intuition for Q, K, V, and Self-Attention
 
 Attention is easiest to understand as **learned information routing**.
@@ -171,6 +174,12 @@ self-attention is usually **causal**:
 future positions are masked out so a token can only attend to earlier tokens.
 The mechanism stays the same;
 the model is simply forbidden from looking ahead.
+
+To make that less abstract, here is a tiny runnable attention example.
+The default snippet uses a query representing the pronoun-like token and three candidate source tokens.
+Run it once, then step through the guided trace to see the raw scores, softmax weights, and final mixed value vector.
+
+<PythonPlayground client:visible {...attentionMechanismsPlayground} />
 
 ### Multi-head attention: one mechanism, many simultaneous views
 

--- a/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
+++ b/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
@@ -16,6 +16,9 @@ summary: >-
   2019 – BERT: Pre-training of Deep Bidirectional Transformers for Language
   Understanding
 ---
+import PythonPlayground from '../../components/PythonPlayground';
+import { bertPlayground } from '../../lib/python-playground-examples';
+
 ## 2019 – BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding
 
 **arXiv:** [1810.04805](https://arxiv.org/abs/1810.04805)  
@@ -74,6 +77,11 @@ TL;DR A 12-layer (base) or 24-layer (large) Transformer encoder, pre-trained on 
 
 The `mask_tokens` function corrupts 15 % of input pieces at random, forcing the network to infer each blank from both left and right context. This made BERT genuinely bidirectional, unlike GPT-1’s left-to-right guessing game or ELMo’s shallow concatenation of two one-directional RNNs.
 
+This browser-side toy version strips away the `torch` machinery and focuses on the bookkeeping that matters.
+Run it once, then walk through the traced values to see exactly which positions become labels, how the masked input is formed, and how the model head maps predictions back to the hidden originals.
+
+<PythonPlayground client:visible {...bertPlayground} />
+
 ### Next-Sentence Prediction (NSP)
 
 `make_sentence_pairs` creates 50 % real A→B pairs and 50 % mismatches. The classifier sitting on `[CLS]` learns discourse-level coherence. Later work (RoBERTa) showed you can ditch NSP without hurting accuracy, but the idea seeded a huge body of inter-sentence objectives (e.g. sentence embedding models, dense retrieval).
@@ -112,4 +120,3 @@ Training cost: ~4 days on 16 TPU v3 chips; a single downstream fine-tune (e.g. Q
 ## Looking Forward
 
 BERT’s recipe is a floor, not a ceiling. Better corruption schemes (SpanBERT, DeBERTa’s disentangled masks), cheaper compressors (DistilBERT, TinyBERT), and smarter attention (Longformer, FlashAttention) all stand on its shoulders. Yet the two short snippets at the top remain the intellectual core: mask some tokens, test sentence order, back-propagate, repeat. That elegance is why BERT is still worth teaching in 2025.
-

--- a/src/content/posts/proximal-policy-optimization-ppo.mdx
+++ b/src/content/posts/proximal-policy-optimization-ppo.mdx
@@ -9,6 +9,9 @@ tags:
 field: Reinforcement Learning
 summary: 2017 – Proximal Policy Optimization Algorithms (PPO)
 ---
+import PythonPlayground from '../../components/PythonPlayground';
+import { ppoPlayground } from '../../lib/python-playground-examples';
+
 ## 2017 – Proximal Policy Optimization Algorithms (PPO)
 
 **arXiv:** [1707.06347](https://arxiv.org/abs/1707.06347)
@@ -59,4 +62,8 @@ def ppo_clip_loss(policy, old_logp, obs, act, adv, clip_eps=0.2):
 ```
 Run several epochs of Adam on batches of rollout data, add a small value-function loss and entropy bonus, and you have a working PPO agent in about 50 lines. This simplicity is why PPO became the "hello world" of modern deep RL.
 
+The important part to internalize is not the `torch` syntax but the numbers PPO refuses to trust.
+This tiny terminal lets you vary the log-probabilities, advantage, and clipping threshold while the walkthrough shows exactly when the unclipped objective gets cut back.
+
+<PythonPlayground client:visible {...ppoPlayground} />
 

--- a/src/lib/pyodide-loader.ts
+++ b/src/lib/pyodide-loader.ts
@@ -1,0 +1,71 @@
+const PYODIDE_INDEX_URL = 'https://cdn.jsdelivr.net/pyodide/v0.28.3/full/';
+const PYODIDE_SCRIPT_SRC = `${PYODIDE_INDEX_URL}pyodide.js`;
+
+export interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<unknown>;
+}
+
+declare global {
+  interface Window {
+    loadPyodide?: (options: { indexURL: string }) => Promise<PyodideRuntime>;
+  }
+}
+
+let scriptPromise: Promise<void> | null = null;
+let runtimePromise: Promise<PyodideRuntime> | null = null;
+
+function ensurePyodideScript() {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('Pyodide can only load in the browser.'));
+  }
+
+  if (window.loadPyodide) {
+    return Promise.resolve();
+  }
+
+  if (!scriptPromise) {
+    scriptPromise = new Promise<void>((resolve, reject) => {
+      const existing = document.querySelector<HTMLScriptElement>(
+        `script[data-pyodide-loader="true"]`,
+      );
+
+      if (existing) {
+        existing.addEventListener('load', () => resolve(), { once: true });
+        existing.addEventListener(
+          'error',
+          () => reject(new Error('Failed to load the Pyodide script.')),
+          { once: true },
+        );
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = PYODIDE_SCRIPT_SRC;
+      script.async = true;
+      script.dataset.pyodideLoader = 'true';
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error('Failed to load the Pyodide script.'));
+      document.head.appendChild(script);
+    });
+  }
+
+  return scriptPromise;
+}
+
+export async function loadPyodideRuntime() {
+  if (!runtimePromise) {
+    runtimePromise = ensurePyodideScript().then(async () => {
+      if (!window.loadPyodide) {
+        throw new Error('Pyodide loader was unavailable after script load.');
+      }
+      return window.loadPyodide({ indexURL: PYODIDE_INDEX_URL });
+    });
+  }
+
+  return runtimePromise;
+}
+
+export function resetPyodideLoaderForTests() {
+  scriptPromise = null;
+  runtimePromise = null;
+}

--- a/src/lib/python-playground-examples.ts
+++ b/src/lib/python-playground-examples.ts
@@ -1,0 +1,497 @@
+import type { PythonPlaygroundProps } from './python-playground';
+
+export const attentionMechanismsPlayground: PythonPlaygroundProps = {
+  title: 'Toy Self-Attention Terminal',
+  initialCode: `import math
+
+tokens = ["animal", "street", "tired"]
+query = [1.0, 0.2]
+keys = {
+    "animal": [1.0, 0.3],
+    "street": [0.2, 0.9],
+    "tired": [0.8, 0.4],
+}
+values = {
+    "animal": [0.9, 0.1],
+    "street": [0.1, 0.8],
+    "tired": [0.7, 0.6],
+}
+
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+scores = {token: dot(query, keys[token]) for token in tokens}
+scale = math.sqrt(len(query))
+scaled_scores = {token: round(score / scale, 3) for token, score in scores.items()}
+exp_scores = {token: math.exp(scaled_scores[token]) for token in tokens}
+normalizer = sum(exp_scores.values())
+weights = {token: round(exp_scores[token] / normalizer, 3) for token in tokens}
+output = [
+    round(sum(weights[token] * values[token][dim] for token in tokens), 3)
+    for dim in range(2)
+]
+
+print("raw scores:", scores)
+print("scaled scores:", scaled_scores)
+print("attention weights:", weights)
+print("context vector:", output)
+`,
+  samples: [
+    {
+      label: 'Pronoun Routing',
+      description: 'Trace how a toy query focuses most strongly on "animal" and "tired".',
+      code: `import math
+
+tokens = ["animal", "street", "tired"]
+query = [1.0, 0.2]
+keys = {
+    "animal": [1.0, 0.3],
+    "street": [0.2, 0.9],
+    "tired": [0.8, 0.4],
+}
+values = {
+    "animal": [0.9, 0.1],
+    "street": [0.1, 0.8],
+    "tired": [0.7, 0.6],
+}
+
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+scores = {token: dot(query, keys[token]) for token in tokens}
+scale = math.sqrt(len(query))
+scaled_scores = {token: round(score / scale, 3) for token, score in scores.items()}
+exp_scores = {token: math.exp(scaled_scores[token]) for token in tokens}
+normalizer = sum(exp_scores.values())
+weights = {token: round(exp_scores[token] / normalizer, 3) for token in tokens}
+output = [
+    round(sum(weights[token] * values[token][dim] for token in tokens), 3)
+    for dim in range(2)
+]
+
+print("raw scores:", scores)
+print("scaled scores:", scaled_scores)
+print("attention weights:", weights)
+print("context vector:", output)
+`,
+    },
+    {
+      label: 'Sharper Query',
+      description: 'Change the query to over-weight the "tired" token and watch the mix shift.',
+      code: `import math
+
+tokens = ["animal", "street", "tired"]
+query = [0.4, 1.0]
+keys = {
+    "animal": [1.0, 0.3],
+    "street": [0.2, 0.9],
+    "tired": [0.8, 0.4],
+}
+values = {
+    "animal": [0.9, 0.1],
+    "street": [0.1, 0.8],
+    "tired": [0.7, 0.6],
+}
+
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+scores = {token: dot(query, keys[token]) for token in tokens}
+scale = math.sqrt(len(query))
+scaled_scores = {token: round(score / scale, 3) for token, score in scores.items()}
+exp_scores = {token: math.exp(scaled_scores[token]) for token in tokens}
+normalizer = sum(exp_scores.values())
+weights = {token: round(exp_scores[token] / normalizer, 3) for token in tokens}
+output = [
+    round(sum(weights[token] * values[token][dim] for token in tokens), 3)
+    for dim in range(2)
+]
+
+print("raw scores:", scores)
+print("scaled scores:", scaled_scores)
+print("attention weights:", weights)
+print("context vector:", output)
+`,
+    },
+  ],
+  walkthroughSteps: [
+    {
+      label: 'Compute raw compatibility scores',
+      lineHint: 18,
+      variables: {
+        query: '[1.0, 0.2]',
+        scores: "{'animal': 1.06, 'street': 0.38, 'tired': 0.88}",
+      },
+      output: 'The query best matches `animal`, with `tired` close behind.',
+    },
+    {
+      label: 'Scale before softmax',
+      lineHint: 20,
+      variables: {
+        scale: '1.414',
+        scaled_scores: "{'animal': 0.75, 'street': 0.269, 'tired': 0.622}",
+      },
+      output: 'Dividing by sqrt(d_k) keeps the logits from becoming too sharp too early.',
+    },
+    {
+      label: 'Normalize into attention weights',
+      lineHint: 23,
+      variables: {
+        normalizer: '5.691',
+        weights: "{'animal': 0.373, 'street': 0.23, 'tired': 0.397}",
+      },
+      output: 'Softmax turns the compatibility scores into a probability distribution.',
+    },
+    {
+      label: 'Mix the values into one context vector',
+      lineHint: 24,
+      variables: {
+        output: '[0.659, 0.52]',
+      },
+      output: 'The final vector is a weighted blend of the returned values, not a hard pointer.',
+    },
+  ],
+  notes:
+    'Try editing the query or one of the key vectors, then re-run. Watch how the weight distribution shifts before the context vector changes.',
+};
+
+export const attentionIsAllYouNeedPlayground: PythonPlaygroundProps = {
+  title: 'Scaled Attention And Positional Encoding Terminal',
+  initialCode: `import math
+
+query = [1.0, 0.0]
+keys = [[1.0, 0.0], [0.6, 0.8], [0.0, 1.0]]
+values = [[5.0, 0.0], [2.0, 2.0], [0.0, 4.0]]
+
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+raw_scores = [dot(query, key) for key in keys]
+scale = math.sqrt(len(query))
+scaled_scores = [round(score / scale, 3) for score in raw_scores]
+exp_scores = [math.exp(score) for score in scaled_scores]
+normalizer = sum(exp_scores)
+weights = [round(score / normalizer, 3) for score in exp_scores]
+context = [
+    round(sum(weights[i] * values[i][dim] for i in range(len(values))), 3)
+    for dim in range(len(values[0]))
+]
+
+def positional_encoding(position, d_model):
+    row = []
+    for i in range(d_model):
+        exponent = (2 * (i // 2)) / d_model
+        angle = position / (10000 ** exponent)
+        row.append(round(math.sin(angle), 4) if i % 2 == 0 else round(math.cos(angle), 4))
+    return row
+
+print("scaled scores:", scaled_scores)
+print("attention weights:", weights)
+print("context:", context)
+print("PE(pos=3, d_model=4):", positional_encoding(3, 4))
+`,
+  samples: [
+    {
+      label: 'Scaled Attention',
+      description: 'Inspect how one query spreads probability mass across three keys.',
+      code: `import math
+
+query = [1.0, 0.0]
+keys = [[1.0, 0.0], [0.6, 0.8], [0.0, 1.0]]
+values = [[5.0, 0.0], [2.0, 2.0], [0.0, 4.0]]
+
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+raw_scores = [dot(query, key) for key in keys]
+scale = math.sqrt(len(query))
+scaled_scores = [round(score / scale, 3) for score in raw_scores]
+exp_scores = [math.exp(score) for score in scaled_scores]
+normalizer = sum(exp_scores)
+weights = [round(score / normalizer, 3) for score in exp_scores]
+context = [
+    round(sum(weights[i] * values[i][dim] for i in range(len(values))), 3)
+    for dim in range(len(values[0]))
+]
+
+print("scaled scores:", scaled_scores)
+print("attention weights:", weights)
+print("context:", context)
+`,
+    },
+    {
+      label: 'Positional Encoding',
+      description: 'Change the position or model width and see the sinusoidal pattern move.',
+      code: `import math
+
+def positional_encoding(position, d_model):
+    row = []
+    for i in range(d_model):
+        exponent = (2 * (i // 2)) / d_model
+        angle = position / (10000 ** exponent)
+        row.append(round(math.sin(angle), 4) if i % 2 == 0 else round(math.cos(angle), 4))
+    return row
+
+for position in range(4):
+    print(f"position {position}:", positional_encoding(position, 6))
+`,
+    },
+  ],
+  walkthroughSteps: [
+    {
+      label: 'Score each key against the query',
+      lineHint: 9,
+      variables: {
+        raw_scores: '[1.0, 0.6, 0.0]',
+        scale: '1.414',
+      },
+      output: 'The first key is the best match, but the second still receives some probability mass.',
+    },
+    {
+      label: 'Scale and normalize',
+      lineHint: 12,
+      variables: {
+        scaled_scores: '[0.707, 0.424, 0.0]',
+        weights: '[0.444, 0.334, 0.221]',
+      },
+      output: 'Scaling avoids overconfident logits before softmax turns them into weights.',
+    },
+    {
+      label: 'Form the context vector',
+      lineHint: 15,
+      variables: {
+        context: '[2.888, 1.552]',
+      },
+      output: 'The context vector is a weighted average of the value vectors.',
+    },
+    {
+      label: 'Inject position information',
+      lineHint: 19,
+      variables: {
+        'PE(pos=3, d_model=4)': '[0.1411, -0.99, 0.03, 0.9996]',
+      },
+      output: 'The sine/cosine pair changes smoothly with position while staying deterministic.',
+    },
+  ],
+  notes:
+    'Run the default sample, then change the query or swap in different keys. For positional encoding, try larger positions and see how the low-frequency dimensions move more slowly.',
+};
+
+export const bertPlayground: PythonPlaygroundProps = {
+  title: 'Tiny BERT Pretraining Terminal',
+  initialCode: `tokens = ["[CLS]", "the", "robot", "learns", "fast", "[SEP]"]
+mask_positions = [2, 3]
+vocab = ["the", "robot", "learns", "fast", "slow", "agent"]
+
+masked_tokens = tokens[:]
+labels = {}
+
+for pos in mask_positions:
+    labels[pos] = tokens[pos]
+    masked_tokens[pos] = "[MASK]"
+
+prediction_scores = {
+    2: {"robot": 0.78, "agent": 0.18, "slow": 0.04},
+    3: {"learns": 0.72, "fast": 0.17, "slow": 0.11},
+}
+
+predictions = {pos: max(scores, key=scores.get) for pos, scores in prediction_scores.items()}
+accuracy = sum(predictions[pos] == labels[pos] for pos in mask_positions) / len(mask_positions)
+
+print("masked input:", masked_tokens)
+print("labels:", labels)
+print("predictions:", predictions)
+print("mlm accuracy:", round(accuracy, 2))
+`,
+  samples: [
+    {
+      label: 'Masked LM',
+      description: 'Follow how masking creates labels only at the hidden positions.',
+      code: `tokens = ["[CLS]", "the", "robot", "learns", "fast", "[SEP]"]
+mask_positions = [2, 3]
+vocab = ["the", "robot", "learns", "fast", "slow", "agent"]
+
+masked_tokens = tokens[:]
+labels = {}
+
+for pos in mask_positions:
+    labels[pos] = tokens[pos]
+    masked_tokens[pos] = "[MASK]"
+
+prediction_scores = {
+    2: {"robot": 0.78, "agent": 0.18, "slow": 0.04},
+    3: {"learns": 0.72, "fast": 0.17, "slow": 0.11},
+}
+
+predictions = {pos: max(scores, key=scores.get) for pos, scores in prediction_scores.items()}
+accuracy = sum(predictions[pos] == labels[pos] for pos in mask_positions) / len(mask_positions)
+
+print("masked input:", masked_tokens)
+print("labels:", labels)
+print("predictions:", predictions)
+print("mlm accuracy:", round(accuracy, 2))
+`,
+    },
+    {
+      label: 'Next Sentence Pair',
+      description: 'See how an NSP-style label is just a binary coherence target.',
+      code: `sentence_a = "The robot picked up the box."
+sentence_b = "It placed it on the shelf."
+sentence_c = "Bananas are usually yellow."
+
+pairs = [
+    (sentence_a, sentence_b, 0),
+    (sentence_a, sentence_c, 1),
+]
+
+for first, second, label in pairs:
+    relation = "is next" if label == 0 else "is random"
+    print(f"A: {first}")
+    print(f"B: {second}")
+    print("label:", relation)
+    print("-" * 24)
+`,
+    },
+  ],
+  walkthroughSteps: [
+    {
+      label: 'Choose masked positions',
+      lineHint: 1,
+      variables: {
+        tokens: "['[CLS]', 'the', 'robot', 'learns', 'fast', '[SEP]']",
+        mask_positions: '[2, 3]',
+      },
+      output: 'Only a subset of tokens become prediction targets in MLM.',
+    },
+    {
+      label: 'Build the corrupted input',
+      lineHint: 7,
+      variables: {
+        masked_tokens: "['[CLS]', 'the', '[MASK]', '[MASK]', 'fast', '[SEP]']",
+        labels: "{2: 'robot', 3: 'learns'}",
+      },
+      output: 'BERT sees the masked sequence, but the loss is only computed against the hidden originals.',
+    },
+    {
+      label: 'Pick the top prediction for each mask',
+      lineHint: 16,
+      variables: {
+        predictions: "{2: 'robot', 3: 'learns'}",
+        accuracy: '1.0',
+      },
+      output: 'The decoder head predicts the original tokens independently at each masked slot.',
+    },
+  ],
+  notes:
+    'Change the mask positions or the prediction scores and re-run. You will see the labels stay tied only to the masked slots, which is the core trick behind BERT pretraining.',
+};
+
+export const ppoPlayground: PythonPlaygroundProps = {
+  title: 'PPO Clipping Terminal',
+  initialCode: `old_logp = -1.20
+new_logp = -0.95
+advantage = 1.50
+clip_eps = 0.20
+
+ratio = round(pow(2.718281828, new_logp - old_logp), 3)
+unclipped = round(ratio * advantage, 3)
+clipped_ratio = min(max(ratio, 1 - clip_eps), 1 + clip_eps)
+clipped = round(clipped_ratio * advantage, 3)
+objective = round(min(unclipped, clipped), 3)
+loss = round(-objective, 3)
+
+print("ratio:", ratio)
+print("unclipped objective:", unclipped)
+print("clipped ratio:", clipped_ratio)
+print("clipped objective:", clipped)
+print("ppo loss:", loss)
+`,
+  samples: [
+    {
+      label: 'Positive Advantage',
+      description: 'A beneficial action gets capped before the update becomes too aggressive.',
+      code: `old_logp = -1.20
+new_logp = -0.95
+advantage = 1.50
+clip_eps = 0.20
+
+ratio = round(pow(2.718281828, new_logp - old_logp), 3)
+unclipped = round(ratio * advantage, 3)
+clipped_ratio = min(max(ratio, 1 - clip_eps), 1 + clip_eps)
+clipped = round(clipped_ratio * advantage, 3)
+objective = round(min(unclipped, clipped), 3)
+loss = round(-objective, 3)
+
+print("ratio:", ratio)
+print("unclipped objective:", unclipped)
+print("clipped ratio:", clipped_ratio)
+print("clipped objective:", clipped)
+print("ppo loss:", loss)
+`,
+    },
+    {
+      label: 'Negative Advantage',
+      description: 'Flip the sign of the advantage to see how clipping protects bad actions too.',
+      code: `old_logp = -1.20
+new_logp = -0.95
+advantage = -1.50
+clip_eps = 0.20
+
+ratio = round(pow(2.718281828, new_logp - old_logp), 3)
+unclipped = round(ratio * advantage, 3)
+clipped_ratio = min(max(ratio, 1 - clip_eps), 1 + clip_eps)
+clipped = round(clipped_ratio * advantage, 3)
+objective = round(max(unclipped, clipped), 3)
+loss = round(-objective, 3)
+
+print("ratio:", ratio)
+print("unclipped objective:", unclipped)
+print("clipped ratio:", clipped_ratio)
+print("clipped objective:", clipped)
+print("ppo loss:", loss)
+`,
+    },
+  ],
+  walkthroughSteps: [
+    {
+      label: 'Form the likelihood ratio',
+      lineHint: 5,
+      variables: {
+        old_logp: '-1.20',
+        new_logp: '-0.95',
+        ratio: '1.284',
+      },
+      output: 'The new policy is assigning more probability to this action than the old policy did.',
+    },
+    {
+      label: 'Compute the unclipped objective',
+      lineHint: 6,
+      variables: {
+        advantage: '1.50',
+        unclipped: '1.926',
+      },
+      output: 'Without clipping, PPO would take the full policy-improvement signal.',
+    },
+    {
+      label: 'Clamp the ratio into the trust region',
+      lineHint: 7,
+      variables: {
+        clip_eps: '0.20',
+        clipped_ratio: '1.2',
+        clipped: '1.8',
+      },
+      output: 'Clipping prevents the update from moving too far away from the data-collecting policy.',
+    },
+    {
+      label: 'Take the conservative objective',
+      lineHint: 9,
+      variables: {
+        objective: '1.8',
+        loss: '-1.8',
+      },
+      output: 'PPO uses the smaller improvement so the optimizer stays conservative.',
+    },
+  ],
+  notes:
+    'Change `new_logp`, `advantage`, or `clip_eps` and watch when the unclipped update starts getting cut back by the trust-region style clamp.',
+};

--- a/src/lib/python-playground.ts
+++ b/src/lib/python-playground.ts
@@ -1,0 +1,20 @@
+export interface PlaygroundSample {
+  label: string;
+  code: string;
+  description?: string;
+}
+
+export interface WalkthroughStep {
+  label: string;
+  lineHint?: number;
+  variables: Record<string, string>;
+  output?: string;
+}
+
+export interface PythonPlaygroundProps {
+  title: string;
+  initialCode: string;
+  samples: PlaygroundSample[];
+  walkthroughSteps?: WalkthroughStep[];
+  notes?: string;
+}

--- a/tests/python-playground.test.tsx
+++ b/tests/python-playground.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PythonPlayground from '../src/components/PythonPlayground';
+import type { PythonPlaygroundProps } from '../src/lib/python-playground';
+
+const { loadPyodideRuntime } = vi.hoisted(() => ({
+  loadPyodideRuntime: vi.fn(),
+}));
+
+vi.mock('../src/lib/pyodide-loader', () => ({
+  loadPyodideRuntime,
+}));
+
+const baseProps: PythonPlaygroundProps = {
+  title: 'Widget Test',
+  initialCode: 'print("hello")',
+  samples: [
+    {
+      label: 'Default Example',
+      code: 'print("hello")',
+      description: 'Base sample',
+    },
+  ],
+  walkthroughSteps: [
+    {
+      label: 'Inspect input',
+      lineHint: 1,
+      variables: {
+        value: '1',
+      },
+      output: 'Starting point',
+    },
+    {
+      label: 'Inspect output',
+      lineHint: 2,
+      variables: {
+        value: '2',
+      },
+      output: 'Next point',
+    },
+  ],
+  notes: 'Notes',
+};
+
+describe('PythonPlayground', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    globalThis.IntersectionObserver = class {
+      private callback: IntersectionObserverCallback;
+      readonly root = null;
+      readonly rootMargin = '0px';
+      readonly thresholds = [0];
+
+      constructor(callback: IntersectionObserverCallback) {
+        this.callback = callback;
+      }
+
+      disconnect() {}
+
+      observe(target: Element) {
+        this.callback([{ isIntersecting: true, target } as IntersectionObserverEntry], this);
+      }
+
+      unobserve() {}
+
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof IntersectionObserver;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(props: PythonPlaygroundProps = baseProps) {
+    await act(async () => {
+      root.render(<PythonPlayground {...props} />);
+    });
+    await flushAsyncWork();
+  }
+
+  async function flushAsyncWork() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  it('shows a ready message after the Python runtime loads', async () => {
+    loadPyodideRuntime.mockResolvedValueOnce({
+      runPythonAsync: vi.fn(),
+    });
+
+    await render();
+
+    expect(container.textContent).toContain('Python is ready. Edit the code and run it.');
+  });
+
+  it('shows an error message when the Python runtime fails to load', async () => {
+    loadPyodideRuntime.mockRejectedValueOnce(new Error('Runtime failed to boot'));
+
+    await render();
+
+    expect(container.textContent).toContain('Runtime failed to boot');
+  });
+
+  it('runs code and prints stdout and stderr', async () => {
+    loadPyodideRuntime.mockResolvedValueOnce({
+      runPythonAsync: vi.fn().mockResolvedValue({
+        toJs: () => ['hello from python\n', 'warning output\n'],
+      }),
+    });
+
+    await render();
+
+    const buttons = container.querySelectorAll('button');
+    const runButton = Array.from(buttons).find((button) => button.textContent === 'Run');
+    expect(runButton).toBeTruthy();
+
+    await act(async () => {
+      runButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushAsyncWork();
+
+    expect(container.textContent).toContain('hello from python');
+    expect(container.textContent).toContain('warning output');
+  });
+
+  it('resets the edited code and clears prior output', async () => {
+    loadPyodideRuntime.mockResolvedValueOnce({
+      runPythonAsync: vi.fn().mockResolvedValue({
+        toJs: () => ['hello from python\n', ''],
+      }),
+    });
+
+    await render();
+
+    const editor = container.querySelector('textarea');
+    expect(editor).toBeTruthy();
+
+    await act(async () => {
+      editor!.value = 'print("changed")';
+      editor!.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const runButton = buttons.find((button) => button.textContent === 'Run');
+    const resetButton = buttons.find((button) => button.textContent === 'Reset');
+
+    await act(async () => {
+      runButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushAsyncWork();
+
+    expect(container.textContent).toContain('hello from python');
+
+    await act(async () => {
+      resetButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(editor?.value).toBe('print("hello")');
+    expect(container.textContent).not.toContain('hello from python');
+  });
+
+  it('moves through the guided walkthrough values', async () => {
+    loadPyodideRuntime.mockResolvedValueOnce({
+      runPythonAsync: vi.fn(),
+    });
+
+    await render();
+
+    expect(container.textContent).toContain('Inspect input');
+    expect(container.textContent).toContain('Starting point');
+    expect(container.textContent).toContain('value1');
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const nextButton = buttons.find((button) => button.textContent === 'Next Step');
+    expect(nextButton).toBeTruthy();
+
+    await act(async () => {
+      nextButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Inspect output');
+    expect(container.textContent).toContain('Next point');
+    expect(container.textContent).toContain('value2');
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable Pyodide-powered Python playground React island with terminal-style UI and guided walkthrough steps
- convert four teaching-heavy posts to MDX and embed curated interactive examples for attention, BERT MLM, and PPO clipping
- add component coverage for runtime loading, execution, reset behavior, and walkthrough navigation

## Testing
- npm run ci