### PR TITLE
Add reading list section

### DIFF
--- a/public/assets/js/music.js
+++ b/public/assets/js/music.js
@@ -1,6 +1,6 @@
 const SPOTIFY_SRC =
   'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
-const YOUTUBE_VIDEO_IDS = ['kGuGH_UvvxA', 'z8Dz-IFFFY4'];
+const YOUTUBE_VIDEO_IDS = ['kGuGH_UvvxA', 'z8Dz-IFFFY4', 'tRsQsTMvPNg'];
 const YOUTUBE_SRC = `https://www.youtube.com/embed/${YOUTUBE_VIDEO_IDS[0]}?playlist=${YOUTUBE_VIDEO_IDS
   .slice(1)
   .join(',')}&rel=0`;

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1183,6 +1183,14 @@ h3,
   color: var(--text-secondary-color);
 }
 
+.resource-list small {
+  display: block;
+  margin-top: 0.45rem;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
 .resource-list span {
   display: flex;
   flex-wrap: wrap;

--- a/src/lib/reading-list.ts
+++ b/src/lib/reading-list.ts
@@ -1,0 +1,26 @@
+export interface ReadingListItem {
+  title: string;
+  author: string;
+  href: string;
+  dateLabel: string;
+  summary: string;
+}
+
+export const READING_LIST_ITEMS: ReadingListItem[] = [
+  {
+    title: 'Writing in the Age of LLMs',
+    author: 'Shreya Shankar',
+    href: 'https://www.sh-reya.com/blog/ai-writing/',
+    dateLabel: 'Jun 16, 2025',
+    summary:
+      'A practical essay on writing with LLMs, avoiding low-density prose, and revising for clarity, rhythm, and judgment.',
+  },
+  {
+    title: "Lil'Log",
+    author: 'Lilian Weng',
+    href: 'https://lilianweng.github.io/',
+    dateLabel: 'Since 2017',
+    summary:
+      'Deep learning and AI research notes with careful long-form explainers on agents, alignment, diffusion, scaling laws, and related systems.',
+  },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import HomeLayout from '../layouts/HomeLayout.astro';
 import { getPostsBySection } from '../lib/content';
 import { CODE_PRACTICE_SECTION_SUMMARY, codePracticeProblems } from '../lib/code-practice';
+import { READING_LIST_ITEMS } from '../lib/reading-list';
 
 const paperPosts = await getPostsBySection('paper-shorts', 'desc');
 const revisionPosts = (await getPostsBySection('revision-notes', 'desc')).filter(
@@ -17,6 +18,7 @@ const totalEntries =
   buildIntuitionPosts.length +
   revisionPosts.length +
   aiPosts.length +
+  READING_LIST_ITEMS.length +
   codePracticeProblems.length;
 
 const sectionCards = [
@@ -59,6 +61,14 @@ const sectionCards = [
     title: 'AI Generated Reports',
     description: 'Audio and text reports produced with AI assistance.',
     count: aiPosts.length,
+  },
+  {
+    id: 'reading-list',
+    href: '/reading_list.html',
+    command: 'reading-list',
+    title: 'Reading List',
+    description: 'External essays, posts, and references worth keeping close.',
+    count: READING_LIST_ITEMS.length,
   },
   {
     id: 'code',
@@ -166,6 +176,7 @@ const formatDate = (date: Date) =>
         <nav class="home-command-bar home-command-bar--hero" aria-label="Homepage sections">
           <a href="#about">/about</a>
           <a href="#latest">/latest</a>
+          <a href="/reading_list.html">/reading</a>
           <a href="/code.html">/code</a>
         </nav>
       </div>

--- a/src/pages/reading_list.astro
+++ b/src/pages/reading_list.astro
@@ -1,0 +1,38 @@
+---
+import SectionHeader from '../components/SectionHeader.astro';
+import PostLayout from '../layouts/PostLayout.astro';
+import { READING_LIST_ITEMS } from '../lib/reading-list';
+
+const itemCountLabel = `${READING_LIST_ITEMS.length} ${
+  READING_LIST_ITEMS.length === 1 ? 'item' : 'items'
+}`;
+---
+
+<PostLayout title="Reading List" showSectionsNav={false}>
+  <SectionHeader
+    eyebrow="Reading List"
+    title="Good things to read"
+    description="External essays, posts, and references worth keeping close."
+    meta={itemCountLabel}
+  />
+
+  <section class="resource-list">
+    <div class="resource-list__header">
+      <h2>Saved links</h2>
+    </div>
+    <ul>
+      {READING_LIST_ITEMS.map((item) => (
+        <li>
+          <div>
+            <strong>{item.title}</strong>
+            <p>{item.summary}</p>
+            <small>{item.author} / {item.dateLabel}</small>
+          </div>
+          <span>
+            <a href={item.href}>Read</a>
+          </span>
+        </li>
+      ))}
+    </ul>
+  </section>
+</PostLayout>


### PR DESCRIPTION
## Summary
- add a Reading List page backed by structured reading-list data
- add Shreya Shankar's AI writing essay and Lilian Weng's Lil'Log
- surface Reading List from the homepage section map and hero shortcut
- add the Claude FM YouTube video to the music playlist

## Testing
- npm run ci