### PR TITLE
Make sections rail sticky on the right at smaller desktop widths

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -895,6 +895,28 @@ a:visited {
   }
 }
 
+@media (min-width: 900px) and (max-width: 1099px) {
+  .page-layout {
+    grid-template-columns: minmax(0, 1fr) 16rem;
+    gap: 1.5rem;
+    align-items: start;
+  }
+
+  .page-content--narrow {
+    width: 100%;
+    margin: 2rem 0;
+  }
+
+  .sections-nav__inner {
+    position: sticky;
+    top: 6.25rem;
+  }
+
+  .sections-nav {
+    margin-top: 7.75rem;
+  }
+}
+
 @media (min-width: 1100px) {
   .page-layout {
     grid-template-columns: minmax(0, 1fr) 16rem;


### PR DESCRIPTION
## What changed
- extend the two-column post layout down to 900px widths
- keep the sections panel as a sticky right-side rail in that range
- leave the existing wide-desktop behavior unchanged

## Why
The sections nav was only a right-side sticky rail at 1100px and up, so on many normal window sizes it no longer sat on the right.

## Testing
- npm run ci
- pre-push hook ran npm run ci before push