### PR TITLE
Shrink home hero stats panels

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1415,8 +1415,8 @@ body.home-page {
 
 .home-hero__content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(13.5rem, 15rem);
-  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1fr) minmax(10.5rem, 12rem);
+  gap: 1.1rem;
   align-items: stretch;
 }
 
@@ -1482,7 +1482,7 @@ body.home-page {
 
 .home-meta-panel {
   display: grid;
-  gap: 0.8rem;
+  gap: 0.65rem;
   width: 100%;
   margin-right: 0;
 }
@@ -1496,15 +1496,16 @@ body.home-page {
 }
 
 .home-meta-panel__item {
-  padding: 1rem;
+  padding: 0.78rem 0.9rem;
+  border-radius: 20px;
 }
 
 .home-meta-panel__item strong {
   display: block;
-  margin-top: 0.4rem;
+  margin-top: 0.3rem;
   color: var(--home-shell-strong);
   font-family: var(--font-reading);
-  font-size: 1.85rem;
+  font-size: 1.55rem;
   font-weight: 500;
   line-height: 1;
 }


### PR DESCRIPTION
## What changed
- narrowed the right-side hero stats column on the landing page
- reduced the sections and entries card padding, gap, and numeric size

## Why
- the sections and entries panels felt visually too large in the homepage hero

## Testing
- npm run ci