### PR TITLE
Fix homepage timeline rail height

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1295,7 +1295,7 @@ body.home-page {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(15rem, 18rem) 16rem;
   gap: 1.25rem;
-  align-items: start;
+  align-items: stretch;
 }
 
 .home-content-shell {
@@ -1310,12 +1310,12 @@ body.home-page {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  align-self: start;
 }
 
 .home-timeline-rail {
-  position: sticky;
-  top: 5.25rem;
-  align-self: start;
+  position: relative;
+  align-self: stretch;
 }
 
 .home-sidebar {
@@ -1718,7 +1718,8 @@ body.home-page {
 }
 
 .timeline-panel {
-  min-height: calc(100vh - 5.25rem);
+  height: 100%;
+  min-height: 100%;
 }
 
 .timeline-list {
@@ -1841,6 +1842,7 @@ body.home-page {
   }
 
   .timeline-panel {
+    height: auto;
     min-height: auto;
   }
 }


### PR DESCRIPTION
## What changed
- removed the sticky viewport-sized behavior from the homepage timeline rail
- made the timeline column stretch to the same height as the left content stack
- preserved the mobile breakpoint fallback with auto height

## Why
- the timeline line should match the left panels exactly so the scroll stays clean and does not jerk near the end of the page

## Testing
- npm run ci