### PR TITLE
Refine homepage recent entries panels

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1475,6 +1475,8 @@ body.home-page {
 .intro-text,
 .home-section-map p,
 .home-collection-card p,
+.home-section-heading p,
+.home-shelf__title-block p,
 .home-panel--footer-note > p,
 .home-empty-state {
   color: var(--home-shell-strong);
@@ -1598,6 +1600,8 @@ body.home-page {
 .home-collection-card p,
 .home-empty-state,
 .links-panel__title + p,
+.home-section-heading p,
+.home-shelf__title-block p,
 .home-panel--footer-note > p,
 .home-post-list small {
   color: var(--home-shell-muted);
@@ -1614,6 +1618,12 @@ body.home-page {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+}
+
+.home-section-heading p {
+  margin: 0;
+  max-width: 46rem;
+  line-height: 1.65;
 }
 
 .home-collection-grid {
@@ -1661,8 +1671,9 @@ body.home-page {
 
 .home-shelf-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
+  align-items: stretch;
 }
 
 .home-panel--shelf,
@@ -1670,14 +1681,29 @@ body.home-page {
   min-height: 100%;
 }
 
+.home-panel--section-intro {
+  padding-block: clamp(1.4rem, 2vw, 1.8rem);
+}
+
 .home-shelf__header {
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 1rem;
 }
 
 .home-shelf__header h3,
 .home-panel--footer-note h2 {
   font-size: 1.28rem;
+}
+
+.home-shelf__title-block {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.home-shelf__title-block p {
+  margin: 0;
+  max-width: 34ch;
+  line-height: 1.55;
 }
 
 .home-post-list {
@@ -1829,10 +1855,6 @@ body.home-page {
   .home-meta-panel {
     width: 100%;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .home-shelf-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .links-panel {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,26 +64,37 @@ const recentShelves = [
   {
     title: 'Arxiv Notes',
     href: '/paper_summaries_field.html',
-    posts: paperPosts.slice(0, 3),
+    summary: 'Summaries of research papers organized by broad interests.',
+    posts: paperPosts.slice(0, 2),
     emptyMessage: 'New research notes will show up here.',
   },
   {
     title: 'Blog',
     href: '/blog.html',
-    posts: blogPosts.slice(0, 3),
+    summary: 'Longer reflections on research, work, and the path so far.',
+    posts: blogPosts.slice(0, 2),
     emptyMessage: 'Blog posts will show up here.',
   },
   {
     title: 'Build Intuition',
     href: '/build_intuition.html',
-    posts: buildIntuitionPosts.slice(0, 3),
+    summary: 'Intuition-first explainers for foundational ideas worth understanding deeply.',
+    posts: buildIntuitionPosts.slice(0, 2),
     emptyMessage: 'Intuition-first explainers will show up here.',
   },
   {
     title: 'Revision Notes',
     href: '/revision_notes.html',
-    posts: revisionPosts.slice(0, 3),
+    summary: 'Detailed revision notes from long-form content online.',
+    posts: revisionPosts.slice(0, 2),
     emptyMessage: 'Revision notes will show up here.',
+  },
+  {
+    title: 'AI Generated Reports',
+    href: '/ai_generated_reports.html',
+    summary: 'Audio or text reports created by AI.',
+    posts: aiPosts.slice(0, 2),
+    emptyMessage: 'This section is ready for future reports.',
   },
 ] as const;
 
@@ -199,16 +210,25 @@ const formatDate = (date: Date) =>
   </section>
 
   <section class="home-shelves" id="latest">
-    <div class="home-section-heading">
+    <article class="home-panel home-panel--section-intro">
       <p class="home-panel__eyebrow">Latest</p>
-      <h2>Recent entries</h2>
-    </div>
+      <div class="home-section-heading">
+        <h2>Recent entries</h2>
+        <p>
+          A quick scan of the newest writing across the site. Each panel links out to the section
+          and highlights the two most recent posts.
+        </p>
+      </div>
+    </article>
 
     <div class="home-shelf-grid">
       {recentShelves.map((shelf) => (
         <article class="home-panel home-panel--shelf">
           <div class="home-shelf__header">
-            <h3>{shelf.title}</h3>
+            <div class="home-shelf__title-block">
+              <h3>{shelf.title}</h3>
+              <p>{shelf.summary}</p>
+            </div>
             <a href={shelf.href}>View all</a>
           </div>
 
@@ -227,25 +247,5 @@ const formatDate = (date: Date) =>
         </article>
       ))}
     </div>
-  </section>
-
-  <section class="home-panel home-panel--footer-note">
-    <div class="home-shelf__header">
-      <h2>AI Generated Reports</h2>
-      <a href="/ai_generated_reports.html">Open section</a>
-    </div>
-    <p>Audio or text reports created by AI.</p>
-    {aiPosts.length > 0 ? (
-      <ul class="home-post-list">
-        {aiPosts.slice(0, 3).map((post) => (
-          <li>
-            <a href={post.data.legacyPath}>{post.data.title}</a>
-            <small>{formatDate(post.data.date)}</small>
-          </li>
-        ))}
-      </ul>
-    ) : (
-      <p class="home-empty-state">This section is ready for future reports.</p>
-    )}
   </section>
 </HomeLayout>


### PR DESCRIPTION
## What changed
- reworked the Recent entries area into a matching panel-based layout
- added a visible intro panel and short summary text for each section card
- limited each card to the two most recent posts and folded AI Generated Reports into the same grid

## Why
- the previous heading was hard to see
- the cards felt visually uneven and the AI reports block sat outside the main panel system
- showing just the latest two posts keeps the section tighter and easier to scan

## Testing
- npm run ci