### PR TITLE
Move code lab to dedicated section page

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2178,12 +2178,6 @@ body.home-page {
   margin-bottom: 0;
 }
 
-.home-code-lab {
-  display: grid;
-  gap: 1rem;
-  margin-top: 1.75rem;
-}
-
 .code-practice-lab {
   display: grid;
   gap: 1rem;
@@ -2528,6 +2522,34 @@ body.home-page {
   margin-top: 1rem;
 }
 
+.code-page {
+  width: min(100%, 74rem);
+  margin: 0 auto;
+  padding-top: 6.25rem;
+}
+
+.code-page__intro {
+  margin-bottom: 2rem;
+}
+
+.code-page__intro h1 {
+  margin: 0;
+}
+
+.code-page__intro p {
+  margin: 1rem 0 0;
+  max-width: 68rem;
+}
+
+.code-page__eyebrow {
+  margin: 0 0 0.45rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--accent-color);
+}
+
 @media (max-width: 820px) {
   .python-playground__header,
   .python-playground__walkthrough-header,
@@ -2551,5 +2573,9 @@ body.home-page {
 
   .code-practice-lab__output {
     display: grid;
+  }
+
+  .code-page {
+    padding-top: 5.75rem;
   }
 }

--- a/src/pages/code.astro
+++ b/src/pages/code.astro
@@ -1,0 +1,33 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import PageControls from '../components/PageControls.astro';
+import CodePracticeLab from '../components/CodePracticeLab';
+import { codePracticeProblems } from '../lib/code-practice';
+---
+
+<BaseLayout
+  title="Code"
+  description="A dedicated interview-practice section with runnable Python problems, hints, and hidden solutions."
+>
+  <PageControls showHomeButton={true} />
+  <div class="page-layout">
+    <main class="page-content code-page" aria-label="Code interview practice">
+      <section class="code-page__intro">
+        <p class="code-page__eyebrow">Code</p>
+        <h1>Interview practice lab</h1>
+        <p>
+          A dedicated space for interview-style Python problems. Each problem comes with the prompt,
+          a runnable workspace, a hint you can reveal when you want a nudge, and a hidden solution
+          you can inspect after taking your own pass.
+        </p>
+        <p>
+          The template is reusable, so new problems can be added without changing the UI. Right now
+          the page starts with a numerically stable softmax cross-entropy problem and is ready to
+          grow from there.
+        </p>
+      </section>
+
+      <CodePracticeLab client:visible problems={codePracticeProblems} />
+    </main>
+  </div>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import HomeLayout from '../layouts/HomeLayout.astro';
 import { getPostsBySection } from '../lib/content';
-import CodePracticeLab from '../components/CodePracticeLab';
 import { codePracticeProblems } from '../lib/code-practice';
 
 const paperPosts = await getPostsBySection('paper-shorts', 'desc');
@@ -63,7 +62,7 @@ const sectionCards = [
   },
   {
     id: 'code',
-    href: '#code',
+    href: '/code.html',
     command: 'code',
     title: 'Code',
     description: 'Interview-style Python practice problems with hints, hidden solutions, and a runnable editor.',
@@ -166,7 +165,7 @@ const formatDate = (date: Date) =>
         <nav class="home-command-bar home-command-bar--hero" aria-label="Homepage sections">
           <a href="#about">/about</a>
           <a href="#latest">/latest</a>
-          <a href="#code">/code</a>
+          <a href="/code.html">/code</a>
         </nav>
       </div>
 
@@ -261,19 +260,4 @@ const formatDate = (date: Date) =>
     </div>
   </section>
 
-  <section class="home-code-lab" id="code">
-    <article class="home-panel home-panel--section-intro">
-      <p class="home-panel__eyebrow">Code</p>
-      <div class="home-section-heading">
-        <h2>Interview practice lab</h2>
-        <p>
-          A reusable coding area for interview prep. Each problem includes the prompt, a runnable
-          Python workspace, a hint you can reveal when you need it, and a hidden solution you can
-          inspect after you take a pass yourself.
-        </p>
-      </div>
-    </article>
-
-    <CodePracticeLab client:visible problems={codePracticeProblems} />
-  </section>
 </HomeLayout>


### PR DESCRIPTION
## What changed
- move the interview practice lab off the homepage and onto a dedicated `/code.html` section page
- keep the homepage `Code` entry as a navigation link to the new section
- add page-level intro styling for the dedicated Code section

## Why it changed
- make the practice experience feel like the other site sections instead of embedding it directly on the front page

## How it was tested
- `npm run ci`
- pre-push hook reran `npm run ci` successfully