### PR TITLE
Add Gemma 4 local benchmarking blog post

### DIFF
--- a/scripts/bench_gemma4_local.py
+++ b/scripts/bench_gemma4_local.py
@@ -1,0 +1,679 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+from requests.adapters import HTTPAdapter
+from huggingface_hub import hf_hub_download
+from transformers import AutoTokenizer
+
+from mlx_lm import load, stream_generate
+from mlx_lm.sample_utils import make_sampler
+
+
+COMMON_TOKENIZER = "google/gemma-4-E4B-it"
+SYSTEM_PROMPT = "You are a concise assistant. Do not use markdown. Answer directly."
+OLLAMA_HOST = "127.0.0.1:11435"
+OLLAMA_URL = f"http://{OLLAMA_HOST}"
+LLAMA_HOST = "127.0.0.1"
+LLAMA_PORT = 18080
+LLAMA_URL = f"http://{LLAMA_HOST}:{LLAMA_PORT}"
+REQUEST_TIMEOUT = 60 * 60
+
+CORPUS = """
+Running Gemma 4 locally on a 64 GB MacBook Pro is really a question about two
+separate bottlenecks. The first is whether the weights fit in memory. The
+second is whether the runtime still feels fast enough to use once the prompt
+gets long and the KV cache starts growing. The interesting decision is not just
+which model loads, but which one feels snappy enough to become a daily model.
+
+Gemma 4 offers four practical sizes for local experiments on Apple Silicon: E2B,
+E4B, 26B A4B, and 31B. The small models are easier to fit and easier to serve,
+but the larger models are meaningfully stronger on reasoning and coding tasks.
+The 26B A4B model is especially interesting because it is a mixture-of-experts
+model with only a small active parameter set per generated token, even though
+all parameters still need to be resident for fast routing.
+
+For a laptop benchmark, the honest question is not whether a model can run at
+all. It is whether the prompt processing feels reasonable, whether time to first
+token stays humane, and whether decode throughput is high enough for interactive
+work. Long context is attractive in a model card, but every extra token shows up
+in latency. That means a runtime comparison should separate short-prompt
+interactive behavior from longer prompt stress tests.
+
+Llama.cpp, MLX, and Ollama all represent viable local paths on Apple Silicon.
+Llama.cpp gives direct control and tends to be the first stop for squeezing out
+raw performance from GGUF releases. MLX is the most Apple-native path, which can
+matter on newer Macs where the framework keeps getting faster. Ollama is the
+convenience layer: easy model tags, easy local API, and a simple integration
+story, but not automatically the fastest stack.
+
+When the goal is to benchmark runtimes rather than model quality, the output
+task should be easy and repeatable. That way, differences in throughput mostly
+reflect inference behavior instead of chain-of-thought length, reasoning depth,
+or response verbosity. It is also useful to run a longer prompt variant, because
+prompt processing often dominates the experience long before generation speed
+becomes the main bottleneck.
+""".strip()
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    slug: str
+    label: str
+    official_id: str
+    llama_repo: str
+    mlx_repo: str
+    ollama_tag: str
+    llama_quant: str
+    llama_file: str
+
+
+MODELS: dict[str, ModelSpec] = {
+    "e2b": ModelSpec(
+        slug="e2b",
+        label="Gemma 4 E2B",
+        official_id="google/gemma-4-E2B-it",
+        llama_repo="ggml-org/gemma-4-E2B-it-GGUF",
+        mlx_repo="mlx-community/gemma-4-e2b-it-4bit",
+        ollama_tag="gemma4:e2b-it-q4_K_M",
+        llama_quant="Q8_0",
+        llama_file="gemma-4-e2b-it-Q8_0.gguf",
+    ),
+    "e4b": ModelSpec(
+        slug="e4b",
+        label="Gemma 4 E4B",
+        official_id="google/gemma-4-E4B-it",
+        llama_repo="ggml-org/gemma-4-E4B-it-GGUF",
+        mlx_repo="mlx-community/gemma-4-e4b-it-4bit",
+        ollama_tag="gemma4:e4b-it-q4_K_M",
+        llama_quant="Q4_K_M",
+        llama_file="gemma-4-e4b-it-Q4_K_M.gguf",
+    ),
+    "26b": ModelSpec(
+        slug="26b",
+        label="Gemma 4 26B A4B",
+        official_id="google/gemma-4-26B-A4B-it",
+        llama_repo="ggml-org/gemma-4-26B-A4B-it-GGUF",
+        mlx_repo="mlx-community/gemma-4-26b-a4b-it-4bit",
+        ollama_tag="gemma4:26b-a4b-it-q4_K_M",
+        llama_quant="Q4_K_M",
+        llama_file="gemma-4-26B-A4B-it-Q4_K_M.gguf",
+    ),
+    "31b": ModelSpec(
+        slug="31b",
+        label="Gemma 4 31B",
+        official_id="google/gemma-4-31B-it",
+        llama_repo="ggml-org/gemma-4-31B-it-GGUF",
+        mlx_repo="mlx-community/gemma-4-31b-it-4bit",
+        ollama_tag="gemma4:31b-it-q4_K_M",
+        llama_quant="Q4_K_M",
+        llama_file="gemma-4-31B-it-Q4_K_M.gguf",
+    ),
+}
+
+SUITES = {
+    "short": {"input_tokens": 512, "max_new_tokens": 192},
+    "long": {"input_tokens": 8192, "max_new_tokens": 96},
+}
+
+
+def log(message: str) -> None:
+    now = datetime.now().strftime("%H:%M:%S")
+    print(f"[{now}] {message}", flush=True)
+
+
+def make_session() -> requests.Session:
+    session = requests.Session()
+    session.mount("http://", HTTPAdapter(pool_connections=1, pool_maxsize=1))
+    return session
+
+
+def get_tokenizer():
+    log(f"Loading tokenizer: {COMMON_TOKENIZER}")
+    return AutoTokenizer.from_pretrained(COMMON_TOKENIZER)
+
+
+def count_tokens(tokenizer, text: str) -> int:
+    return len(tokenizer.encode(text, add_special_tokens=False))
+
+
+def build_background(tokenizer, target_tokens: int) -> tuple[str, int]:
+    corpus_tokens = tokenizer.encode(CORPUS, add_special_tokens=False)
+    if target_tokens <= 0:
+        return "", 0
+    repeats = (target_tokens // len(corpus_tokens)) + 2
+    combined_tokens = (corpus_tokens * repeats)[:target_tokens]
+    background = tokenizer.decode(combined_tokens, skip_special_tokens=True)
+    actual = count_tokens(tokenizer, background)
+    return background, actual
+
+
+def build_user_prompt(tokenizer, target_tokens: int, lines: int) -> tuple[str, int]:
+    instruction = (
+        f"Read the background notes below. Then print the integers 1 through {lines}, "
+        "one per line, zero-padded to three digits, and nothing else.\n\n"
+        "Background notes:\n"
+    )
+    instruction_tokens = count_tokens(tokenizer, instruction)
+    background, background_tokens = build_background(tokenizer, max(target_tokens - instruction_tokens, 1))
+    prompt = f"{instruction}{background}"
+    actual_tokens = count_tokens(tokenizer, prompt)
+    return prompt, actual_tokens
+
+
+def cleanup_process(proc: subprocess.Popen[Any] | None) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    try:
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=20)
+    except Exception:
+        proc.kill()
+        proc.wait(timeout=20)
+
+
+def ensure_local_gguf(spec: ModelSpec) -> str:
+    log(f"Downloading GGUF artifact from {spec.llama_repo}/{spec.llama_file}")
+    return hf_hub_download(repo_id=spec.llama_repo, filename=spec.llama_file)
+
+
+def wait_for_http(url: str, attempts: int = 900, delay_s: float = 2.0) -> None:
+    session = make_session()
+    last_error: Exception | None = None
+    for _ in range(attempts):
+        try:
+            response = session.get(url, timeout=10)
+            if response.ok:
+                return
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+        time.sleep(delay_s)
+    raise RuntimeError(f"Timed out waiting for {url}") from last_error
+
+
+def llama_request(session: requests.Session, messages: list[dict[str, str]], max_tokens: int) -> dict[str, Any]:
+    payload = {
+        "model": "gemma4",
+        "messages": messages,
+        "stream": True,
+        "temperature": 0,
+        "top_k": 1,
+        "top_p": 1,
+        "seed": 123,
+        "max_tokens": max_tokens,
+    }
+    start = time.perf_counter()
+    response = session.post(
+        f"{LLAMA_URL}/v1/chat/completions",
+        json=payload,
+        stream=True,
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    first_token_at: float | None = None
+    pieces: list[str] = []
+
+    for raw_line in response.iter_lines():
+        if not raw_line:
+            continue
+        if not raw_line.startswith(b"data: "):
+            continue
+        chunk = raw_line[6:].decode("utf-8")
+        if chunk == "[DONE]":
+            break
+        data = json.loads(chunk)
+        delta = data["choices"][0].get("delta", {}).get("content", "")
+        if delta:
+            if first_token_at is None:
+                first_token_at = time.perf_counter()
+            pieces.append(delta)
+
+    elapsed = time.perf_counter() - start
+    ttft = None if first_token_at is None else first_token_at - start
+    return {
+        "text": "".join(pieces),
+        "elapsed_s": elapsed,
+        "ttft_s": ttft,
+    }
+
+
+def start_llama_server(spec: ModelSpec, ctx_size: int, model_path: str) -> tuple[subprocess.Popen[Any], Path]:
+    log(f"Starting llama.cpp server for {spec.label} ({spec.llama_quant})")
+    log_path = Path("/private/tmp") / f"llama-server-{spec.slug}.log"
+    log_file = log_path.open("w")
+    cmd = [
+        "llama-server",
+        "--model",
+        model_path,
+        "--no-mmproj",
+        "--chat-template-kwargs",
+        '{"enable_thinking": false}',
+        "--host",
+        LLAMA_HOST,
+        "--port",
+        str(LLAMA_PORT),
+        "--ctx-size",
+        str(ctx_size),
+        "--flash-attn",
+        "on",
+        "--metrics",
+    ]
+    proc = subprocess.Popen(cmd, stdout=log_file, stderr=subprocess.STDOUT)
+    try:
+        wait_for_http(f"{LLAMA_URL}/health")
+    except Exception:
+        cleanup_process(proc)
+        raise
+    return proc, log_path
+
+
+def benchmark_llama(spec: ModelSpec, tokenizer, suites: list[str]) -> dict[str, Any]:
+    ctx_size = 16384
+    model_path = ensure_local_gguf(spec)
+    proc, log_path = start_llama_server(spec, ctx_size=ctx_size, model_path=model_path)
+    session = make_session()
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": "Print OK and nothing else."},
+    ]
+    try:
+        log(f"Warming up llama.cpp for {spec.label}")
+        llama_request(session, messages, max_tokens=8)
+
+        suite_results: dict[str, Any] = {}
+        for suite_name in suites:
+            config = SUITES[suite_name]
+            prompt, prompt_tokens = build_user_prompt(
+                tokenizer,
+                target_tokens=config["input_tokens"],
+                lines=config["max_new_tokens"],
+            )
+            messages = [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ]
+            log(f"Measuring llama.cpp {spec.label} [{suite_name}]")
+            result = llama_request(session, messages, max_tokens=config["max_new_tokens"])
+            output_tokens = count_tokens(tokenizer, result["text"])
+            decode_window = None
+            decode_tps = None
+            if result["ttft_s"] is not None and result["elapsed_s"] > result["ttft_s"]:
+                decode_window = result["elapsed_s"] - result["ttft_s"]
+                if output_tokens > 0:
+                    decode_tps = output_tokens / decode_window
+            avg_tps = output_tokens / result["elapsed_s"] if output_tokens > 0 else None
+            suite_results[suite_name] = {
+                "target_input_tokens": config["input_tokens"],
+                "actual_input_tokens": prompt_tokens,
+                "max_new_tokens": config["max_new_tokens"],
+                "output_tokens": output_tokens,
+                "ttft_ms": None if result["ttft_s"] is None else round(result["ttft_s"] * 1000, 2),
+                "elapsed_ms": round(result["elapsed_s"] * 1000, 2),
+                "decode_toks_per_s": None if decode_tps is None else round(decode_tps, 2),
+                "avg_toks_per_s": None if avg_tps is None else round(avg_tps, 2),
+            }
+
+        return {
+            "runtime": "llama.cpp",
+            "runtime_artifact": model_path,
+            "notes": "Text-only benchmark using llama-server with flash attention on and no multimodal projector.",
+            "server_log": str(log_path),
+            "suites": suite_results,
+        }
+    finally:
+        cleanup_process(proc)
+
+
+def ensure_ollama_daemon() -> tuple[subprocess.Popen[Any] | None, bool]:
+    session = make_session()
+    try:
+        response = session.get(f"{OLLAMA_URL}/api/tags", timeout=5)
+        if response.ok:
+            return None, False
+    except Exception:  # noqa: BLE001
+        pass
+
+    flash_attention = os.environ.get("OLLAMA_FLASH_ATTENTION")
+    if flash_attention:
+        log(f"Starting dedicated Ollama daemon with OLLAMA_FLASH_ATTENTION={flash_attention}")
+    else:
+        log("Starting dedicated Ollama daemon with default settings")
+    env = os.environ.copy()
+    env["OLLAMA_HOST"] = OLLAMA_HOST
+    log_path = Path("/private/tmp") / "ollama-gemma4-bench.log"
+    log_file = log_path.open("w")
+    proc = subprocess.Popen(["ollama", "serve"], stdout=log_file, stderr=subprocess.STDOUT, env=env)
+    wait_for_http(f"{OLLAMA_URL}/api/tags")
+    return proc, True
+
+
+def ollama_cmd(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["OLLAMA_HOST"] = OLLAMA_HOST
+    return subprocess.run(
+        ["ollama", *args],
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def ensure_ollama_model(spec: ModelSpec) -> str:
+    log(f"Pulling Ollama model {spec.ollama_tag}")
+    ollama_cmd("pull", spec.ollama_tag)
+    return spec.ollama_tag
+
+
+def ollama_request(session: requests.Session, model_tag: str, prompt: str, max_tokens: int) -> dict[str, Any]:
+    payload = {
+        "model": model_tag,
+        "prompt": prompt,
+        "raw": True,
+        "stream": True,
+        "keep_alive": "15m",
+        "options": {
+            "temperature": 0,
+            "top_k": 1,
+            "top_p": 1,
+            "seed": 123,
+            "num_predict": max_tokens,
+        },
+    }
+    start = time.perf_counter()
+    response = session.post(
+        f"{OLLAMA_URL}/api/generate",
+        json=payload,
+        stream=True,
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    first_token_at: float | None = None
+    pieces: list[str] = []
+    final_chunk: dict[str, Any] | None = None
+
+    for raw_line in response.iter_lines():
+        if not raw_line:
+            continue
+        data = json.loads(raw_line.decode("utf-8"))
+        content = data.get("response", "")
+        if content:
+            if first_token_at is None:
+                first_token_at = time.perf_counter()
+            pieces.append(content)
+        if data.get("done"):
+            final_chunk = data
+            break
+
+    elapsed = time.perf_counter() - start
+    ttft = None if first_token_at is None else first_token_at - start
+    return {
+        "text": "".join(pieces),
+        "elapsed_s": elapsed,
+        "ttft_s": ttft,
+        "final_chunk": final_chunk or {},
+    }
+
+
+def benchmark_ollama(spec: ModelSpec, tokenizer, suites: list[str]) -> dict[str, Any]:
+    daemon_proc, started_here = ensure_ollama_daemon()
+    session = make_session()
+    model_name = ensure_ollama_model(spec)
+    try:
+        log(f"Warming up Ollama for {spec.label}")
+        warm_messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": "Print OK and nothing else."},
+        ]
+        warm_prompt = tokenizer.apply_chat_template(
+            warm_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        ollama_request(session, model_name, warm_prompt, max_tokens=8)
+
+        suite_results: dict[str, Any] = {}
+        for suite_name in suites:
+            config = SUITES[suite_name]
+            prompt, prompt_tokens = build_user_prompt(
+                tokenizer,
+                target_tokens=config["input_tokens"],
+                lines=config["max_new_tokens"],
+            )
+            messages = [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ]
+            rendered_prompt = tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=False,
+            )
+            log(f"Measuring Ollama {spec.label} [{suite_name}]")
+            result = ollama_request(session, model_name, rendered_prompt, max_tokens=config["max_new_tokens"])
+            output_tokens = count_tokens(tokenizer, result["text"])
+            decode_window = None
+            decode_tps = None
+            if result["ttft_s"] is not None and result["elapsed_s"] > result["ttft_s"]:
+                decode_window = result["elapsed_s"] - result["ttft_s"]
+                if output_tokens > 0:
+                    decode_tps = output_tokens / decode_window
+            avg_tps = output_tokens / result["elapsed_s"] if output_tokens > 0 else None
+            final_chunk = result["final_chunk"]
+            suite_results[suite_name] = {
+                "target_input_tokens": config["input_tokens"],
+                "actual_input_tokens": prompt_tokens,
+                "max_new_tokens": config["max_new_tokens"],
+                "output_tokens": output_tokens,
+                "ttft_ms": None if result["ttft_s"] is None else round(result["ttft_s"] * 1000, 2),
+                "elapsed_ms": round(result["elapsed_s"] * 1000, 2),
+                "decode_toks_per_s": None if decode_tps is None else round(decode_tps, 2),
+                "avg_toks_per_s": None if avg_tps is None else round(avg_tps, 2),
+                "ollama_prompt_eval_count": final_chunk.get("prompt_eval_count"),
+                "ollama_prompt_eval_duration_ms": (
+                    None
+                    if final_chunk.get("prompt_eval_duration") is None
+                    else round(final_chunk["prompt_eval_duration"] / 1_000_000, 2)
+                ),
+                "ollama_eval_count": final_chunk.get("eval_count"),
+                "ollama_eval_duration_ms": (
+                    None
+                    if final_chunk.get("eval_duration") is None
+                    else round(final_chunk["eval_duration"] / 1_000_000, 2)
+                ),
+            }
+
+        details = ollama_cmd("show", model_name, "--modelfile").stdout
+        flash_attention = os.environ.get("OLLAMA_FLASH_ATTENTION")
+        runtime_note = "Text-only benchmark using a dedicated Ollama daemon and a local GGUF import."
+        if flash_attention:
+            runtime_note = (
+                "Text-only benchmark using a dedicated Ollama daemon, "
+                f"OLLAMA_FLASH_ATTENTION={flash_attention}, and a local GGUF import."
+            )
+        return {
+            "runtime": "ollama",
+            "runtime_artifact": model_name,
+            "notes": f"{runtime_note} Native Ollama tag benchmark, not a local GGUF import.",
+            "ollama_modelfile": details,
+            "suites": suite_results,
+        }
+    finally:
+        if started_here:
+            cleanup_process(daemon_proc)
+
+
+def benchmark_mlx(spec: ModelSpec, tokenizer, suites: list[str]) -> dict[str, Any]:
+    log(f"Loading MLX model {spec.mlx_repo}")
+    model, model_tokenizer = load(spec.mlx_repo)
+    sampler = make_sampler(temp=0.0, top_k=1, top_p=1.0)
+    try:
+        warm_messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": "Print OK and nothing else."},
+        ]
+        warm_prompt = model_tokenizer.apply_chat_template(
+            warm_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        log(f"Warming up MLX for {spec.label}")
+        for _ in stream_generate(model, model_tokenizer, warm_prompt, max_tokens=8, sampler=sampler):
+            pass
+
+        suite_results: dict[str, Any] = {}
+        for suite_name in suites:
+            config = SUITES[suite_name]
+            prompt, prompt_tokens = build_user_prompt(
+                tokenizer,
+                target_tokens=config["input_tokens"],
+                lines=config["max_new_tokens"],
+            )
+            messages = [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ]
+            rendered_prompt = model_tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=False,
+            )
+
+            log(f"Measuring MLX {spec.label} [{suite_name}]")
+            start = time.perf_counter()
+            first_token_at: float | None = None
+            pieces: list[str] = []
+            for chunk in stream_generate(
+                model,
+                model_tokenizer,
+                rendered_prompt,
+                max_tokens=config["max_new_tokens"],
+                sampler=sampler,
+            ):
+                if chunk.text:
+                    if first_token_at is None:
+                        first_token_at = time.perf_counter()
+                    pieces.append(chunk.text)
+            elapsed = time.perf_counter() - start
+            ttft = None if first_token_at is None else first_token_at - start
+            text = "".join(pieces)
+            output_tokens = count_tokens(tokenizer, text)
+            decode_window = None
+            decode_tps = None
+            if ttft is not None and elapsed > ttft:
+                decode_window = elapsed - ttft
+                if output_tokens > 0:
+                    decode_tps = output_tokens / decode_window
+            avg_tps = output_tokens / elapsed if output_tokens > 0 else None
+            suite_results[suite_name] = {
+                "target_input_tokens": config["input_tokens"],
+                "actual_input_tokens": prompt_tokens,
+                "max_new_tokens": config["max_new_tokens"],
+                "output_tokens": output_tokens,
+                "ttft_ms": None if ttft is None else round(ttft * 1000, 2),
+                "elapsed_ms": round(elapsed * 1000, 2),
+                "decode_toks_per_s": None if decode_tps is None else round(decode_tps, 2),
+                "avg_toks_per_s": None if avg_tps is None else round(avg_tps, 2),
+            }
+
+        return {
+            "runtime": "mlx-lm",
+            "runtime_artifact": spec.mlx_repo,
+            "notes": "Text-only benchmark using mlx-lm Python API and 4-bit MLX community weights.",
+            "suites": suite_results,
+        }
+    finally:
+        del model
+        del model_tokenizer
+        gc.collect()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark Gemma 4 local runtimes on Apple Silicon.")
+    parser.add_argument("--runtime", choices=["llama", "mlx", "ollama"], required=True)
+    parser.add_argument("--model", choices=sorted(MODELS.keys()), required=True)
+    parser.add_argument(
+        "--suites",
+        default="short,long",
+        help="Comma-separated list drawn from: short,long",
+    )
+    parser.add_argument("--output", required=True, help="Path to write JSON results.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    suite_names = [name.strip() for name in args.suites.split(",") if name.strip()]
+    unknown = [name for name in suite_names if name not in SUITES]
+    if unknown:
+        raise SystemExit(f"Unknown suites: {', '.join(unknown)}")
+
+    spec = MODELS[args.model]
+    tokenizer = get_tokenizer()
+
+    if args.runtime == "llama":
+        result = benchmark_llama(spec, tokenizer, suite_names)
+    elif args.runtime == "mlx":
+        result = benchmark_mlx(spec, tokenizer, suite_names)
+    else:
+        result = benchmark_ollama(spec, tokenizer, suite_names)
+
+    payload = {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "machine": {
+            "hostname": os.uname().nodename,
+            "platform": sys.platform,
+            "cpu": subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.brand_string"],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout.strip(),
+            "memory_gb": round(
+                int(
+                    subprocess.run(
+                        ["sysctl", "-n", "hw.memsize"],
+                        check=True,
+                        text=True,
+                        capture_output=True,
+                    ).stdout.strip()
+                )
+                / (1024**3),
+                1,
+            ),
+        },
+        "model": {
+            "slug": spec.slug,
+            "label": spec.label,
+            "official_id": spec.official_id,
+        },
+        **result,
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    log(f"Wrote results to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -1,0 +1,151 @@
+---
+title: Running Gemma 4 locally on a 64 GB MacBook Pro
+date: '2026-04-04T04:00:00.000Z'
+section: blog
+postSlug: running-gemma-4-locally-on-a-64-gb-macbook-pro
+legacyPath: /blog/2026/04/04/running-gemma-4-locally-on-a-64-gb-macbook-pro.html
+tags:
+  - LLMs
+  - Apple Silicon
+summary: >-
+  Benchmarks for MLX, llama.cpp, and Ollama running Gemma 4 on a 64 GB M5 Max
+  MacBook Pro, plus what I would actually use every day.
+---
+# Running Gemma 4 locally on a 64 GB MacBook Pro
+
+I wanted the answer to a very specific question: on a 64 GB M5 Max MacBook Pro, what is the best Gemma 4 model I can run locally, and what is the fastest way to run it?
+
+The model answer stayed simple.
+
+The runtime answer got much more interesting once I stopped guessing and actually benchmarked it.
+
+The short version, as of April 4, 2026:
+
+- Best model that fits: `Gemma 4 31B`
+- Best daily balance: `Gemma 4 26B A4B`
+- Fastest usable runtime I tested on this machine: `MLX`
+- Most direct low-level path: `llama.cpp`
+- Current Ollama status for Gemma 4 on this machine: it crashes before first token
+
+That last one surprised me the most.
+
+## What fits
+
+According to Google's current Gemma docs, approximate Q4 inference memory requirements are `3.2 GB` for `Gemma 4 E2B`, `5 GB` for `Gemma 4 E4B`, `15.6 GB` for `Gemma 4 26B A4B`, and `17.4 GB` for `Gemma 4 31B` ([Google docs](https://ai.google.dev/gemma/docs/core)).
+
+So on a 64 GB machine, all four models are realistic local targets, including the two workstation-class ones that matter most for serious use:
+
+- `Gemma 4 26B A4B`
+- `Gemma 4 31B`
+
+The `26B A4B` model is the more interesting one for everyday laptop use. It is MoE, so only `4B` parameters are active per generated token, even though the full model still has to be resident in memory. The `31B` model is the strongest dense option that still makes sense on this machine. Google also lists `128K` context for the small models and `256K` context for the larger ones, which is great capability-wise, but not remotely free from a latency perspective ([Google docs](https://ai.google.dev/gemma/docs/core), [Gemma 4 31B card](https://huggingface.co/google/gemma-4-31B-it)).
+
+So my view did not really change here:
+
+- If you want the best Gemma 4 model that comfortably fits, start with `31B`.
+- If you want the model I would actually pay the most attention to for daily use, it is `26B A4B`.
+
+## How I benchmarked it
+
+I ran everything on:
+
+- `Apple M5 Max`
+- `64 GB` unified memory
+- `macOS 26.3.1 (a)`
+
+I tested the three obvious Mac paths:
+
+- `llama.cpp` via `llama-server` and the official `ggml-org` GGUF releases
+- `MLX` via `mlx-lm` and the `mlx-community` 4-bit conversions
+- `Ollama` via native `gemma4:*` tags
+
+I used two text-only suites so the results would reflect inference behavior rather than reasoning verbosity:
+
+- Short suite: `512` input tokens, `192` output tokens
+- Long suite: `8192` input tokens, `96` output tokens
+
+The output task was intentionally boring and deterministic: read background text, then print numbered lines. Temperature was pinned to `0`, and I measured:
+
+- Time to first token
+- Decode tokens per second
+- Average tokens per second over the full request
+
+One important caveat: this is a fastest-practical-path comparison, not a perfect same-weights lab setup. I used the most direct current artifact for each runtime. That means the `E2B` comparison is not perfectly apples-to-apples: official `llama.cpp` GGUF for `E2B` is `Q8_0`, while the MLX and Ollama paths use 4-bit artifacts.
+
+## What The Benchmarks Say
+
+I came into this expecting `llama.cpp` to win on raw speed.
+
+That is not what the machine gave me.
+
+For the smaller models, MLX was clearly faster on this M5 Max. For `26B A4B`, the story got more nuanced: `llama.cpp` and MLX were effectively tied on the short prompt, but MLX still pulled ahead once the prompt got long. For `31B`, MLX went back to being the cleaner win, especially on prompt processing and time to first token.
+
+### Short Suite
+
+| Model | Runtime | Artifact | TTFT | Decode tok/s | Avg tok/s |
+| ----- | ------- | -------- | ---- | ------------ | --------- |
+| `E2B` | MLX | `mlx-community/gemma-4-e2b-it-4bit` | `181 ms` | `182.86` | `155.95` |
+| `E2B` | llama.cpp | `ggml-org` `Q8_0` GGUF | `127 ms` | `119.46` | `110.73` |
+| `E4B` | MLX | `mlx-community/gemma-4-e4b-it-4bit` | `230 ms` | `114.96` | `101.03` |
+| `E4B` | llama.cpp | `ggml-org` `Q4_K_M` GGUF | `391 ms` | `96.54` | `80.69` |
+| `26B A4B` | MLX | `mlx-community/gemma-4-26b-a4b-it-4bit` | `422 ms` | `115.80` | `92.31` |
+| `26B A4B` | llama.cpp | `ggml-org` `Q4_K_M` GGUF | `334 ms` | `110.85` | `92.92` |
+| `31B` | MLX | `mlx-community/gemma-4-31b-it-4bit` | `906 ms` | `27.50` | `24.34` |
+| `31B` | llama.cpp | `ggml-org` `Q4_K_M` GGUF | `1279 ms` | `24.89` | `21.35` |
+
+### Long Suite
+
+| Model | Runtime | Artifact | TTFT | Decode tok/s | Avg tok/s |
+| ----- | ------- | -------- | ---- | ------------ | --------- |
+| `E2B` | MLX | `mlx-community/gemma-4-e2b-it-4bit` | `879 ms` | `175.68` | `67.33` |
+| `E2B` | llama.cpp | `ggml-org` `Q8_0` GGUF | `1634 ms` | `114.07` | `38.78` |
+| `E4B` | MLX | `mlx-community/gemma-4-e4b-it-4bit` | `1682 ms` | `103.95` | `36.85` |
+| `E4B` | llama.cpp | `ggml-org` `Q4_K_M` GGUF | `3068 ms` | `89.35` | `23.17` |
+| `26B A4B` | MLX | `mlx-community/gemma-4-26b-a4b-it-4bit` | `2182 ms` | `104.36` | `30.95` |
+| `26B A4B` | llama.cpp | `ggml-org` `Q4_K_M` GGUF | `3227 ms` | `101.42` | `23.00` |
+| `31B` | MLX | `mlx-community/gemma-4-31b-it-4bit` | `13501 ms` | `23.73` | `5.47` |
+| `31B` | llama.cpp | `ggml-org` `Q4_K_M` GGUF | `24164 ms` | `20.72` | `3.33` |
+
+The pattern is pretty clear:
+
+- MLX is winning the small-model tests by a healthy margin.
+- `26B A4B` is much closer on short prompts than I expected.
+- `31B` is a meaningful step down in responsiveness compared with `26B A4B`, even though it still fits comfortably in memory.
+- `31B` also stops being a close runtime contest: MLX is simply better behaved there on this machine.
+- On longer prompts, MLX is still more comfortable because time to first token is substantially lower.
+- The difference between "weights fit" and "this feels good to use" becomes real very quickly once prompt length goes up.
+
+That last point matters more than people usually admit. Decode speed often holds up decently. What really starts to hurt is prompt processing and time to first token.
+
+## Ollama, Right Now
+
+I wanted a clean Ollama column here.
+
+I could not get one.
+
+On this exact machine, using current native Gemma 4 tags like `gemma4:e2b-it-q4_K_M`, Ollama `0.20.2` failed before first token with a Metal backend compilation error and returned HTTP `500` from `/api/generate`. The key error was the same `bfloat` vs `half` cooperative tensor mismatch in Metal Performance Primitives that other Apple M5 users have reported upstream ([issue #13460](https://github.com/ollama/ollama/issues/13460), [issue #14432](https://github.com/ollama/ollama/issues/14432), [issue #13867](https://github.com/ollama/ollama/issues/13867)).
+
+That matters because it changes the recommendation:
+
+- This is not a general "Gemma 4 cannot run on Apple Silicon" problem.
+- It is not even a general "M5 cannot run local models" problem.
+- `llama.cpp` and MLX both worked on the same machine.
+- The failure appears to be specific to Ollama's current Apple / Metal path on M5-class hardware.
+
+So if your question is "should I start with Ollama because it is easiest," my current answer is no, not for Gemma 4 on this hardware, at least not until that backend issue is fixed.
+
+## What I Would Actually Use
+
+If I cared about the strongest local Gemma 4 model, I would start with `31B`.
+
+If I cared about the model I would actually want to use every day on this machine, I would pay the closest attention to `26B A4B`.
+
+If I cared about the fastest usable runtime on this machine, the answer is no longer "obviously llama.cpp." The current evidence points more toward:
+
+1. `MLX` first
+2. `llama.cpp` second
+3. `Ollama` later, once the M5 Metal breakage is fixed
+
+That is a more opinionated answer than I expected going in, but it feels much less hand-wavy now.
+
+And honestly, that was the point of running the benchmarks in the first place.


### PR DESCRIPTION
## What changed
- add a new blog post for the blog section on running Gemma 4 locally on a 64 GB M5 Max MacBook Pro
- include measured benchmarks for Gemma 4 E2B, E4B, 26B A4B, and 31B across MLX and llama.cpp
- document the current Ollama failure mode on this machine and link the upstream M5 Metal issues
- add the local benchmark harness used to generate the numbers

## Why
The draft started from reasoned recommendations, but the final post is now grounded in actual machine data so the runtime advice is evidence-backed instead of speculative.

## Testing
- `npm run ci`
- pre-push hook re-ran `npm run ci` successfully