### PR TITLE
Rework code section into index and problem pages

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2180,11 +2180,11 @@ body.home-page {
 
 .code-practice-lab {
   display: grid;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
-.code-practice-lab h3,
-.code-practice-lab h4,
+.code-practice-lab h1,
+.code-practice-lab h2,
 .code-practice-lab p,
 .code-practice-lab li,
 .code-practice-lab button,
@@ -2197,14 +2197,8 @@ body.home-page {
   font-family: var(--font-mono);
 }
 
-.code-practice-lab__problem-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.code-practice-lab__problem-strip button,
-.code-practice-lab__reveal-actions button,
+.code-practice-lab__hero-actions button,
+.code-practice-lab__solution-header button,
 .code-practice-lab__actions button {
   appearance: none;
   border: 1px solid rgba(127, 197, 255, 0.25);
@@ -2219,57 +2213,29 @@ body.home-page {
     background-color 0.18s ease;
 }
 
-:root[data-theme="dark"] .code-practice-lab__problem-strip button,
-:root[data-theme="dark"] .code-practice-lab__reveal-actions button,
+:root[data-theme="dark"] .code-practice-lab__hero-actions button,
+:root[data-theme="dark"] .code-practice-lab__solution-header button,
 :root[data-theme="dark"] .code-practice-lab__actions button {
   border-color: rgba(255, 228, 92, 0.24);
   background: rgba(22, 18, 2, 0.82);
   color: #fff7cf;
 }
 
-.code-practice-lab__problem-strip button:hover,
-.code-practice-lab__reveal-actions button:hover,
+.code-practice-lab__hero-actions button:hover,
+.code-practice-lab__solution-header button:hover,
 .code-practice-lab__actions button:hover {
   transform: translateY(-1px);
   border-color: rgba(127, 197, 255, 0.55);
 }
 
-:root[data-theme="dark"] .code-practice-lab__problem-strip button:hover,
-:root[data-theme="dark"] .code-practice-lab__reveal-actions button:hover,
+:root[data-theme="dark"] .code-practice-lab__hero-actions button:hover,
+:root[data-theme="dark"] .code-practice-lab__solution-header button:hover,
 :root[data-theme="dark"] .code-practice-lab__actions button:hover {
   border-color: rgba(255, 228, 92, 0.52);
 }
 
-.code-practice-lab__problem-strip button.is-active {
-  background: rgba(38, 84, 165, 0.9);
-  border-color: rgba(151, 208, 255, 0.7);
-}
-
-:root[data-theme="dark"] .code-practice-lab__problem-strip button.is-active {
-  background: rgba(96, 76, 8, 0.92);
-  border-color: rgba(255, 228, 92, 0.58);
-}
-
-.code-practice-lab__problem-strip button span,
-.code-practice-lab__problem-strip button strong {
-  display: block;
-}
-
-.code-practice-lab__problem-strip button span {
-  margin-bottom: 0.2rem;
-  font-size: 0.74rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  opacity: 0.78;
-}
-
+.code-practice-lab__hero,
 .code-practice-lab__workspace {
-  display: grid;
-  grid-template-columns: minmax(0, 1.02fr) minmax(0, 0.98fr);
-  gap: 1rem;
-}
-
-.code-practice-lab__panel {
   padding: 1.25rem;
   border-radius: 24px;
   border: 1px solid rgba(118, 169, 255, 0.18);
@@ -2279,7 +2245,8 @@ body.home-page {
   color: #dff0ff;
 }
 
-:root[data-theme="dark"] .code-practice-lab__panel {
+:root[data-theme="dark"] .code-practice-lab__hero,
+:root[data-theme="dark"] .code-practice-lab__workspace {
   border-color: rgba(255, 228, 92, 0.2);
   background:
     linear-gradient(180deg, rgba(10, 10, 10, 0.98), rgba(19, 16, 4, 0.98));
@@ -2287,6 +2254,7 @@ body.home-page {
   color: #fff7cf;
 }
 
+.code-practice-lab__hero-header,
 .code-practice-lab__header {
   display: flex;
   justify-content: space-between;
@@ -2294,8 +2262,8 @@ body.home-page {
   gap: 1rem;
 }
 
-.code-practice-lab__header h3,
-.code-practice-lab__header h4 {
+.code-practice-lab__title-block h1,
+.code-practice-lab__header h2 {
   margin: 0;
 }
 
@@ -2309,6 +2277,10 @@ body.home-page {
 
 :root[data-theme="dark"] .code-practice-lab__eyebrow {
   color: #ffe45c;
+}
+
+.code-practice-lab__title-block {
+  min-width: 0;
 }
 
 .code-practice-lab__summary,
@@ -2328,6 +2300,7 @@ body.home-page {
 .code-practice-lab__summary {
   margin: 0.45rem 0 0;
   line-height: 1.55;
+  max-width: 52rem;
 }
 
 .code-practice-lab__difficulty {
@@ -2343,24 +2316,12 @@ body.home-page {
   background: rgba(35, 28, 2, 0.78);
 }
 
-.code-practice-lab__tags {
+.code-practice-lab__hero-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
-  margin-top: 1rem;
-}
-
-.code-practice-lab__tags span {
-  padding: 0.32rem 0.65rem;
-  border-radius: 999px;
-  background: rgba(127, 197, 255, 0.1);
-  border: 1px solid rgba(127, 197, 255, 0.16);
-  font-size: 0.8rem;
-}
-
-:root[data-theme="dark"] .code-practice-lab__tags span {
-  background: rgba(255, 228, 92, 0.08);
-  border-color: rgba(255, 228, 92, 0.16);
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
 }
 
 .code-practice-lab__copy {
@@ -2372,8 +2333,9 @@ body.home-page {
   line-height: 1.65;
 }
 
-.code-practice-lab__block,
-.code-practice-lab__reveal-panel,
+.code-practice-lab__hint-panel,
+.code-practice-lab__solution-panel,
+.code-practice-lab__spec-card,
 .code-practice-lab__output > div {
   margin-top: 1rem;
   padding: 1rem;
@@ -2382,11 +2344,36 @@ body.home-page {
   background: rgba(4, 14, 28, 0.72);
 }
 
-:root[data-theme="dark"] .code-practice-lab__block,
-:root[data-theme="dark"] .code-practice-lab__reveal-panel,
+:root[data-theme="dark"] .code-practice-lab__hint-panel,
+:root[data-theme="dark"] .code-practice-lab__solution-panel,
+:root[data-theme="dark"] .code-practice-lab__spec-card,
 :root[data-theme="dark"] .code-practice-lab__output > div {
   border-color: rgba(255, 228, 92, 0.16);
   background: rgba(11, 10, 2, 0.78);
+}
+
+.code-practice-lab__hint-panel {
+  max-width: 28rem;
+  margin-left: auto;
+}
+
+.code-practice-lab__solution-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.code-practice-lab__prompt {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.code-practice-lab__spec-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
 }
 
 .code-practice-lab__section-label,
@@ -2398,9 +2385,9 @@ body.home-page {
   letter-spacing: 0.12em;
 }
 
-.code-practice-lab__block pre,
+.code-practice-lab__spec-card pre,
 .code-practice-lab__example pre,
-.code-practice-lab__reveal-panel pre,
+.code-practice-lab__solution-panel pre,
 .code-practice-lab__output pre {
   margin: 0;
   white-space: pre-wrap;
@@ -2431,7 +2418,6 @@ body.home-page {
   background: rgba(8, 8, 8, 0.72);
 }
 
-.code-practice-lab__reveal-actions,
 .code-practice-lab__actions {
   display: flex;
   flex-wrap: wrap;
@@ -2492,7 +2478,7 @@ body.home-page {
 
 .code-practice-lab__editor {
   width: 100%;
-  min-height: 24rem;
+  min-height: 34rem;
   resize: vertical;
   box-sizing: border-box;
   border-radius: 16px;
@@ -2522,32 +2508,140 @@ body.home-page {
   margin-top: 1rem;
 }
 
-.code-page {
-  width: min(100%, 74rem);
-  margin: 0 auto;
-  padding-top: 6.25rem;
+.code-index {
+  display: grid;
+  gap: 1.5rem;
 }
 
-.code-page__intro {
-  margin-bottom: 2rem;
+.code-index__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
-.code-page__intro h1 {
+.code-index__header h1 {
   margin: 0;
 }
 
-.code-page__intro p {
-  margin: 1rem 0 0;
-  max-width: 68rem;
+.code-index__header > div > p:last-child {
+  margin: 0.85rem 0 0;
+  max-width: 44rem;
 }
 
-.code-page__eyebrow {
+.code-index__eyebrow {
   margin: 0 0 0.45rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.78rem;
   font-weight: 700;
   color: var(--accent-color);
+}
+
+.code-index__count {
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(125, 162, 247, 0.18);
+  background: var(--panel-bg);
+  text-align: right;
+}
+
+.code-index__count span,
+.code-index__count strong {
+  display: block;
+}
+
+.code-index__count span {
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-secondary-color);
+}
+
+.code-index__count strong {
+  margin-top: 0.35rem;
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  color: var(--text-color);
+}
+
+.code-index__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.code-index__card {
+  display: block;
+  padding: 1.1rem 1.15rem;
+  border-radius: 22px;
+  background: var(--panel-bg);
+  border: 1px solid rgba(125, 162, 247, 0.16);
+  box-shadow: var(--button-shadow);
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.code-index__card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--button-shadow-hover);
+  border-color: rgba(125, 162, 247, 0.32);
+  text-decoration: none;
+}
+
+.code-index__card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.code-index__card-header p,
+.code-index__card-header span {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-secondary-color);
+}
+
+.code-index__card h2 {
+  margin: 0.7rem 0 0;
+}
+
+.code-index__card > p {
+  margin: 0.75rem 0 0;
+}
+
+.code-index__card strong {
+  display: inline-block;
+  margin-top: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.code-problem-page {
+  padding: 6.25rem 1rem 2rem;
+}
+
+.code-problem-page__shell {
+  width: min(100%, 86rem);
+  margin: 0 auto;
+}
+
+.code-problem-page__back-link {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text-secondary-color);
 }
 
 @media (max-width: 820px) {
@@ -2564,8 +2658,9 @@ body.home-page {
     display: grid;
   }
 
-  .code-practice-lab__workspace,
+  .code-practice-lab__hero-header,
   .code-practice-lab__header,
+  .code-practice-lab__spec-grid,
   .code-practice-lab__output {
     grid-template-columns: 1fr;
     flex-direction: column;
@@ -2575,7 +2670,16 @@ body.home-page {
     display: grid;
   }
 
-  .code-page {
+  .code-index__header {
+    flex-direction: column;
+  }
+
+  .code-index__count {
+    width: 100%;
+    text-align: left;
+  }
+
+  .code-problem-page {
     padding-top: 5.75rem;
   }
 }

--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -5,16 +5,38 @@ import { runPythonSnippet } from '../lib/python-runner';
 import type { CodePracticeProblem } from '../lib/code-practice';
 
 interface CodePracticeLabProps {
-  problems: readonly CodePracticeProblem[];
+  problem: CodePracticeProblem;
 }
 
-export default function CodePracticeLab({ problems }: CodePracticeLabProps) {
+function formatPackages(packages: readonly string[] = []) {
+  return packages.map((packageName) => {
+    if (packageName === 'numpy') {
+      return 'NumPy';
+    }
+    return packageName;
+  });
+}
+
+function getRuntimeNote(packages: readonly string[] = []) {
+  const packageLabels = formatPackages(packages);
+  if (packageLabels.length === 0) {
+    return 'The in-browser Python runtime executes this workspace locally in the browser.';
+  }
+
+  if (packageLabels.length === 1) {
+    return `${packageLabels[0]} is available and will load automatically the first time you run the code.`;
+  }
+
+  const leadingPackages = packageLabels.slice(0, -1).join(', ');
+  const trailingPackage = packageLabels.at(-1);
+  return `${leadingPackages}, and ${trailingPackage} are available and will load automatically the first time you run the code.`;
+}
+
+export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const containerRef = useRef<HTMLElement | null>(null);
   const runtimeRef = useRef<PyodideRuntime | null>(null);
   const loadingRef = useRef(false);
-  const [selectedProblemIndex, setSelectedProblemIndex] = useState(0);
-  const selectedProblem = problems[selectedProblemIndex] ?? problems[0];
-  const [code, setCode] = useState(selectedProblem?.starterCode ?? '');
+  const [code, setCode] = useState(problem.starterCode);
   const [output, setOutput] = useState('');
   const [errorOutput, setErrorOutput] = useState('');
   const [showHint, setShowHint] = useState(false);
@@ -26,16 +48,12 @@ export default function CodePracticeLab({ problems }: CodePracticeLabProps) {
   const [isRunning, setIsRunning] = useState(false);
 
   useEffect(() => {
-    if (!selectedProblem) {
-      return;
-    }
-
-    setCode(selectedProblem.starterCode);
+    setCode(problem.starterCode);
     setOutput('');
     setErrorOutput('');
     setShowHint(false);
     setShowSolution(false);
-  }, [selectedProblem]);
+  }, [problem]);
 
   useEffect(() => {
     let didCancel = false;
@@ -111,11 +129,7 @@ export default function CodePracticeLab({ problems }: CodePracticeLabProps) {
     };
   }, []);
 
-  if (!selectedProblem) {
-    return null;
-  }
-
-  const editorId = `${selectedProblem.id}-editor`;
+  const editorId = `${problem.id}-editor`;
 
   async function handleRun() {
     if (!runtimeRef.current) {
@@ -131,7 +145,7 @@ export default function CodePracticeLab({ problems }: CodePracticeLabProps) {
       const result = await runPythonSnippet(
         runtimeRef.current,
         code,
-        selectedProblem.packages ?? [],
+        problem.packages ?? [],
       );
 
       startTransition(() => {
@@ -146,183 +160,166 @@ export default function CodePracticeLab({ problems }: CodePracticeLabProps) {
   }
 
   function handleReset() {
-    setCode(selectedProblem.starterCode);
+    setCode(problem.starterCode);
     setOutput('');
     setErrorOutput('');
   }
 
   return (
     <section className="code-practice-lab" ref={containerRef}>
-      <div className="code-practice-lab__problem-strip" aria-label="Practice problems">
-        {problems.map((problem, index) => (
-          <button
-            key={problem.id}
-            className={index === selectedProblemIndex ? 'is-active' : undefined}
-            type="button"
-            onClick={() => setSelectedProblemIndex(index)}
-          >
-            <span>{`Problem ${String(problem.order).padStart(2, '0')}`}</span>
-            <strong>{problem.title}</strong>
-          </button>
-        ))}
-      </div>
-
-      <div className="code-practice-lab__workspace">
-        <article className="code-practice-lab__panel code-practice-lab__panel--problem">
-          <div className="code-practice-lab__header">
-            <div>
-              <p className="code-practice-lab__eyebrow">Interview Practice</p>
-              <h3>{`Problem ${selectedProblem.order}: ${selectedProblem.title}`}</h3>
-              <p className="code-practice-lab__summary">{selectedProblem.summary}</p>
-            </div>
-            <span className="code-practice-lab__difficulty">{selectedProblem.difficulty}</span>
+      <article className="code-practice-lab__hero">
+        <div className="code-practice-lab__hero-header">
+          <div className="code-practice-lab__title-block">
+            <p className="code-practice-lab__eyebrow">{`Problem ${String(problem.order).padStart(2, '0')}`}</p>
+            <h1>{problem.title}</h1>
+            <p className="code-practice-lab__summary">{problem.summary}</p>
           </div>
 
-          {selectedProblem.tags && selectedProblem.tags.length > 0 && (
-            <div className="code-practice-lab__tags" aria-label="Problem topics">
-              {selectedProblem.tags.map((tag) => (
-                <span key={tag}>{tag}</span>
-              ))}
-            </div>
-          )}
-
-          <div className="code-practice-lab__copy">
-            {selectedProblem.prompt.map((paragraph) => (
-              <p key={paragraph}>{paragraph}</p>
-            ))}
-          </div>
-
-          <div className="code-practice-lab__block">
-            <p className="code-practice-lab__section-label">Implement</p>
-            <pre>
-              <code>{selectedProblem.signature}</code>
-            </pre>
-          </div>
-
-          <div className="code-practice-lab__block">
-            <p className="code-practice-lab__section-label">Where</p>
-            <ul className="code-practice-lab__list">
-              {selectedProblem.requirements.map((requirement) => (
-                <li key={requirement}>{requirement}</li>
-              ))}
-            </ul>
-          </div>
-
-          <div className="code-practice-lab__block">
-            <p className="code-practice-lab__section-label">Examples</p>
-            <div className="code-practice-lab__examples">
-              {selectedProblem.examples.map((example) => (
-                <div key={example.label} className="code-practice-lab__example">
-                  <p>{example.label}</p>
-                  <pre>
-                    <code>{`${example.lines.join('\n')}\n\n${example.result}`}</code>
-                  </pre>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="code-practice-lab__reveal-actions">
+          <div className="code-practice-lab__hero-actions">
+            <span className="code-practice-lab__difficulty">{problem.difficulty}</span>
             <button
               type="button"
               aria-expanded={showHint}
               onClick={() => setShowHint((current) => !current)}
             >
-              {showHint ? 'Hide hint' : 'Show hint'}
+              {showHint ? 'Hide hint' : 'Hint'}
             </button>
             <button
               type="button"
               aria-expanded={showSolution}
               onClick={() => setShowSolution((current) => !current)}
             >
-              {showSolution ? 'Hide solution' : 'Reveal solution'}
+              {showSolution ? 'Hide solution' : 'Solution'}
             </button>
           </div>
+        </div>
 
-          {showHint && (
-            <div className="code-practice-lab__reveal-panel">
-              <p className="code-practice-lab__section-label">Hint</p>
+        {showHint && (
+          <div className="code-practice-lab__hint-panel">
+            <p className="code-practice-lab__section-label">Hint</p>
+            <ul className="code-practice-lab__list">
+              {problem.hint.map((hintLine) => (
+                <li key={hintLine}>{hintLine}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {showSolution && (
+          <div className="code-practice-lab__solution-panel">
+            <div className="code-practice-lab__solution-header">
+              <p className="code-practice-lab__section-label">Solution</p>
+              <button type="button" onClick={() => setShowSolution(false)}>
+                Collapse
+              </button>
+            </div>
+
+            <div className="code-practice-lab__copy">
+              {problem.solutionNotes.map((note) => (
+                <p key={note}>{note}</p>
+              ))}
+            </div>
+            <pre>
+              <code>{problem.solutionCode}</code>
+            </pre>
+          </div>
+        )}
+
+        <div className="code-practice-lab__prompt">
+          <div className="code-practice-lab__copy">
+            {problem.prompt.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+
+          <div className="code-practice-lab__spec-grid">
+            <article className="code-practice-lab__spec-card">
+              <p className="code-practice-lab__section-label">Implement</p>
+              <pre>
+                <code>{problem.signature}</code>
+              </pre>
+            </article>
+
+            <article className="code-practice-lab__spec-card">
+              <p className="code-practice-lab__section-label">Requirements</p>
               <ul className="code-practice-lab__list">
-                {selectedProblem.hint.map((hintLine) => (
-                  <li key={hintLine}>{hintLine}</li>
+                {problem.requirements.map((requirement) => (
+                  <li key={requirement}>{requirement}</li>
                 ))}
               </ul>
-            </div>
-          )}
+            </article>
 
-          {showSolution && (
-            <div className="code-practice-lab__reveal-panel">
-              <p className="code-practice-lab__section-label">Solution</p>
-              <div className="code-practice-lab__copy">
-                {selectedProblem.solutionNotes.map((note) => (
-                  <p key={note}>{note}</p>
+            <article className="code-practice-lab__spec-card">
+              <p className="code-practice-lab__section-label">Examples</p>
+              <div className="code-practice-lab__examples">
+                {problem.examples.map((example) => (
+                  <div key={example.label} className="code-practice-lab__example">
+                    <p>{example.label}</p>
+                    <pre>
+                      <code>{`${example.lines.join('\n')}\n\n${example.result}`}</code>
+                    </pre>
+                  </div>
                 ))}
               </div>
-              <pre>
-                <code>{selectedProblem.solutionCode}</code>
-              </pre>
-            </div>
-          )}
-        </article>
-
-        <article className="code-practice-lab__panel code-practice-lab__panel--editor">
-          <div className="code-practice-lab__header code-practice-lab__header--editor">
-            <div>
-              <p className="code-practice-lab__eyebrow">Python Workspace</p>
-              <h4>Run your solution</h4>
-            </div>
-            <p
-              className={`code-practice-lab__status code-practice-lab__status--${status}`}
-              aria-live="polite"
-            >
-              {statusMessage}
-            </p>
+            </article>
           </div>
+        </div>
+      </article>
 
-          <p className="code-practice-lab__runtime-note">
-            NumPy is available for this problem and will load automatically the first time you run
-            it.
+      <article className="code-practice-lab__workspace">
+        <div className="code-practice-lab__header code-practice-lab__header--workspace">
+          <div>
+            <p className="code-practice-lab__eyebrow">Python Workspace</p>
+            <h2>Run your solution</h2>
+          </div>
+          <p
+            className={`code-practice-lab__status code-practice-lab__status--${status}`}
+            aria-live="polite"
+          >
+            {statusMessage}
           </p>
+        </div>
 
-          <div className="code-practice-lab__promptbar">
-            <span className="code-practice-lab__dot" />
-            <span className="code-practice-lab__dot" />
-            <span className="code-practice-lab__dot" />
-            <span className="code-practice-lab__prompt">python interview_practice.py</span>
+        <p className="code-practice-lab__runtime-note">{getRuntimeNote(problem.packages ?? [])}</p>
+
+        <div className="code-practice-lab__promptbar">
+          <span className="code-practice-lab__dot" />
+          <span className="code-practice-lab__dot" />
+          <span className="code-practice-lab__dot" />
+          <span className="code-practice-lab__prompt">python interview_practice.py</span>
+        </div>
+
+        <label className="code-practice-lab__editor-label" htmlFor={editorId}>
+          Editable starter code
+        </label>
+        <textarea
+          id={editorId}
+          className="code-practice-lab__editor"
+          spellCheck={false}
+          value={code}
+          onChange={(event) => setCode(event.target.value)}
+        />
+
+        <div className="code-practice-lab__actions">
+          <button type="button" onClick={() => void handleRun()} disabled={status !== 'ready' || isRunning}>
+            {isRunning ? 'Running...' : 'Run code'}
+          </button>
+          <button type="button" onClick={handleReset}>
+            Reset starter
+          </button>
+        </div>
+
+        <div className="code-practice-lab__output">
+          <div>
+            <p>stdout</p>
+            <pre>{output || 'Run the starter code to see your printed output here.'}</pre>
           </div>
-
-          <label className="code-practice-lab__editor-label" htmlFor={editorId}>
-            Editable starter code
-          </label>
-          <textarea
-            id={editorId}
-            className="code-practice-lab__editor"
-            spellCheck={false}
-            value={code}
-            onChange={(event) => setCode(event.target.value)}
-          />
-
-          <div className="code-practice-lab__actions">
-            <button type="button" onClick={() => void handleRun()} disabled={status !== 'ready' || isRunning}>
-              {isRunning ? 'Running...' : 'Run code'}
-            </button>
-            <button type="button" onClick={handleReset}>
-              Reset starter
-            </button>
+          <div>
+            <p>stderr</p>
+            <pre>{errorOutput || 'Execution errors will appear here.'}</pre>
           </div>
-
-          <div className="code-practice-lab__output">
-            <div>
-              <p>stdout</p>
-              <pre>{output || 'Run the starter code to see your printed output here.'}</pre>
-            </div>
-            <div>
-              <p>stderr</p>
-              <pre>{errorOutput || 'Execution errors will appear here.'}</pre>
-            </div>
-          </div>
-        </article>
-      </div>
+        </div>
+      </article>
     </section>
   );
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
-const themeStylesheetHref = '/css/override.css?v=20260416-code-lab-1';
+const themeStylesheetHref = '/css/override.css?v=20260417-code-section-rework-1';
 ---
 
 <!DOCTYPE html>

--- a/src/lib/code-practice.ts
+++ b/src/lib/code-practice.ts
@@ -22,6 +22,18 @@ export interface CodePracticeProblem {
   tags?: readonly string[];
 }
 
+export const CODE_PRACTICE_SECTION_SUMMARY =
+  'Interview-style Python problems with runnable starter code, hints, and hidden solutions.';
+
+export function getCodePracticeProblemPath(problem: Pick<CodePracticeProblem, 'id'> | string) {
+  const problemId = typeof problem === 'string' ? problem : problem.id;
+  return `/code/${problemId}.html`;
+}
+
+export function getCodePracticeProblemById(problemId: string) {
+  return codePracticeProblems.find((problem) => problem.id === problemId);
+}
+
 export const codePracticeProblems: readonly CodePracticeProblem[] = [
   {
     id: 'stable-softmax-cross-entropy',

--- a/src/pages/code.astro
+++ b/src/pages/code.astro
@@ -1,33 +1,46 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import PageControls from '../components/PageControls.astro';
-import CodePracticeLab from '../components/CodePracticeLab';
-import { codePracticeProblems } from '../lib/code-practice';
+import PostLayout from '../layouts/PostLayout.astro';
+import {
+  CODE_PRACTICE_SECTION_SUMMARY,
+  codePracticeProblems,
+  getCodePracticeProblemPath,
+} from '../lib/code-practice';
+
+const problemCountLabel = String(codePracticeProblems.length).padStart(2, '0');
 ---
 
-<BaseLayout
+<PostLayout
   title="Code"
-  description="A dedicated interview-practice section with runnable Python problems, hints, and hidden solutions."
+  description="A dedicated index of coding interview practice problems with runnable Python workspaces."
 >
-  <PageControls showHomeButton={true} />
-  <div class="page-layout">
-    <main class="page-content code-page" aria-label="Code interview practice">
-      <section class="code-page__intro">
-        <p class="code-page__eyebrow">Code</p>
-        <h1>Interview practice lab</h1>
-        <p>
-          A dedicated space for interview-style Python problems. Each problem comes with the prompt,
-          a runnable workspace, a hint you can reveal when you want a nudge, and a hidden solution
-          you can inspect after taking your own pass.
-        </p>
-        <p>
-          The template is reusable, so new problems can be added without changing the UI. Right now
-          the page starts with a numerically stable softmax cross-entropy problem and is ready to
-          grow from there.
-        </p>
-      </section>
+  <section class="code-index">
+    <div class="code-index__header">
+      <div>
+        <p class="code-index__eyebrow">Code</p>
+        <h1>Interview practice</h1>
+        <p>{CODE_PRACTICE_SECTION_SUMMARY}</p>
+      </div>
 
-      <CodePracticeLab client:visible problems={codePracticeProblems} />
-    </main>
-  </div>
-</BaseLayout>
+      <div class="code-index__count">
+        <span>Problems</span>
+        <strong>{problemCountLabel}</strong>
+      </div>
+    </div>
+
+    <ul class="code-index__list">
+      {codePracticeProblems.map((problem) => (
+        <li>
+          <a class="code-index__card" href={getCodePracticeProblemPath(problem)}>
+            <div class="code-index__card-header">
+              <p>{`Problem ${String(problem.order).padStart(2, '0')}`}</p>
+              <span>{problem.difficulty}</span>
+            </div>
+            <h2>{problem.title}</h2>
+            <p>{problem.summary}</p>
+            <strong>Open problem</strong>
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
+</PostLayout>

--- a/src/pages/code/[id].astro
+++ b/src/pages/code/[id].astro
@@ -1,0 +1,35 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageControls from '../../components/PageControls.astro';
+import CodePracticeLab from '../../components/CodePracticeLab';
+import type { CodePracticeProblem } from '../../lib/code-practice';
+import { codePracticeProblems } from '../../lib/code-practice';
+
+export function getStaticPaths() {
+  return codePracticeProblems.map((problem) => ({
+    params: { id: problem.id },
+    props: { problem },
+  }));
+}
+
+interface Props {
+  problem: CodePracticeProblem;
+}
+
+const { problem } = Astro.props;
+---
+
+<BaseLayout title={problem.title} description={problem.summary}>
+  <PageControls showHomeButton={true} />
+  <main class="code-problem-page" aria-label={`${problem.title} interview practice`}>
+    <div class="code-problem-page__shell">
+      <p class="code-problem-page__back-link">
+        <a href="/code.html">All problems</a>
+        <span>/</span>
+        <span>{`Problem ${String(problem.order).padStart(2, '0')}`}</span>
+      </p>
+
+      <CodePracticeLab client:visible problem={problem} />
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import HomeLayout from '../layouts/HomeLayout.astro';
 import { getPostsBySection } from '../lib/content';
-import { codePracticeProblems } from '../lib/code-practice';
+import { CODE_PRACTICE_SECTION_SUMMARY, codePracticeProblems } from '../lib/code-practice';
 
 const paperPosts = await getPostsBySection('paper-shorts', 'desc');
 const revisionPosts = (await getPostsBySection('revision-notes', 'desc')).filter(
@@ -65,7 +65,7 @@ const sectionCards = [
     href: '/code.html',
     command: 'code',
     title: 'Code',
-    description: 'Interview-style Python practice problems with hints, hidden solutions, and a runnable editor.',
+    description: CODE_PRACTICE_SECTION_SUMMARY,
     count: codePracticeProblems.length,
   },
 ] as const;

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -91,7 +91,7 @@ describe('CodePracticeLab', () => {
 
   async function render() {
     await act(async () => {
-      root.render(<CodePracticeLab problems={[testProblem]} />);
+      root.render(<CodePracticeLab problem={testProblem} />);
     });
     await flushAsyncWork();
   }
@@ -103,13 +103,14 @@ describe('CodePracticeLab', () => {
 
     await render();
 
-    expect(container.textContent).toContain('Problem 1: Stable softmax cross-entropy');
+    expect(container.textContent).toContain('Problem 01');
+    expect(container.textContent).toContain('Stable softmax cross-entropy');
     expect(container.textContent).not.toContain('Subtract the row max first.');
     expect(container.textContent).not.toContain('print("solution")');
 
     const buttons = Array.from(container.querySelectorAll('button'));
-    const hintButton = buttons.find((button) => button.textContent === 'Show hint');
-    const solutionButton = buttons.find((button) => button.textContent === 'Reveal solution');
+    const hintButton = buttons.find((button) => button.textContent === 'Hint');
+    const solutionButton = buttons.find((button) => button.textContent === 'Solution');
 
     await act(async () => {
       hintButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));


### PR DESCRIPTION
## What changed
- turn `Code` into a proper section flow with a lightweight `/code.html` index page and dedicated per-problem pages
- redesign the individual coding problem page so the prompt sits up top and the editor/workspace dominates the screen
- remove tag clutter, keep hint controls at the top right, and make the solution a collapsible panel
- update shared routing helpers and tests for the new structure

## Why it changed
- make the Code section behave more like the other site sections instead of feeling like one oversized landing page
- improve readability and give the actual coding workspace visual priority

## How it was tested
- `npm run ci`
- pre-push hook reran `npm run ci` successfully