### PR TITLE
Refresh attention post visuals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,9 @@
 
 - If you update the KaTeX CDN URL or version in `src/layouts/BaseLayout.astro`, update the stylesheet SRI hash too.
 - A bad KaTeX CSS integrity hash causes browsers to reject the stylesheet, which makes equations render as a broken mix of MathML and visible KaTeX HTML.
+
+## Post Images
+
+- Prefer post diagrams that are immediately grokkable at a glance: minimal text, minimal visual noise, and one clear idea per image.
+- Favor simple hand-drawn or sketch-style visuals with clean black strokes, lots of whitespace, and restrained color accents, similar to an Excalidraw-style explainer.
+- For animated explanatory visuals, keep motion subtle and instructional rather than flashy. The animation should make the concept easier to follow, not add decoration.

--- a/public/assets/images/attention-mechanisms-flow.svg
+++ b/public/assets/images/attention-mechanisms-flow.svg
@@ -1,232 +1,135 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
   <title id="title">Animated intuition for self-attention</title>
-  <desc id="desc">An animated diagram showing the token it emitting a query, scoring the tokens animal, street, and tired, and mixing their values into a contextualized representation.</desc>
+  <desc id="desc">A minimal animated sketch showing the token it checking animal, street, and tired, then forming a new contextualized meaning.</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#f8fbff" />
-      <stop offset="100%" stop-color="#eef4fb" />
-    </linearGradient>
-    <linearGradient id="tokenFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ffffff" />
-      <stop offset="100%" stop-color="#f8fafc" />
-    </linearGradient>
-    <linearGradient id="queryFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#dbeafe" />
-      <stop offset="100%" stop-color="#bfdbfe" />
-    </linearGradient>
-    <linearGradient id="memoryFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#eef2ff" />
-      <stop offset="100%" stop-color="#e0e7ff" />
-    </linearGradient>
-    <linearGradient id="outputFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#fef3c7" />
-      <stop offset="100%" stop-color="#fde68a" />
-    </linearGradient>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity="0.1" />
-    </filter>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563eb" />
-    </marker>
-    <marker id="arrowSoft" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b" />
-    </marker>
     <style>
-      .title { font: 700 34px Inter, Arial, sans-serif; fill: #0f172a; }
-      .subtitle { font: 21px "IBM Plex Sans", Arial, sans-serif; fill: #475569; }
-      .label { font: 600 20px Inter, Arial, sans-serif; fill: #334155; }
-      .body { font: 18px "IBM Plex Sans", Arial, sans-serif; fill: #334155; }
-      .mono { font: 500 22px "Roboto Mono", monospace; fill: #0f172a; }
-      .scoreText { font: 700 16px "IBM Plex Sans", Arial, sans-serif; }
-      .qPulse {
-        transform-origin: 540px 304px;
-        animation: qPulse 6s ease-in-out infinite;
+      .ink { stroke: #222222; stroke-width: 4.5; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+      .thin { stroke: #222222; stroke-width: 3.5; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+      .token { fill: #ffffff; stroke: #222222; stroke-width: 4; }
+      .focus { fill: #dff7e2; stroke: #222222; stroke-width: 4; }
+      .soft { fill: #eef8ef; stroke: #222222; stroke-width: 4; }
+      .panel { fill: #f7f7f4; stroke: #222222; stroke-width: 4; }
+      .label { fill: #222222; font-family: "Comic Sans MS", "Chalkboard SE", "Marker Felt", cursive, sans-serif; }
+      .title { font-size: 36px; font-weight: 700; }
+      .body { font-size: 24px; }
+      .small { font-size: 22px; }
+      .arrow-strong { stroke: #222222; stroke-width: 5; stroke-dasharray: 12 12; animation: routeStrong 5.5s ease-in-out infinite; }
+      .arrow-weak { stroke: #222222; stroke-width: 4; stroke-dasharray: 10 12; animation: routeWeak 5.5s ease-in-out infinite; }
+      .arrow-mid { stroke: #222222; stroke-width: 4.5; stroke-dasharray: 12 12; animation: routeMid 5.5s ease-in-out infinite; }
+      .return-strong { stroke: #2f9e44; stroke-width: 5; stroke-dasharray: 12 12; animation: backStrong 5.5s ease-in-out infinite; }
+      .return-mid { stroke: #74b816; stroke-width: 4.5; stroke-dasharray: 12 12; animation: backMid 5.5s ease-in-out infinite; }
+      .return-weak { stroke: #c0c0c0; stroke-width: 4; stroke-dasharray: 10 12; animation: backWeak 5.5s ease-in-out infinite; }
+      .pulse { animation: pulse 5.5s ease-in-out infinite; transform-origin: 609px 301px; }
+      .output { animation: outPulse 5.5s ease-in-out infinite; transform-origin: 1090px 332px; }
+      .dot-strong { animation: dotStrong 5.5s ease-in-out infinite; }
+      .dot-mid { animation: dotMid 5.5s ease-in-out infinite; }
+      .dot-weak { animation: dotWeak 5.5s ease-in-out infinite; }
+      @keyframes pulse {
+        0%, 100% { transform: scale(1); }
+        14%, 28% { transform: scale(1.05); }
       }
-      .arrowStrong {
-        stroke-dasharray: 14 10;
-        animation: pulseStrong 6s ease-in-out infinite;
+      @keyframes routeStrong {
+        0%, 100% { opacity: 0.12; stroke-dashoffset: 0; }
+        15%, 40% { opacity: 1; stroke-dashoffset: -38; }
+        55% { opacity: 0.18; }
       }
-      .arrowWeak {
-        stroke-dasharray: 10 10;
-        animation: pulseWeak 6s ease-in-out infinite;
-      }
-      .arrowMedium {
-        stroke-dasharray: 12 10;
-        animation: pulseMedium 6s ease-in-out infinite;
-      }
-      .returnStrong {
-        stroke-dasharray: 12 10;
-        animation: returnStrong 6s ease-in-out infinite;
-      }
-      .returnWeak {
-        stroke-dasharray: 10 10;
-        animation: returnWeak 6s ease-in-out infinite;
-      }
-      .returnMedium {
-        stroke-dasharray: 10 10;
-        animation: returnMedium 6s ease-in-out infinite;
-      }
-      .animalBar {
-        animation: barStrong 6s ease-in-out infinite;
-      }
-      .streetBar {
-        animation: barWeak 6s ease-in-out infinite;
-      }
-      .tiredBar {
-        animation: barMedium 6s ease-in-out infinite;
-      }
-      .outputPulse {
-        animation: outputPulse 6s ease-in-out infinite;
-      }
-      @keyframes qPulse {
-        0%, 100% { transform: scale(1); opacity: 0.88; }
-        12% { transform: scale(1.06); opacity: 1; }
-        24% { transform: scale(1); opacity: 0.92; }
-      }
-      @keyframes pulseStrong {
-        0%, 100% { opacity: 0.14; stroke-dashoffset: 0; }
-        18%, 44% { opacity: 1; stroke-dashoffset: -48; }
-        60% { opacity: 0.2; stroke-dashoffset: -70; }
-      }
-      @keyframes pulseWeak {
+      @keyframes routeWeak {
         0%, 100% { opacity: 0.1; stroke-dashoffset: 0; }
-        22%, 46% { opacity: 0.55; stroke-dashoffset: -36; }
-        60% { opacity: 0.12; stroke-dashoffset: -56; }
+        18%, 40% { opacity: 0.35; stroke-dashoffset: -28; }
+        55% { opacity: 0.1; }
       }
-      @keyframes pulseMedium {
+      @keyframes routeMid {
         0%, 100% { opacity: 0.1; stroke-dashoffset: 0; }
-        26%, 52% { opacity: 0.78; stroke-dashoffset: -42; }
-        64% { opacity: 0.14; stroke-dashoffset: -62; }
+        21%, 43% { opacity: 0.72; stroke-dashoffset: -32; }
+        58% { opacity: 0.12; }
       }
-      @keyframes barStrong {
-        0%, 22%, 100% { width: 0; opacity: 0.25; }
-        34%, 56% { width: 180px; opacity: 1; }
-        70% { width: 180px; opacity: 0.4; }
+      @keyframes backStrong {
+        0%, 45%, 100% { opacity: 0.08; stroke-dashoffset: 0; }
+        58%, 86% { opacity: 1; stroke-dashoffset: -36; }
       }
-      @keyframes barWeak {
-        0%, 24%, 100% { width: 0; opacity: 0.2; }
-        38%, 56% { width: 32px; opacity: 0.9; }
-        70% { width: 32px; opacity: 0.35; }
+      @keyframes backMid {
+        0%, 48%, 100% { opacity: 0.08; stroke-dashoffset: 0; }
+        61%, 86% { opacity: 0.78; stroke-dashoffset: -30; }
       }
-      @keyframes barMedium {
-        0%, 26%, 100% { width: 0; opacity: 0.2; }
-        40%, 58% { width: 92px; opacity: 0.95; }
-        72% { width: 92px; opacity: 0.35; }
+      @keyframes backWeak {
+        0%, 50%, 100% { opacity: 0.05; stroke-dashoffset: 0; }
+        63%, 86% { opacity: 0.25; stroke-dashoffset: -24; }
       }
-      @keyframes returnStrong {
-        0%, 42%, 100% { opacity: 0.08; stroke-dashoffset: 0; }
-        54%, 82% { opacity: 0.95; stroke-dashoffset: -44; }
+      @keyframes outPulse {
+        0%, 58%, 100% { transform: scale(1); }
+        74% { transform: scale(1.04); }
       }
-      @keyframes returnWeak {
-        0%, 44%, 100% { opacity: 0.08; stroke-dashoffset: 0; }
-        58%, 82% { opacity: 0.45; stroke-dashoffset: -36; }
+      @keyframes dotStrong {
+        0%, 100% { fill: #ffffff; }
+        18%, 52% { fill: #baf3bd; }
       }
-      @keyframes returnMedium {
-        0%, 46%, 100% { opacity: 0.08; stroke-dashoffset: 0; }
-        60%, 84% { opacity: 0.72; stroke-dashoffset: -40; }
+      @keyframes dotMid {
+        0%, 100% { fill: #ffffff; }
+        24%, 55% { fill: #ddf5df; }
       }
-      @keyframes outputPulse {
-        0%, 52%, 100% { transform: scale(1); opacity: 0.95; }
-        70% { transform: scale(1.03); opacity: 1; }
-        82% { transform: scale(1.01); opacity: 0.98; }
+      @keyframes dotWeak {
+        0%, 100% { fill: #ffffff; }
+        20%, 55% { fill: #f4f4f4; }
       }
     </style>
+    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 12 6 L 0 12" fill="none" stroke="#222222" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 12 6 L 0 12" fill="none" stroke="#2f9e44" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+    </marker>
   </defs>
 
-  <rect width="1280" height="720" fill="url(#bg)" />
-  <rect x="30" y="30" width="1220" height="660" rx="32" fill="#ffffff" stroke="#dbe6f3" stroke-width="2" />
+  <rect width="1280" height="720" fill="#fcfcfa" />
 
-  <text x="74" y="94" class="title">Self-attention as routing</text>
-  <text x="74" y="130" class="subtitle">
-    A token emits a query, compares it with every key, then mixes the returned values into a contextualized output.
-  </text>
+  <text x="64" y="78" class="label title">Self-attention, stripped down</text>
+  <text x="64" y="116" class="label body">Watch "it" check a few options, then pull back the most useful meaning.</text>
 
-  <text x="78" y="186" class="label">Sequence</text>
-  <g filter="url(#shadow)">
-    <rect x="76" y="208" width="124" height="58" rx="16" fill="url(#tokenFill)" stroke="#cbd5e1" stroke-width="2" />
-    <rect x="216" y="208" width="140" height="58" rx="16" fill="#e0f2fe" stroke="#38bdf8" stroke-width="2.5" />
-    <rect x="372" y="208" width="118" height="58" rx="16" fill="url(#tokenFill)" stroke="#cbd5e1" stroke-width="2" />
-    <rect x="506" y="208" width="110" height="58" rx="16" fill="url(#tokenFill)" stroke="#cbd5e1" stroke-width="2" />
-    <rect x="632" y="208" width="128" height="58" rx="16" fill="#dbeafe" stroke="#2563eb" stroke-width="3" />
-    <rect x="776" y="208" width="110" height="58" rx="16" fill="url(#tokenFill)" stroke="#cbd5e1" stroke-width="2" />
-    <rect x="902" y="208" width="122" height="58" rx="16" fill="#dcfce7" stroke="#22c55e" stroke-width="2.5" />
-  </g>
-  <text x="138" y="245" text-anchor="middle" class="mono">The</text>
-  <text x="286" y="245" text-anchor="middle" class="mono">animal</text>
-  <text x="431" y="245" text-anchor="middle" class="mono">didn't</text>
-  <text x="561" y="245" text-anchor="middle" class="mono">cross</text>
-  <text x="696" y="245" text-anchor="middle" class="mono">it</text>
-  <text x="831" y="245" text-anchor="middle" class="mono">too</text>
-  <text x="963" y="245" text-anchor="middle" class="mono">tired</text>
+  <rect x="72" y="170" width="118" height="62" rx="18" class="token" />
+  <rect x="206" y="170" width="148" height="62" rx="18" class="focus" />
+  <rect x="372" y="170" width="128" height="62" rx="18" class="token" />
+  <rect x="518" y="170" width="98" height="62" rx="18" class="token" />
+  <rect x="632" y="170" width="86" height="62" rx="18" class="panel" />
+  <rect x="736" y="170" width="92" height="62" rx="18" class="token" />
+  <rect x="846" y="170" width="124" height="62" rx="18" class="soft" />
 
-  <g class="qPulse" filter="url(#shadow)">
-    <rect x="454" y="292" width="242" height="94" rx="24" fill="url(#queryFill)" stroke="#3b82f6" stroke-width="2.5" />
-    <text x="486" y="332" fill="#1d4ed8" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">
-      Query from "it"
-    </text>
-    <text x="486" y="362" fill="#1e3a8a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
-      Find the right antecedent
-    </text>
+  <text x="131" y="210" text-anchor="middle" class="label body">The</text>
+  <text x="280" y="210" text-anchor="middle" class="label body">animal</text>
+  <text x="436" y="210" text-anchor="middle" class="label body">didn't</text>
+  <text x="567" y="210" text-anchor="middle" class="label body">cross</text>
+  <text x="675" y="210" text-anchor="middle" class="label body">it</text>
+  <text x="782" y="210" text-anchor="middle" class="label body">too</text>
+  <text x="908" y="210" text-anchor="middle" class="label body">tired</text>
+
+  <g class="pulse">
+    <rect x="500" y="266" width="218" height="70" rx="20" class="panel" />
+    <text x="609" y="310" text-anchor="middle" class="label body">query from "it"</text>
   </g>
 
-  <text x="80" y="446" class="label">Candidate keys and values</text>
+  <path d="M 588 336 C 500 396, 410 430, 286 452" class="arrow-strong" marker-end="url(#arrow)" fill="none" />
+  <path d="M 610 338 C 610 396, 610 416, 610 448" class="arrow-weak" marker-end="url(#arrow)" fill="none" />
+  <path d="M 632 336 C 744 394, 832 426, 918 450" class="arrow-mid" marker-end="url(#arrow)" fill="none" />
 
-  <g filter="url(#shadow)">
-    <rect x="78" y="470" width="310" height="106" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2.5" />
-    <rect x="78" y="596" width="310" height="62" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
-    <rect x="78" y="596" width="0" height="62" rx="20" fill="#2563eb" opacity="0.92" class="animalBar" />
+  <circle cx="270" cy="462" r="28" class="token dot-strong" />
+  <circle cx="610" cy="462" r="28" class="token dot-weak" />
+  <circle cx="934" cy="462" r="28" class="token dot-mid" />
+  <text x="270" y="536" text-anchor="middle" class="label body">animal</text>
+  <text x="610" y="536" text-anchor="middle" class="label body">street</text>
+  <text x="934" y="536" text-anchor="middle" class="label body">tired</text>
+  <text x="270" y="572" text-anchor="middle" class="label small">big weight</text>
+  <text x="610" y="572" text-anchor="middle" class="label small">tiny weight</text>
+  <text x="934" y="572" text-anchor="middle" class="label small">some weight</text>
 
-    <rect x="432" y="470" width="310" height="106" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2" />
-    <rect x="432" y="596" width="310" height="62" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
-    <rect x="432" y="596" width="0" height="62" rx="20" fill="#64748b" opacity="0.92" class="streetBar" />
+  <path d="M 298 462 C 470 462, 720 360, 1020 320" class="return-strong" marker-end="url(#arrowGreen)" fill="none" />
+  <path d="M 638 462 C 770 450, 868 396, 1020 360" class="return-weak" marker-end="url(#arrowGreen)" fill="none" />
+  <path d="M 962 462 C 1010 442, 1030 406, 1044 386" class="return-mid" marker-end="url(#arrowGreen)" fill="none" />
 
-    <rect x="786" y="470" width="310" height="106" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2.2" />
-    <rect x="786" y="596" width="310" height="62" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
-    <rect x="786" y="596" width="0" height="62" rx="20" fill="#0f766e" opacity="0.92" class="tiredBar" />
+  <g class="output">
+    <rect x="1028" y="246" width="196" height="174" rx="24" class="panel" />
+    <text x="1126" y="298" text-anchor="middle" class="label body">new meaning</text>
+    <text x="1126" y="338" text-anchor="middle" class="label body">mostly animal</text>
+    <text x="1126" y="374" text-anchor="middle" class="label body">plus tired</text>
   </g>
 
-  <text x="110" y="510" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">animal</text>
-  <text x="110" y="542" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">key: plausible antecedent</text>
-  <text x="110" y="630" fill="#ffffff" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18" font-weight="700">attention weight</text>
-  <text x="312" y="634" text-anchor="end" class="scoreText" fill="#dbeafe">0.72</text>
-
-  <text x="464" y="510" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">street</text>
-  <text x="464" y="542" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">key: weak semantic fit</text>
-  <text x="464" y="630" fill="#0f172a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18" font-weight="700">attention weight</text>
-  <text x="666" y="634" text-anchor="end" class="scoreText" fill="#334155">0.08</text>
-
-  <text x="818" y="510" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">tired</text>
-  <text x="818" y="542" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">key: useful causal clue</text>
-  <text x="818" y="630" fill="#ffffff" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18" font-weight="700">attention weight</text>
-  <text x="1020" y="634" text-anchor="end" class="scoreText" fill="#d1fae5">0.20</text>
-
-  <path d="M 548 386 C 470 418, 340 448, 232 468" fill="none" stroke="#2563eb" stroke-width="5.5" stroke-linecap="round" marker-end="url(#arrow)" class="arrowStrong" />
-  <path d="M 570 388 C 580 422, 580 442, 586 468" fill="none" stroke="#64748b" stroke-width="3.4" stroke-linecap="round" marker-end="url(#arrowSoft)" class="arrowWeak" />
-  <path d="M 604 386 C 720 416, 848 446, 938 468" fill="none" stroke="#0f766e" stroke-width="4.2" stroke-linecap="round" marker-end="url(#arrowSoft)" class="arrowMedium" />
-
-  <text x="1100" y="184" class="label">Contextualized output</text>
-  <g class="outputPulse" filter="url(#shadow)">
-    <rect x="1088" y="222" width="126" height="258" rx="26" fill="url(#outputFill)" stroke="#f59e0b" stroke-width="2.5" />
-    <text x="1151" y="274" text-anchor="middle" fill="#92400e" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">
-      New vector
-    </text>
-    <text x="1151" y="312" text-anchor="middle" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
-      "it" now means
-    </text>
-    <text x="1151" y="340" text-anchor="middle" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
-      mostly animal
-    </text>
-    <text x="1151" y="368" text-anchor="middle" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
-      plus a smaller
-    </text>
-    <text x="1151" y="396" text-anchor="middle" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="18">
-      fatigue signal
-    </text>
-  </g>
-
-  <path d="M 388 520 C 492 520, 734 346, 1086 340" fill="none" stroke="#2563eb" stroke-width="4.8" stroke-linecap="round" marker-end="url(#arrowSoft)" class="returnStrong" />
-  <path d="M 742 522 C 842 520, 926 430, 1086 378" fill="none" stroke="#64748b" stroke-width="3.2" stroke-linecap="round" marker-end="url(#arrowSoft)" class="returnWeak" />
-  <path d="M 1096 522 C 1112 508, 1122 470, 1126 438" fill="none" stroke="#0f766e" stroke-width="3.8" stroke-linecap="round" marker-end="url(#arrowSoft)" class="returnMedium" />
-
-  <rect x="76" y="674" width="1130" height="0.5" fill="#cbd5e1" />
+  <text x="72" y="648" class="label title">Key idea: attention makes a soft choice, not a single hard jump.</text>
 </svg>

--- a/public/assets/images/attention-mechanisms-intuition.svg
+++ b/public/assets/images/attention-mechanisms-intuition.svg
@@ -1,192 +1,76 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900" role="img" aria-labelledby="title desc">
   <title id="title">Attention as differentiable lookup</title>
-  <desc id="desc">A diagram showing a query from the token it matching the keys for animal, street, and tired, then mixing their values into a contextualized output representation.</desc>
+  <desc id="desc">A minimal sketch-style diagram showing the token it querying animal, street, and tired, then mixing the useful values into a new meaning.</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#f8fbff" />
-      <stop offset="100%" stop-color="#eef4fb" />
-    </linearGradient>
-    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ffffff" />
-      <stop offset="100%" stop-color="#f9fbfe" />
-    </linearGradient>
-    <linearGradient id="queryFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#dbeafe" />
-      <stop offset="100%" stop-color="#bfdbfe" />
-    </linearGradient>
-    <linearGradient id="memoryFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#eef2ff" />
-      <stop offset="100%" stop-color="#e0e7ff" />
-    </linearGradient>
-    <linearGradient id="valueFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#dcfce7" />
-      <stop offset="100%" stop-color="#bbf7d0" />
-    </linearGradient>
-    <linearGradient id="outputFill" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#fef3c7" />
-      <stop offset="100%" stop-color="#fde68a" />
-    </linearGradient>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#0f172a" flood-opacity="0.08" />
-    </filter>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563eb" />
-    </marker>
-    <marker id="arrowSoft" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b" />
+    <style>
+      .ink { stroke: #222222; stroke-width: 4.5; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+      .ink-soft { stroke: #222222; stroke-width: 3.5; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+      .label { fill: #222222; font-family: "Comic Sans MS", "Chalkboard SE", "Marker Felt", cursive, sans-serif; }
+      .title { font-size: 42px; font-weight: 700; }
+      .subtitle { font-size: 24px; }
+      .boxtext { font-size: 28px; font-weight: 700; }
+      .small { font-size: 24px; }
+      .tiny { font-size: 22px; }
+      .good { fill: #baf3bd; stroke: #222222; stroke-width: 4; }
+      .soft { fill: #ebf9ee; stroke: #222222; stroke-width: 4; }
+      .bad { fill: #ffffff; stroke: #222222; stroke-width: 4; }
+      .pill { fill: #ffffff; stroke: #222222; stroke-width: 4; }
+      .note { fill: #f6f6f4; stroke: #222222; stroke-width: 4; }
+    </style>
+    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 12 6 L 0 12" fill="none" stroke="#222222" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
     </marker>
   </defs>
 
-  <rect width="1400" height="900" fill="url(#bg)" />
-  <rect x="34" y="34" width="1332" height="832" rx="34" fill="url(#panel)" stroke="#dbe6f3" stroke-width="2" />
+  <rect width="1400" height="900" fill="#fcfcfa" />
 
-  <text x="80" y="105" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="40" font-weight="700">
-    Attention as differentiable lookup
-  </text>
-  <text x="80" y="145" fill="#475569" font-family="IBM Plex Sans, Arial, sans-serif" font-size="23">
-    The current token emits a query, scores candidate keys, then mixes their values into a new contextual representation.
-  </text>
+  <text x="84" y="92" class="label title">Attention = look up what matters</text>
+  <text x="84" y="132" class="label subtitle">Simple version: the token "it" asks who matters most, then mixes the useful info back in.</text>
 
-  <rect x="76" y="210" width="300" height="470" rx="28" fill="#f8fbff" stroke="#c8d7e7" stroke-width="2" />
-  <text x="108" y="258" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
-    Current token
-  </text>
-  <text x="108" y="294" fill="#64748b" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    Sentence fragment:
-  </text>
-  <rect x="108" y="320" width="190" height="64" rx="20" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
-  <text x="203" y="362" text-anchor="middle" fill="#0f172a" font-family="Roboto Mono, monospace" font-size="28" font-weight="500">
-    it
-  </text>
+  <rect x="120" y="262" width="210" height="88" rx="20" class="pill" />
+  <text x="225" y="318" text-anchor="middle" class="label boxtext">token: it</text>
 
-  <rect x="108" y="418" width="236" height="156" rx="22" fill="url(#queryFill)" stroke="#60a5fa" stroke-width="2.5" filter="url(#shadow)" />
-  <text x="136" y="458" fill="#1d4ed8" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">
-    Query q
-  </text>
-  <text x="136" y="494" fill="#1e3a8a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    What antecedent fits here?
-  </text>
-  <text x="136" y="526" fill="#1e3a8a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    What explains "too tired"?
-  </text>
-  <text x="136" y="558" fill="#1e3a8a" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    Which prior token matters now?
-  </text>
+  <rect x="120" y="392" width="250" height="94" rx="22" class="note" />
+  <text x="245" y="448" text-anchor="middle" class="label boxtext">query</text>
+  <text x="245" y="478" text-anchor="middle" class="label tiny">"who does it refer to?"</text>
 
-  <rect x="430" y="190" width="540" height="520" rx="28" fill="#f8fbff" stroke="#c8d7e7" stroke-width="2" />
-  <text x="460" y="238" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
-    Candidate memory slots
-  </text>
-  <text x="460" y="274" fill="#64748b" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    Each token advertises a key and carries a value.
-  </text>
+  <path d="M 330 308 C 420 250, 470 220, 560 200" class="ink" marker-end="url(#arrow)" />
+  <path d="M 330 308 C 430 308, 470 308, 560 308" class="ink" marker-end="url(#arrow)" />
+  <path d="M 330 308 C 420 366, 470 394, 560 416" class="ink-soft" marker-end="url(#arrow)" stroke-dasharray="10 12" />
 
-  <rect x="466" y="320" width="468" height="98" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2.5" filter="url(#shadow)" />
-  <text x="500" y="356" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">
-    animal
-  </text>
-  <text x="500" y="384" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16">
-    key: animate noun, plausible
-  </text>
-  <text x="500" y="406" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16">
-    antecedent for "too tired"
-  </text>
-  <rect x="726" y="336" width="176" height="60" rx="18" fill="url(#valueFill)" stroke="#22c55e" stroke-width="2" />
-  <text x="810" y="374" text-anchor="middle" fill="#166534" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20" font-weight="600">
-    value: entity meaning
-  </text>
+  <text x="440" y="222" class="label small">high match</text>
+  <text x="446" y="290" class="label small">highest match</text>
+  <text x="446" y="402" class="label small">small match</text>
 
-  <rect x="466" y="454" width="468" height="98" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2" />
-  <text x="500" y="490" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">
-    street
-  </text>
-  <text x="500" y="518" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16">
-    key: location cue, weak match
-  </text>
-  <text x="500" y="540" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16">
-    for explaining "too tired"
-  </text>
-  <rect x="726" y="470" width="176" height="60" rx="18" fill="url(#valueFill)" stroke="#22c55e" stroke-width="2" />
-  <text x="810" y="508" text-anchor="middle" fill="#166534" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20" font-weight="600">
-    value: scene detail
-  </text>
+  <circle cx="620" cy="196" r="34" class="soft" />
+  <text x="690" y="206" class="label boxtext">tired</text>
+  <text x="690" y="238" class="label tiny">useful clue</text>
+  <text x="645" y="210" class="label boxtext" fill="#2f9e44"> </text>
+  <path d="M 737 185 l 16 16 l 28 -38" stroke="#2f9e44" stroke-width="8" fill="none" stroke-linecap="round" stroke-linejoin="round" />
 
-  <rect x="466" y="588" width="468" height="98" rx="24" fill="url(#memoryFill)" stroke="#818cf8" stroke-width="2" />
-  <text x="500" y="624" fill="#312e81" font-family="Roboto Mono, monospace" font-size="24" font-weight="500">
-    tired
-  </text>
-  <text x="500" y="652" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16">
-    key: causal clue that helps
-  </text>
-  <text x="500" y="674" fill="#4338ca" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16">
-    explain why it happened
-  </text>
-  <rect x="726" y="604" width="176" height="60" rx="18" fill="url(#valueFill)" stroke="#22c55e" stroke-width="2" />
-  <text x="810" y="642" text-anchor="middle" fill="#166534" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20" font-weight="600">
-    value: fatigue signal
-  </text>
+  <circle cx="620" cy="308" r="34" class="good" />
+  <text x="690" y="318" class="label boxtext">animal</text>
+  <text x="690" y="350" class="label tiny">best antecedent</text>
+  <path d="M 737 297 l 16 16 l 28 -38" stroke="#2f9e44" stroke-width="8" fill="none" stroke-linecap="round" stroke-linejoin="round" />
 
-  <path d="M 344 496 C 404 468, 420 400, 458 368" fill="none" stroke="#2563eb" stroke-width="7" stroke-linecap="round" marker-end="url(#arrow)" opacity="0.95" />
-  <path d="M 344 500 C 404 510, 420 510, 458 504" fill="none" stroke="#94a3b8" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrowSoft)" opacity="0.9" />
-  <path d="M 344 520 C 398 570, 420 610, 458 640" fill="none" stroke="#0f766e" stroke-width="5" stroke-linecap="round" marker-end="url(#arrowSoft)" opacity="0.8" />
+  <circle cx="620" cy="420" r="34" class="bad" />
+  <text x="690" y="430" class="label boxtext">street</text>
+  <text x="690" y="462" class="label tiny">weak fit</text>
+  <path d="M 741 397 l 30 42 M 771 397 l -30 42" stroke="#e03131" stroke-width="8" fill="none" stroke-linecap="round" />
 
-  <rect x="348" y="354" width="82" height="28" rx="14" fill="#f8fbff" opacity="0.96" />
-  <text x="389" y="373" text-anchor="middle" fill="#1d4ed8" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16" font-weight="700">
-    w = 0.72
-  </text>
-  <rect x="348" y="481" width="82" height="28" rx="14" fill="#f8fbff" opacity="0.96" />
-  <text x="389" y="500" text-anchor="middle" fill="#64748b" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16" font-weight="700">
-    w = 0.08
-  </text>
-  <rect x="348" y="609" width="82" height="28" rx="14" fill="#f8fbff" opacity="0.96" />
-  <text x="389" y="628" text-anchor="middle" fill="#0f766e" font-family="IBM Plex Sans, Arial, sans-serif" font-size="16" font-weight="700">
-    w = 0.20
-  </text>
+  <text x="160" y="610" class="label title">Keys choose where to look</text>
+  <text x="160" y="650" class="label subtitle">Values choose what comes back</text>
 
-  <rect x="1012" y="210" width="300" height="470" rx="28" fill="#f8fbff" stroke="#c8d7e7" stroke-width="2" />
-  <text x="1046" y="258" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
-    Weighted output
-  </text>
-  <text x="1046" y="294" fill="#64748b" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    Mix returned values into a new vector.
-  </text>
+  <path d="M 850 210 C 930 240, 966 274, 1028 324" class="ink" marker-end="url(#arrow)" />
+  <path d="M 850 318 C 942 320, 980 336, 1028 356" class="ink" marker-end="url(#arrow)" />
+  <path d="M 850 430 C 936 410, 972 400, 1028 382" class="ink-soft" marker-end="url(#arrow)" stroke-dasharray="10 12" />
 
-  <rect x="1046" y="330" width="232" height="168" rx="24" fill="url(#outputFill)" stroke="#f59e0b" stroke-width="2.5" filter="url(#shadow)" />
-  <text x="1076" y="374" fill="#92400e" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">
-    Contextualized "it"
-  </text>
-  <text x="1076" y="412" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    Refers mostly to
-  </text>
-  <text x="1076" y="442" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    the animal, while also
-  </text>
-  <text x="1076" y="472" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    absorbing the causal
-  </text>
-  <text x="1076" y="502" fill="#78350f" font-family="IBM Plex Sans, Arial, sans-serif" font-size="20">
-    clue from tired.
-  </text>
+  <rect x="1036" y="250" width="264" height="214" rx="26" class="note" />
+  <text x="1168" y="308" text-anchor="middle" class="label boxtext">new meaning of "it"</text>
+  <text x="1168" y="356" text-anchor="middle" class="label small">mostly animal</text>
+  <text x="1168" y="392" text-anchor="middle" class="label small">+ some tired</text>
+  <text x="1168" y="428" text-anchor="middle" class="label small">+ almost no street</text>
 
-  <text x="1048" y="560" fill="#0f172a" font-family="Roboto Mono, monospace" font-size="20">
-    0.72 v_animal
-  </text>
-  <text x="1048" y="592" fill="#0f172a" font-family="Roboto Mono, monospace" font-size="20">
-    + 0.08 v_street
-  </text>
-  <text x="1048" y="624" fill="#0f172a" font-family="Roboto Mono, monospace" font-size="20">
-    + 0.20 v_tired
-  </text>
-
-  <path d="M 934 368 C 980 368, 992 374, 1038 386" fill="none" stroke="#f59e0b" stroke-width="4" stroke-linecap="round" marker-end="url(#arrowSoft)" />
-  <path d="M 934 504 C 978 504, 994 476, 1038 456" fill="none" stroke="#94a3b8" stroke-width="3" stroke-linecap="round" marker-end="url(#arrowSoft)" opacity="0.7" />
-  <path d="M 934 638 C 978 638, 994 560, 1038 528" fill="none" stroke="#16a34a" stroke-width="3.5" stroke-linecap="round" marker-end="url(#arrowSoft)" opacity="0.8" />
-
-  <rect x="76" y="732" width="1236" height="96" rx="24" fill="#0f172a" opacity="0.95" />
-  <text x="112" y="780" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">
-    Deep intuition
-  </text>
-  <text x="112" y="812" fill="#cbd5e1" font-family="IBM Plex Sans, Arial, sans-serif" font-size="22">
-    Keys decide where to look. Values decide what comes back. The output is a new representation, not a copied token.
-  </text>
+  <text x="972" y="560" class="label title">Not a hard pointer</text>
+  <text x="972" y="600" class="label subtitle">It is a weighted mix of useful signals.</text>
 </svg>


### PR DESCRIPTION
## What changed
- redrew the two attention deep-dive visuals in a cleaner sketch-style explainer format
- simplified the static image and animated routing graphic to reduce noise and improve at-a-glance comprehension
- documented the preferred low-noise hand-drawn diagram style in AGENTS.md

## Why
- the previous visuals worked technically, but this pass better matches the desired easily grokkable explanatory style

## Testing
- npm run ci