### PR TITLE
Add homepage code interview practice lab

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2178,6 +2178,356 @@ body.home-page {
   margin-bottom: 0;
 }
 
+.home-code-lab {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.75rem;
+}
+
+.code-practice-lab {
+  display: grid;
+  gap: 1rem;
+}
+
+.code-practice-lab h3,
+.code-practice-lab h4,
+.code-practice-lab p,
+.code-practice-lab li,
+.code-practice-lab button,
+.code-practice-lab textarea,
+.code-practice-lab code,
+.code-practice-lab pre,
+.code-practice-lab label,
+.code-practice-lab span,
+.code-practice-lab strong {
+  font-family: var(--font-mono);
+}
+
+.code-practice-lab__problem-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.code-practice-lab__problem-strip button,
+.code-practice-lab__reveal-actions button,
+.code-practice-lab__actions button {
+  appearance: none;
+  border: 1px solid rgba(127, 197, 255, 0.25);
+  background: rgba(9, 21, 44, 0.78);
+  color: #dff0ff;
+  padding: 0.8rem 1rem;
+  border-radius: 20px;
+  cursor: pointer;
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background-color 0.18s ease;
+}
+
+:root[data-theme="dark"] .code-practice-lab__problem-strip button,
+:root[data-theme="dark"] .code-practice-lab__reveal-actions button,
+:root[data-theme="dark"] .code-practice-lab__actions button {
+  border-color: rgba(255, 228, 92, 0.24);
+  background: rgba(22, 18, 2, 0.82);
+  color: #fff7cf;
+}
+
+.code-practice-lab__problem-strip button:hover,
+.code-practice-lab__reveal-actions button:hover,
+.code-practice-lab__actions button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(127, 197, 255, 0.55);
+}
+
+:root[data-theme="dark"] .code-practice-lab__problem-strip button:hover,
+:root[data-theme="dark"] .code-practice-lab__reveal-actions button:hover,
+:root[data-theme="dark"] .code-practice-lab__actions button:hover {
+  border-color: rgba(255, 228, 92, 0.52);
+}
+
+.code-practice-lab__problem-strip button.is-active {
+  background: rgba(38, 84, 165, 0.9);
+  border-color: rgba(151, 208, 255, 0.7);
+}
+
+:root[data-theme="dark"] .code-practice-lab__problem-strip button.is-active {
+  background: rgba(96, 76, 8, 0.92);
+  border-color: rgba(255, 228, 92, 0.58);
+}
+
+.code-practice-lab__problem-strip button span,
+.code-practice-lab__problem-strip button strong {
+  display: block;
+}
+
+.code-practice-lab__problem-strip button span {
+  margin-bottom: 0.2rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.78;
+}
+
+.code-practice-lab__workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.02fr) minmax(0, 0.98fr);
+  gap: 1rem;
+}
+
+.code-practice-lab__panel {
+  padding: 1.25rem;
+  border-radius: 24px;
+  border: 1px solid rgba(118, 169, 255, 0.18);
+  background:
+    linear-gradient(180deg, rgba(12, 20, 40, 0.98), rgba(7, 13, 26, 0.99));
+  box-shadow: 0 24px 48px rgba(7, 20, 48, 0.24);
+  color: #dff0ff;
+}
+
+:root[data-theme="dark"] .code-practice-lab__panel {
+  border-color: rgba(255, 228, 92, 0.2);
+  background:
+    linear-gradient(180deg, rgba(10, 10, 10, 0.98), rgba(19, 16, 4, 0.98));
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.46);
+  color: #fff7cf;
+}
+
+.code-practice-lab__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.code-practice-lab__header h3,
+.code-practice-lab__header h4 {
+  margin: 0;
+}
+
+.code-practice-lab__eyebrow {
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  color: #7fc5ff;
+}
+
+:root[data-theme="dark"] .code-practice-lab__eyebrow {
+  color: #ffe45c;
+}
+
+.code-practice-lab__summary,
+.code-practice-lab__copy p,
+.code-practice-lab__runtime-note,
+.code-practice-lab__status {
+  color: rgba(223, 240, 255, 0.84);
+}
+
+:root[data-theme="dark"] .code-practice-lab__summary,
+:root[data-theme="dark"] .code-practice-lab__copy p,
+:root[data-theme="dark"] .code-practice-lab__runtime-note,
+:root[data-theme="dark"] .code-practice-lab__status {
+  color: rgba(255, 247, 207, 0.84);
+}
+
+.code-practice-lab__summary {
+  margin: 0.45rem 0 0;
+  line-height: 1.55;
+}
+
+.code-practice-lab__difficulty {
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 197, 255, 0.22);
+  background: rgba(18, 37, 68, 0.82);
+  white-space: nowrap;
+}
+
+:root[data-theme="dark"] .code-practice-lab__difficulty {
+  border-color: rgba(255, 228, 92, 0.2);
+  background: rgba(35, 28, 2, 0.78);
+}
+
+.code-practice-lab__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.code-practice-lab__tags span {
+  padding: 0.32rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(127, 197, 255, 0.1);
+  border: 1px solid rgba(127, 197, 255, 0.16);
+  font-size: 0.8rem;
+}
+
+:root[data-theme="dark"] .code-practice-lab__tags span {
+  background: rgba(255, 228, 92, 0.08);
+  border-color: rgba(255, 228, 92, 0.16);
+}
+
+.code-practice-lab__copy {
+  margin-top: 1rem;
+}
+
+.code-practice-lab__copy p {
+  margin: 0 0 0.9rem;
+  line-height: 1.65;
+}
+
+.code-practice-lab__block,
+.code-practice-lab__reveal-panel,
+.code-practice-lab__output > div {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(127, 197, 255, 0.16);
+  background: rgba(4, 14, 28, 0.72);
+}
+
+:root[data-theme="dark"] .code-practice-lab__block,
+:root[data-theme="dark"] .code-practice-lab__reveal-panel,
+:root[data-theme="dark"] .code-practice-lab__output > div {
+  border-color: rgba(255, 228, 92, 0.16);
+  background: rgba(11, 10, 2, 0.78);
+}
+
+.code-practice-lab__section-label,
+.code-practice-lab__example p,
+.code-practice-lab__output p {
+  margin: 0 0 0.7rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.code-practice-lab__block pre,
+.code-practice-lab__example pre,
+.code-practice-lab__reveal-panel pre,
+.code-practice-lab__output pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.code-practice-lab__list {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.code-practice-lab__examples {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.code-practice-lab__example {
+  padding: 0.9rem;
+  border-radius: 16px;
+  border: 1px solid rgba(127, 197, 255, 0.14);
+  background: rgba(2, 9, 18, 0.68);
+}
+
+:root[data-theme="dark"] .code-practice-lab__example {
+  border-color: rgba(255, 228, 92, 0.14);
+  background: rgba(8, 8, 8, 0.72);
+}
+
+.code-practice-lab__reveal-actions,
+.code-practice-lab__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.code-practice-lab__status--ready {
+  color: #86f7c0;
+}
+
+.code-practice-lab__status--error {
+  color: #ff8e8e;
+}
+
+.code-practice-lab__runtime-note {
+  margin: 0.85rem 0 0;
+  line-height: 1.55;
+}
+
+.code-practice-lab__promptbar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 1rem;
+  margin-bottom: 0.85rem;
+}
+
+.code-practice-lab__dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: #ff7c7c;
+}
+
+.code-practice-lab__dot:nth-child(2) {
+  background: #ffd76e;
+}
+
+.code-practice-lab__dot:nth-child(3) {
+  background: #81f0b0;
+}
+
+.code-practice-lab__prompt {
+  margin-left: 0.4rem;
+  color: rgba(223, 240, 255, 0.72);
+}
+
+:root[data-theme="dark"] .code-practice-lab__prompt {
+  color: rgba(255, 247, 207, 0.72);
+}
+
+.code-practice-lab__editor-label {
+  display: block;
+  margin-bottom: 0.6rem;
+  font-size: 0.84rem;
+}
+
+.code-practice-lab__editor {
+  width: 100%;
+  min-height: 24rem;
+  resize: vertical;
+  box-sizing: border-box;
+  border-radius: 16px;
+  border: 1px solid rgba(127, 197, 255, 0.18);
+  background: rgba(3, 10, 20, 0.84);
+  color: inherit;
+  padding: 1rem;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+:root[data-theme="dark"] .code-practice-lab__editor {
+  border-color: rgba(255, 228, 92, 0.2);
+  background: rgba(7, 7, 7, 0.9);
+}
+
+.code-practice-lab__actions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.code-practice-lab__output {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
 @media (max-width: 820px) {
   .python-playground__header,
   .python-playground__walkthrough-header,
@@ -2189,6 +2539,17 @@ body.home-page {
 
   .python-playground__output,
   .python-playground__variables {
+    display: grid;
+  }
+
+  .code-practice-lab__workspace,
+  .code-practice-lab__header,
+  .code-practice-lab__output {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+
+  .code-practice-lab__output {
     display: grid;
   }
 }

--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -1,0 +1,328 @@
+import React, { startTransition, useEffect, useRef, useState } from 'react';
+import { loadPyodideRuntime } from '../lib/pyodide-loader';
+import type { PyodideRuntime } from '../lib/pyodide-loader';
+import { runPythonSnippet } from '../lib/python-runner';
+import type { CodePracticeProblem } from '../lib/code-practice';
+
+interface CodePracticeLabProps {
+  problems: readonly CodePracticeProblem[];
+}
+
+export default function CodePracticeLab({ problems }: CodePracticeLabProps) {
+  const containerRef = useRef<HTMLElement | null>(null);
+  const runtimeRef = useRef<PyodideRuntime | null>(null);
+  const loadingRef = useRef(false);
+  const [selectedProblemIndex, setSelectedProblemIndex] = useState(0);
+  const selectedProblem = problems[selectedProblemIndex] ?? problems[0];
+  const [code, setCode] = useState(selectedProblem?.starterCode ?? '');
+  const [output, setOutput] = useState('');
+  const [errorOutput, setErrorOutput] = useState('');
+  const [showHint, setShowHint] = useState(false);
+  const [showSolution, setShowSolution] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [statusMessage, setStatusMessage] = useState(
+    'Python runtime will load when this lab scrolls into view.',
+  );
+  const [isRunning, setIsRunning] = useState(false);
+
+  useEffect(() => {
+    if (!selectedProblem) {
+      return;
+    }
+
+    setCode(selectedProblem.starterCode);
+    setOutput('');
+    setErrorOutput('');
+    setShowHint(false);
+    setShowSolution(false);
+  }, [selectedProblem]);
+
+  useEffect(() => {
+    let didCancel = false;
+
+    async function bootstrapRuntime() {
+      if (runtimeRef.current || loadingRef.current) {
+        return;
+      }
+
+      loadingRef.current = true;
+      setStatus('loading');
+      setStatusMessage('Preparing the in-browser Python runtime...');
+
+      try {
+        const runtime = await loadPyodideRuntime();
+        if (didCancel) {
+          return;
+        }
+
+        runtimeRef.current = runtime;
+        setStatus('ready');
+        setStatusMessage('Python is ready. Run the starter code or edit your solution.');
+      } catch (error) {
+        if (didCancel) {
+          return;
+        }
+
+        setStatus('error');
+        setStatusMessage(
+          error instanceof Error ? error.message : 'The Python runtime failed to load.',
+        );
+      } finally {
+        loadingRef.current = false;
+      }
+    }
+
+    if (typeof window === 'undefined') {
+      return () => {
+        didCancel = true;
+      };
+    }
+
+    const node = containerRef.current;
+    if (!node) {
+      return () => {
+        didCancel = true;
+      };
+    }
+
+    if (typeof window.IntersectionObserver !== 'function') {
+      void bootstrapRuntime();
+      return () => {
+        didCancel = true;
+      };
+    }
+
+    const observer = new window.IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry?.isIntersecting) {
+          observer.disconnect();
+          void bootstrapRuntime();
+        }
+      },
+      { rootMargin: '160px 0px' },
+    );
+
+    observer.observe(node);
+
+    return () => {
+      didCancel = true;
+      observer.disconnect();
+    };
+  }, []);
+
+  if (!selectedProblem) {
+    return null;
+  }
+
+  const editorId = `${selectedProblem.id}-editor`;
+
+  async function handleRun() {
+    if (!runtimeRef.current) {
+      setStatusMessage('Python is still loading. Try again in a moment.');
+      return;
+    }
+
+    setIsRunning(true);
+    setOutput('');
+    setErrorOutput('');
+
+    try {
+      const result = await runPythonSnippet(
+        runtimeRef.current,
+        code,
+        selectedProblem.packages ?? [],
+      );
+
+      startTransition(() => {
+        setOutput(result.stdout.trimEnd());
+        setErrorOutput(result.stderr.trimEnd());
+      });
+    } catch (error) {
+      setErrorOutput(error instanceof Error ? error.message : 'Unknown execution error.');
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  function handleReset() {
+    setCode(selectedProblem.starterCode);
+    setOutput('');
+    setErrorOutput('');
+  }
+
+  return (
+    <section className="code-practice-lab" ref={containerRef}>
+      <div className="code-practice-lab__problem-strip" aria-label="Practice problems">
+        {problems.map((problem, index) => (
+          <button
+            key={problem.id}
+            className={index === selectedProblemIndex ? 'is-active' : undefined}
+            type="button"
+            onClick={() => setSelectedProblemIndex(index)}
+          >
+            <span>{`Problem ${String(problem.order).padStart(2, '0')}`}</span>
+            <strong>{problem.title}</strong>
+          </button>
+        ))}
+      </div>
+
+      <div className="code-practice-lab__workspace">
+        <article className="code-practice-lab__panel code-practice-lab__panel--problem">
+          <div className="code-practice-lab__header">
+            <div>
+              <p className="code-practice-lab__eyebrow">Interview Practice</p>
+              <h3>{`Problem ${selectedProblem.order}: ${selectedProblem.title}`}</h3>
+              <p className="code-practice-lab__summary">{selectedProblem.summary}</p>
+            </div>
+            <span className="code-practice-lab__difficulty">{selectedProblem.difficulty}</span>
+          </div>
+
+          {selectedProblem.tags && selectedProblem.tags.length > 0 && (
+            <div className="code-practice-lab__tags" aria-label="Problem topics">
+              {selectedProblem.tags.map((tag) => (
+                <span key={tag}>{tag}</span>
+              ))}
+            </div>
+          )}
+
+          <div className="code-practice-lab__copy">
+            {selectedProblem.prompt.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+
+          <div className="code-practice-lab__block">
+            <p className="code-practice-lab__section-label">Implement</p>
+            <pre>
+              <code>{selectedProblem.signature}</code>
+            </pre>
+          </div>
+
+          <div className="code-practice-lab__block">
+            <p className="code-practice-lab__section-label">Where</p>
+            <ul className="code-practice-lab__list">
+              {selectedProblem.requirements.map((requirement) => (
+                <li key={requirement}>{requirement}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="code-practice-lab__block">
+            <p className="code-practice-lab__section-label">Examples</p>
+            <div className="code-practice-lab__examples">
+              {selectedProblem.examples.map((example) => (
+                <div key={example.label} className="code-practice-lab__example">
+                  <p>{example.label}</p>
+                  <pre>
+                    <code>{`${example.lines.join('\n')}\n\n${example.result}`}</code>
+                  </pre>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="code-practice-lab__reveal-actions">
+            <button
+              type="button"
+              aria-expanded={showHint}
+              onClick={() => setShowHint((current) => !current)}
+            >
+              {showHint ? 'Hide hint' : 'Show hint'}
+            </button>
+            <button
+              type="button"
+              aria-expanded={showSolution}
+              onClick={() => setShowSolution((current) => !current)}
+            >
+              {showSolution ? 'Hide solution' : 'Reveal solution'}
+            </button>
+          </div>
+
+          {showHint && (
+            <div className="code-practice-lab__reveal-panel">
+              <p className="code-practice-lab__section-label">Hint</p>
+              <ul className="code-practice-lab__list">
+                {selectedProblem.hint.map((hintLine) => (
+                  <li key={hintLine}>{hintLine}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {showSolution && (
+            <div className="code-practice-lab__reveal-panel">
+              <p className="code-practice-lab__section-label">Solution</p>
+              <div className="code-practice-lab__copy">
+                {selectedProblem.solutionNotes.map((note) => (
+                  <p key={note}>{note}</p>
+                ))}
+              </div>
+              <pre>
+                <code>{selectedProblem.solutionCode}</code>
+              </pre>
+            </div>
+          )}
+        </article>
+
+        <article className="code-practice-lab__panel code-practice-lab__panel--editor">
+          <div className="code-practice-lab__header code-practice-lab__header--editor">
+            <div>
+              <p className="code-practice-lab__eyebrow">Python Workspace</p>
+              <h4>Run your solution</h4>
+            </div>
+            <p
+              className={`code-practice-lab__status code-practice-lab__status--${status}`}
+              aria-live="polite"
+            >
+              {statusMessage}
+            </p>
+          </div>
+
+          <p className="code-practice-lab__runtime-note">
+            NumPy is available for this problem and will load automatically the first time you run
+            it.
+          </p>
+
+          <div className="code-practice-lab__promptbar">
+            <span className="code-practice-lab__dot" />
+            <span className="code-practice-lab__dot" />
+            <span className="code-practice-lab__dot" />
+            <span className="code-practice-lab__prompt">python interview_practice.py</span>
+          </div>
+
+          <label className="code-practice-lab__editor-label" htmlFor={editorId}>
+            Editable starter code
+          </label>
+          <textarea
+            id={editorId}
+            className="code-practice-lab__editor"
+            spellCheck={false}
+            value={code}
+            onChange={(event) => setCode(event.target.value)}
+          />
+
+          <div className="code-practice-lab__actions">
+            <button type="button" onClick={() => void handleRun()} disabled={status !== 'ready' || isRunning}>
+              {isRunning ? 'Running...' : 'Run code'}
+            </button>
+            <button type="button" onClick={handleReset}>
+              Reset starter
+            </button>
+          </div>
+
+          <div className="code-practice-lab__output">
+            <div>
+              <p>stdout</p>
+              <pre>{output || 'Run the starter code to see your printed output here.'}</pre>
+            </div>
+            <div>
+              <p>stderr</p>
+              <pre>{errorOutput || 'Execution errors will appear here.'}</pre>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/src/components/PythonPlayground.tsx
+++ b/src/components/PythonPlayground.tsx
@@ -2,51 +2,7 @@ import React, { startTransition, useEffect, useRef, useState } from 'react';
 import { loadPyodideRuntime } from '../lib/pyodide-loader';
 import type { PyodideRuntime } from '../lib/pyodide-loader';
 import type { PythonPlaygroundProps } from '../lib/python-playground';
-
-const EXECUTION_PREFIX = `
-import contextlib
-import io
-import traceback
-`;
-
-function escapePythonTripleQuotedString(source: string) {
-  return source.replace(/\\/g, '\\\\').replace(/"""/g, '\\"""');
-}
-
-async function runCode(runtime: PyodideRuntime, code: string) {
-  const escapedCode = escapePythonTripleQuotedString(code);
-  const result = await runtime.runPythonAsync(`
-${EXECUTION_PREFIX}
-_stdout_buffer = io.StringIO()
-_stderr_buffer = io.StringIO()
-_execution_result = None
-
-with contextlib.redirect_stdout(_stdout_buffer), contextlib.redirect_stderr(_stderr_buffer):
-    try:
-        exec("""${escapedCode}""", {})
-    except Exception:
-        traceback.print_exc()
-
-(_stdout_buffer.getvalue(), _stderr_buffer.getvalue())
-`);
-
-  const normalizedResult =
-    typeof result === 'object' &&
-    result !== null &&
-    'toJs' in result &&
-    typeof result.toJs === 'function'
-      ? result.toJs()
-      : result;
-
-  if (!Array.isArray(normalizedResult)) {
-    return { stdout: '', stderr: 'Unexpected result returned from Python runtime.' };
-  }
-
-  return {
-    stdout: String(normalizedResult[0] ?? ''),
-    stderr: String(normalizedResult[1] ?? ''),
-  };
-}
+import { runPythonSnippet } from '../lib/python-runner';
 
 export default function PythonPlayground({
   title,
@@ -148,7 +104,7 @@ export default function PythonPlayground({
     setErrorOutput('');
 
     try {
-      const result = await runCode(runtimeRef.current, code);
+      const result = await runPythonSnippet(runtimeRef.current, code);
       startTransition(() => {
         setOutput(result.stdout.trimEnd());
         setErrorOutput(result.stderr.trimEnd());

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
-const themeStylesheetHref = '/css/override.css?v=20260318-cyberpunk-restore-1';
+const themeStylesheetHref = '/css/override.css?v=20260416-code-lab-1';
 ---
 
 <!DOCTYPE html>

--- a/src/lib/code-practice.ts
+++ b/src/lib/code-practice.ts
@@ -1,0 +1,110 @@
+export interface CodePracticeExample {
+  label: string;
+  lines: string[];
+  result: string;
+}
+
+export interface CodePracticeProblem {
+  id: string;
+  order: number;
+  title: string;
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  summary: string;
+  prompt: string[];
+  signature: string;
+  requirements: string[];
+  examples: CodePracticeExample[];
+  hint: string[];
+  solutionNotes: string[];
+  solutionCode: string;
+  starterCode: string;
+  packages?: readonly string[];
+  tags?: readonly string[];
+}
+
+export const codePracticeProblems: readonly CodePracticeProblem[] = [
+  {
+    id: 'stable-softmax-cross-entropy',
+    order: 1,
+    title: 'Stable softmax cross-entropy',
+    difficulty: 'Medium',
+    summary:
+      'Implement a numerically stable batch softmax cross-entropy loss in NumPy with proper input validation.',
+    prompt: [
+      'Write `softmax_cross_entropy(logits, labels)` so it returns the mean cross-entropy loss across a batch.',
+      'Treat this like an interview question: keep the implementation concise, validate the inputs, and avoid numerical overflow when computing the softmax terms.',
+    ],
+    signature: `def softmax_cross_entropy(logits, labels):
+    ...`,
+    requirements: [
+      '`logits` is a 2D NumPy array of shape `(N, C)`.',
+      '`labels` is a 1D NumPy array of shape `(N,)` with integer class ids in `[0, C - 1]`.',
+      'Return the mean cross-entropy loss over the batch.',
+      'The implementation must be numerically stable.',
+      'Raise `ValueError` on invalid shapes or invalid labels.',
+    ],
+    examples: [
+      {
+        label: 'Example',
+        lines: ['logits = [[2.0, 1.0, 0.1]]', 'labels = [0]'],
+        result: 'loss ~= 0.41703',
+      },
+    ],
+    hint: [
+      'Subtract the per-row maximum from `logits` before exponentiating.',
+      'Use `np.arange(N)` to gather the logit for the correct class in each row.',
+      'Compute the loss as `logsumexp - correct_class_logit`, then average across the batch.',
+      'Validate `ndim`, matching batch size, integer labels, non-empty shapes, and label range.',
+    ],
+    solutionNotes: [
+      'The stable trick is to shift each row by its maximum value before applying `exp`, which preserves the softmax probabilities while avoiding overflow.',
+      'Once shifted, the mean cross-entropy is just the average of `log(sum(exp(shifted))) - shifted[row, label]` across the batch.',
+    ],
+    solutionCode: `import numpy as np
+
+def softmax_cross_entropy(logits, labels):
+    logits = np.asarray(logits, dtype=np.float64)
+    labels = np.asarray(labels)
+
+    if logits.ndim != 2:
+        raise ValueError("logits must be a 2D array of shape (N, C)")
+    if labels.ndim != 1:
+        raise ValueError("labels must be a 1D array of shape (N,)")
+
+    batch_size, num_classes = logits.shape
+    if batch_size == 0:
+        raise ValueError("logits must contain at least one sample")
+    if num_classes == 0:
+        raise ValueError("logits must contain at least one class")
+    if labels.shape[0] != batch_size:
+        raise ValueError("labels must have the same batch size as logits")
+    if not np.issubdtype(labels.dtype, np.integer):
+        raise ValueError("labels must contain integer class ids")
+    if np.any(labels < 0) or np.any(labels >= num_classes):
+        raise ValueError("labels contain out-of-range class ids")
+
+    shifted = logits - np.max(logits, axis=1, keepdims=True)
+    logsumexp = np.log(np.sum(np.exp(shifted), axis=1))
+    correct_class_logits = shifted[np.arange(batch_size), labels]
+    losses = logsumexp - correct_class_logits
+
+    return float(np.mean(losses))`,
+    starterCode: `import numpy as np
+
+def softmax_cross_entropy(logits, labels):
+    logits = np.asarray(logits)
+    labels = np.asarray(labels)
+
+    # TODO:
+    # 1. Validate the input shapes and labels.
+    # 2. Compute a numerically stable mean cross-entropy loss.
+    raise NotImplementedError("Implement softmax_cross_entropy")
+
+sample_logits = np.array([[2.0, 1.0, 0.1]])
+sample_labels = np.array([0])
+
+print(f"{softmax_cross_entropy(sample_logits, sample_labels):.5f}")`,
+    packages: ['numpy'],
+    tags: ['NumPy', 'Numerical Stability', 'Interview Practice'],
+  },
+] as const;

--- a/src/lib/pyodide-loader.ts
+++ b/src/lib/pyodide-loader.ts
@@ -2,6 +2,7 @@ const PYODIDE_INDEX_URL = 'https://cdn.jsdelivr.net/pyodide/v0.28.3/full/';
 const PYODIDE_SCRIPT_SRC = `${PYODIDE_INDEX_URL}pyodide.js`;
 
 export interface PyodideRuntime {
+  loadPackage?: (packages: string | string[]) => Promise<void>;
   runPythonAsync(code: string): Promise<unknown>;
 }
 

--- a/src/lib/python-runner.ts
+++ b/src/lib/python-runner.ts
@@ -1,0 +1,82 @@
+import type { PyodideRuntime } from './pyodide-loader';
+
+const EXECUTION_PREFIX = `
+import contextlib
+import io
+import traceback
+`;
+
+const PYTHON_PACKAGE_PATTERNS = [
+  {
+    name: 'numpy',
+    pattern: /\b(?:import\s+numpy|from\s+numpy\s+import)\b/,
+  },
+] as const;
+
+function escapePythonTripleQuotedString(source: string) {
+  return source.replace(/\\/g, '\\\\').replace(/"""/g, '\\"""');
+}
+
+async function ensurePythonPackages(
+  runtime: PyodideRuntime,
+  code: string,
+  explicitPackages: readonly string[] = [],
+) {
+  if (typeof runtime.loadPackage !== 'function') {
+    return;
+  }
+
+  const packageNames = new Set(explicitPackages);
+  for (const packageMatcher of PYTHON_PACKAGE_PATTERNS) {
+    if (packageMatcher.pattern.test(code)) {
+      packageNames.add(packageMatcher.name);
+    }
+  }
+
+  if (packageNames.size === 0) {
+    return;
+  }
+
+  await runtime.loadPackage(Array.from(packageNames));
+}
+
+export async function runPythonSnippet(
+  runtime: PyodideRuntime,
+  code: string,
+  packages: readonly string[] = [],
+) {
+  await ensurePythonPackages(runtime, code, packages);
+
+  const escapedCode = escapePythonTripleQuotedString(code);
+  const result = await runtime.runPythonAsync(`
+${EXECUTION_PREFIX}
+_stdout_buffer = io.StringIO()
+_stderr_buffer = io.StringIO()
+_execution_result = None
+
+with contextlib.redirect_stdout(_stdout_buffer), contextlib.redirect_stderr(_stderr_buffer):
+    try:
+        exec("""${escapedCode}""", {})
+    except Exception:
+        traceback.print_exc()
+
+(_stdout_buffer.getvalue(), _stderr_buffer.getvalue())
+`);
+
+  const normalizedResult =
+    typeof result === 'object' &&
+    result !== null &&
+    'toJs' in result &&
+    typeof result.toJs === 'function'
+      ? result.toJs()
+      : result;
+
+  if (!Array.isArray(normalizedResult)) {
+    return { stdout: '', stderr: 'Unexpected result returned from Python runtime.' };
+  }
+
+  return {
+    stdout: String(normalizedResult[0] ?? ''),
+    stderr: String(normalizedResult[1] ?? ''),
+  };
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 import HomeLayout from '../layouts/HomeLayout.astro';
 import { getPostsBySection } from '../lib/content';
+import CodePracticeLab from '../components/CodePracticeLab';
+import { codePracticeProblems } from '../lib/code-practice';
 
 const paperPosts = await getPostsBySection('paper-shorts', 'desc');
 const revisionPosts = (await getPostsBySection('revision-notes', 'desc')).filter(
@@ -15,7 +17,8 @@ const totalEntries =
   blogPosts.length +
   buildIntuitionPosts.length +
   revisionPosts.length +
-  aiPosts.length;
+  aiPosts.length +
+  codePracticeProblems.length;
 
 const sectionCards = [
   {
@@ -57,6 +60,14 @@ const sectionCards = [
     title: 'AI Generated Reports',
     description: 'Audio or text reports created by AI.',
     count: aiPosts.length,
+  },
+  {
+    id: 'code',
+    href: '#code',
+    command: 'code',
+    title: 'Code',
+    description: 'Interview-style Python practice problems with hints, hidden solutions, and a runnable editor.',
+    count: codePracticeProblems.length,
   },
 ] as const;
 
@@ -155,13 +166,14 @@ const formatDate = (date: Date) =>
         <nav class="home-command-bar home-command-bar--hero" aria-label="Homepage sections">
           <a href="#about">/about</a>
           <a href="#latest">/latest</a>
+          <a href="#code">/code</a>
         </nav>
       </div>
 
       <div class="home-meta-panel" aria-label="Site overview">
         <div class="home-meta-panel__item">
           <span class="home-meta-panel__label">Sections</span>
-          <strong>05</strong>
+          <strong>{String(sectionCards.length).padStart(2, '0')}</strong>
         </div>
         <div class="home-meta-panel__item">
           <span class="home-meta-panel__label">Entries</span>
@@ -247,5 +259,21 @@ const formatDate = (date: Date) =>
         </article>
       ))}
     </div>
+  </section>
+
+  <section class="home-code-lab" id="code">
+    <article class="home-panel home-panel--section-intro">
+      <p class="home-panel__eyebrow">Code</p>
+      <div class="home-section-heading">
+        <h2>Interview practice lab</h2>
+        <p>
+          A reusable coding area for interview prep. Each problem includes the prompt, a runnable
+          Python workspace, a hint you can reveal when you need it, and a hidden solution you can
+          inspect after you take a pass yourself.
+        </p>
+      </div>
+    </article>
+
+    <CodePracticeLab client:visible problems={codePracticeProblems} />
   </section>
 </HomeLayout>

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CodePracticeLab from '../src/components/CodePracticeLab';
+import type { CodePracticeProblem } from '../src/lib/code-practice';
+
+const { loadPyodideRuntime } = vi.hoisted(() => ({
+  loadPyodideRuntime: vi.fn(),
+}));
+
+vi.mock('../src/lib/pyodide-loader', () => ({
+  loadPyodideRuntime,
+}));
+
+const testProblem: CodePracticeProblem = {
+  id: 'stable-softmax-cross-entropy',
+  order: 1,
+  title: 'Stable softmax cross-entropy',
+  difficulty: 'Medium',
+  summary: 'Implement a stable softmax loss.',
+  prompt: ['Prompt copy'],
+  signature: 'def softmax_cross_entropy(logits, labels):\n    ...',
+  requirements: ['Do the thing'],
+  examples: [
+    {
+      label: 'Example',
+      lines: ['logits = [[2.0, 1.0, 0.1]]', 'labels = [0]'],
+      result: 'loss ~= 0.41703',
+    },
+  ],
+  hint: ['Subtract the row max first.'],
+  solutionNotes: ['Use a row-wise max shift before the exponentials.'],
+  solutionCode: 'print("solution")',
+  starterCode: 'print("starter")',
+  packages: ['numpy'],
+  tags: ['NumPy'],
+};
+
+describe('CodePracticeLab', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    globalThis.IntersectionObserver = class {
+      private callback: IntersectionObserverCallback;
+      readonly root = null;
+      readonly rootMargin = '0px';
+      readonly thresholds = [0];
+
+      constructor(callback: IntersectionObserverCallback) {
+        this.callback = callback;
+      }
+
+      disconnect() {}
+
+      observe(target: Element) {
+        this.callback([{ isIntersecting: true, target } as IntersectionObserverEntry], this);
+      }
+
+      unobserve() {}
+
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof IntersectionObserver;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function flushAsyncWork() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  async function render() {
+    await act(async () => {
+      root.render(<CodePracticeLab problems={[testProblem]} />);
+    });
+    await flushAsyncWork();
+  }
+
+  it('reveals the hint and solution only after the user clicks', async () => {
+    loadPyodideRuntime.mockResolvedValueOnce({
+      runPythonAsync: vi.fn(),
+    });
+
+    await render();
+
+    expect(container.textContent).toContain('Problem 1: Stable softmax cross-entropy');
+    expect(container.textContent).not.toContain('Subtract the row max first.');
+    expect(container.textContent).not.toContain('print("solution")');
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const hintButton = buttons.find((button) => button.textContent === 'Show hint');
+    const solutionButton = buttons.find((button) => button.textContent === 'Reveal solution');
+
+    await act(async () => {
+      hintButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      solutionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Subtract the row max first.');
+    expect(container.textContent).toContain('print("solution")');
+  });
+
+  it('loads required packages and prints run output', async () => {
+    const loadPackage = vi.fn().mockResolvedValue(undefined);
+    loadPyodideRuntime.mockResolvedValueOnce({
+      loadPackage,
+      runPythonAsync: vi.fn().mockResolvedValue({
+        toJs: () => ['0.41703\n', ''],
+      }),
+    });
+
+    await render();
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const runButton = buttons.find((button) => button.textContent === 'Run code');
+
+    await act(async () => {
+      runButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushAsyncWork();
+
+    expect(loadPackage).toHaveBeenCalledWith(['numpy']);
+    expect(container.textContent).toContain('0.41703');
+  });
+});


### PR DESCRIPTION
## What changed
- add a new `Code` section to the homepage with a reusable interview-practice lab
- add the first problem, `Stable softmax cross-entropy`, with hidden hint and solution reveals
- reuse the Pyodide runner through a shared helper so the new lab and existing playgrounds share execution logic

## Why it changed
- create a recurring, LeetCode-style space on the front page for Python interview practice
- make it easy to add more problems later by appending typed entries to the shared problem list

## How it was tested
- `npm run ci`
- pre-push hook reran `npm run ci` successfully