### PR TITLE
Tighten site content and summaries

### DIFF
--- a/src/content/posts/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
+++ b/src/content/posts/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
@@ -9,9 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Computer Vision
-summary: >-
-  2020 – An Image Is Worth 16×16 Words: Transformers for Image Recognition at
-  Scale
+summary: ViT showed that patchified images and standard Transformer encoders can rival CNNs when pre-training data is large enough.
 ---
 ## 2020 – An Image Is Worth 16×16 Words: Transformers for Image Recognition at Scale
 

--- a/src/content/posts/attention-is-all-you-need.mdx
+++ b/src/content/posts/attention-is-all-you-need.mdx
@@ -7,7 +7,7 @@ legacyPath: /paper shorts/2017/06/01/attention-is-all-you-need.html
 tags:
   - Other
 field: Natural Language Processing
-summary: 2017 – Attention Is All You Need
+summary: The Transformer removed recurrence from sequence modeling and made attention-first architectures practical at scale.
 ---
 import PythonPlayground from '../../components/PythonPlayground';
 import { attentionIsAllYouNeedPlayground } from '../../lib/python-playground-examples';

--- a/src/content/posts/auto-encoding-variational-bayes.md
+++ b/src/content/posts/auto-encoding-variational-bayes.md
@@ -7,7 +7,7 @@ legacyPath: /paper shorts/2014/04/01/auto-encoding-variational-bayes.html
 tags:
   - Other
 field: Variational Inference
-summary: 2014 – Auto-Encoding Variational Bayes
+summary: VAEs made latent-variable models trainable with SGD by turning stochastic sampling into a differentiable reparameterized path.
 ---
 ## 2014 – Auto-Encoding Variational Bayes
 

--- a/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
+++ b/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
@@ -12,9 +12,7 @@ legacyPath: >-
 tags:
   - Other
 field: Natural Language Processing
-summary: >-
-  2019 – BERT: Pre-training of Deep Bidirectional Transformers for Language
-  Understanding
+summary: BERT made bidirectional encoder pre-training reusable across NLP tasks through masked-language modeling and fine-tuning.
 ---
 import PythonPlayground from '../../components/PythonPlayground';
 import { bertPlayground } from '../../lib/python-playground-examples';

--- a/src/content/posts/deep-residual-learning-for-image-recognition.md
+++ b/src/content/posts/deep-residual-learning-for-image-recognition.md
@@ -7,7 +7,7 @@ legacyPath: /paper shorts/2015/12/01/deep-residual-learning-for-image-recognitio
 tags:
   - Other
 field: Computer Vision
-summary: 2015 – Deep Residual Learning for Image Recognition
+summary: ResNet made very deep CNNs practical by learning residual updates and carrying gradients through identity shortcuts.
 ---
 ## 2015 – Deep Residual Learning for Image Recognition
 
@@ -61,4 +61,3 @@ class MiniResidual(nn.Module):
 ```
 
 **Take-home message:** ResNet's core idea is almost comically simple: add the identity back. That shortcut reshaped deep-learning practice, and today almost every high-performance architecture inherits some version of its skip-connection logic.
-

--- a/src/content/posts/denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/denoising-diffusion-probabilistic-models.md
@@ -7,7 +7,7 @@ legacyPath: /paper shorts/2020/06/01/denoising-diffusion-probabilistic-models.ht
 tags:
   - Other
 field: Generative Models
-summary: 2020 – Denoising Diffusion Probabilistic Models (DDPM)
+summary: DDPMs turned generation into learned denoising, trading slow sampling for stable training and strong image quality.
 ---
 ## 2020 – Denoising Diffusion Probabilistic Models (DDPM)
 

--- a/src/content/posts/direct-preference-optimization-dpo.md
+++ b/src/content/posts/direct-preference-optimization-dpo.md
@@ -7,9 +7,7 @@ legacyPath: /paper shorts/2023/05/01/direct-preference-optimization-dpo.html
 tags:
   - Other
 field: Reinforcement Learning
-summary: >-
-  2023 – Direct Preference Optimization: Your Language Model Is Secretly a
-  Reward Model
+summary: DPO replaced explicit reward modeling and PPO with a direct preference loss derived from the RLHF objective.
 ---
 ## 2023 – Direct Preference Optimization: Your Language Model Is Secretly a Reward Model
 

--- a/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
+++ b/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
@@ -9,7 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Computer Vision
-summary: '2020 – EfficientDet: Scalable and Efficient Object Detection'
+summary: EfficientDet paired BiFPN feature fusion with compound scaling to make detector accuracy and latency easier to trade off.
 ---
 ## 2020 – EfficientDet: Scalable and Efficient Object Detection
 

--- a/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
+++ b/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
@@ -9,7 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Computer Vision
-summary: 2019 – EfficientNet — Rethinking Model Scaling for ConvNets
+summary: EfficientNet made CNN scaling more systematic by growing depth, width, and resolution together under a compute budget.
 ---
 ## 2019 – EfficientNet — Rethinking Model Scaling for ConvNets
 

--- a/src/content/posts/generative-adversarial-networks.md
+++ b/src/content/posts/generative-adversarial-networks.md
@@ -7,7 +7,7 @@ legacyPath: /paper shorts/2014/06/01/generative-adversarial-networks.html
 tags:
   - Other
 field: Generative Models
-summary: 2014 – Generative Adversarial Networks
+summary: GANs framed generation as a two-player game between a generator and discriminator, producing sharp samples without explicit likelihoods.
 ---
 ## 2014 – Generative Adversarial Networks
 

--- a/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
@@ -9,7 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Generative Models
-summary: 2021 – Improved Denoising Diffusion Probabilistic Models (ID DPM)
+summary: Improved DDPM tightened diffusion likelihoods and made sampling faster by learning reverse-process variance.
 ---
 ## 2021 – Improved Denoising Diffusion Probabilistic Models (ID DPM)
 

--- a/src/content/posts/language-models-are-few-shot-learners.md
+++ b/src/content/posts/language-models-are-few-shot-learners.md
@@ -7,7 +7,7 @@ legacyPath: /paper shorts/2020/05/01/language-models-are-few-shot-learners.html
 tags:
   - Other
 field: Natural Language Processing
-summary: 2020 – Language Models are Few-Shot Learners (GPT-3)
+summary: GPT-3 showed that scale can turn language models into few-shot learners, but also exposed the limits of prompting alone.
 ---
 ## 2020 – Language Models are Few-Shot Learners (GPT-3)
 

--- a/src/content/posts/learning-transferable-visual-models-from-natural-language-supervision.md
+++ b/src/content/posts/learning-transferable-visual-models-from-natural-language-supervision.md
@@ -9,9 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Computer Vision
-summary: >-
-  2021 – Learning Transferable Visual Models From Natural Language Supervision
-  (CLIP)
+summary: CLIP used image-text contrastive training to make visual representations transfer through natural-language prompts.
 ---
 ## 2021 – Learning Transferable Visual Models From Natural Language Supervision (CLIP)
 

--- a/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
+++ b/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
@@ -7,9 +7,7 @@ legacyPath: /paper shorts/2019/11/01/mastering-atari-go-chess-shogi-muzero.html
 tags:
   - Other
 field: Reinforcement Learning
-summary: >-
-  2019 – Mastering Atari, Go, Chess & Shogi by Planning with a Learned Model
-  (MuZero)
+summary: MuZero learned just enough model dynamics to plan with MCTS, without reconstructing full environment observations.
 ---
 ## 2019 – Mastering Atari, Go, Chess & Shogi by Planning with a Learned Model (MuZero)
 

--- a/src/content/posts/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.md
+++ b/src/content/posts/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.md
@@ -9,7 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Alignment
-summary: '2026 – mSFT: Addressing Dataset Mixtures Overfitting Heterogeneously in Multi-task SFT'
+summary: mSFT adapts multitask fine-tuning mixtures by tracking which datasets overfit at different rates.
 ---
 ## 2026 – mSFT: Addressing Dataset Mixtures Overfitting Heterogeneously in Multi-task SFT
 

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -7,19 +7,9 @@ legacyPath: /blog/2025/02/08/my-journey-so-far-full-story.html
 tags:
   - Other
 summary: >-
-  Index - Introduction - Growing Up - Undergrad at MIT, Manipal - Depression -
-  Grad school at Mines - Finding a Job Out of Grad School - First Job at DEKA -
-  Zoox
+  A personal account of finding robotics through setbacks, project work,
+  graduate school, DEKA, and Zoox.
 ---
-## Index
-- [Introduction](#introduction)
-- [Growing Up](#growing-up)
-- [Undergrad at MIT, Manipal](#undergrad-at-mit-manipal)
-- [Depression](#depression)
-- [Grad school at Mines](#grad-school-at-mines)
-- [Finding a Job Out of Grad School](#finding-a-job-out-of-grad-school)
-- [First Job at DEKA](#first-job-at-deka)
-- [Zoox](#zoox)
 
 ## Introduction
 
@@ -31,7 +21,7 @@ I grew up in Jaipur, a city that shaped much of my early life. I lost my father 
 
 Most of my schooling was in Jaipur, and like many aspiring engineers, I spent three intense years in Kota preparing for the JEE. Kota is often described as a **factory** ([Netflix show](https://www.netflix.com/title/81249783) / [Wiki](https://en.wikipedia.org/wiki/Kota_Factory)), and that description is not far off. The city runs on academic competition. It is also a perfect breeding ground for [Girard's mimetic theory of desire](https://en.wikipedia.org/wiki/Mimetic_theory), where students absorb each other's ambitions and anxieties until it becomes hard to tell what you actually want. Despite working hard, I did not clear the IIT exam. At 18, that failure felt crushing, like I had let everyone down after years of preparation. Even now, at 33, the memory still makes my body tense up.
 
-### Takeaways
+### What that period taught me
 - **Be resilient** in the face of adversity.
 - Sometimes, **no matter how hard you try, you will fail** - and that's okay.
 - **It's okay to indulge** in things you like (like video games), but don’t let them consume you.
@@ -50,7 +40,7 @@ Even with that ridiculous ending, the concept was real. A similar design is now 
 
 <img src="/assets/images/IMG_8842.jpg" alt="Areca Nut Robot" class="float-right" style="max-width:65%;">
 
-### Takeaways
+### What undergrad changed
 - **It's never too late to start.**
 - **Jugaad** (resourcefulness in Hindi) is okay, as long as you don’t cheat outright!
 - **Building things that help others** brings a ton of joy.
@@ -77,7 +67,7 @@ Those experiences helped me find a purpose and clarify what I wanted to work on.
 
 The results started rolling in, and I was accepted into three different schools. I still remember rereading the first acceptance email about five times, in disbelief that I had actually been accepted! With newfound clarity and excitement, I packed my bags and headed to the U.S. for grad school, ready to start a new chapter as a robotics graduate student at the Colorado School of Mines!
 
-### Takeaways
+### What the reset clarified
 - **Depression can be scary.**
 - **Having a purpose** makes it low-effort to work hard.
 - **Always have a backup plan.**
@@ -98,7 +88,7 @@ The third semester at CSM was a turning point in my career. I spent a lot of tim
 
 Looking back, the best thing I did was build a strong foundation in the skills I cared about and then find practical ways to use them. Grad school is not just about grades. It is about the projects you take on, the challenges you solve, and the people you learn from. For students in grad school now, my advice is simple: take on projects that stretch you, use the resources around you, and follow the problems that genuinely excite you. That is how progress starts to compound.
 
-### Takeaways
+### What Mines taught me
 - **Focus on building a strong foundation** in the areas that excite you.
 - **It's okay to feel out of place** in the beginning. Navigating many changes at once can be overwhelming, but it's part of the process.
 - **Be intentional** about what you want to get out of grad school. Tailor your coursework and experiences to align with your interests.

--- a/src/content/posts/playing-atari-with-dqn.md
+++ b/src/content/posts/playing-atari-with-dqn.md
@@ -7,7 +7,7 @@ legacyPath: /paper shorts/2013/12/01/playing-atari-with-dqn.html
 tags:
   - Other
 field: Reinforcement Learning
-summary: 2013 – Playing Atari with Deep Reinforcement Learning
+summary: DQN combined Q-learning, replay, and target networks to make pixel-based Atari control work with deep networks.
 ---
 ## 2013 – Playing Atari with Deep Reinforcement Learning
 

--- a/src/content/posts/proximal-policy-optimization-ppo.mdx
+++ b/src/content/posts/proximal-policy-optimization-ppo.mdx
@@ -7,7 +7,7 @@ legacyPath: /paper shorts/2017/07/01/proximal-policy-optimization-ppo.html
 tags:
   - Other
 field: Reinforcement Learning
-summary: 2017 – Proximal Policy Optimization Algorithms (PPO)
+summary: PPO kept policy updates stable with a clipped objective that is much simpler to implement than TRPO.
 ---
 import PythonPlayground from '../../components/PythonPlayground';
 import { ppoPlayground } from '../../lib/python-playground-examples';

--- a/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
+++ b/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
@@ -15,13 +15,7 @@ summary: >-
 ---
 # Replacing OpenClaw with Hermes Agent using local weights
 
-I wanted a specific outcome: stop using OpenClaw, switch to [Hermes Agent](https://github.com/nousresearch/hermes-agent), and keep the whole thing local.
-
-Not "local except for the model."
-
-Actually local.
-
-That meant two constraints:
+I wanted a specific outcome: replace OpenClaw with [Hermes Agent](https://github.com/nousresearch/hermes-agent) while keeping inference fully local. That meant two constraints:
 
 1. I did not want to fall back to OpenRouter, Anthropic, or anything else cloud-hosted.
 2. I only wanted to use model artifacts that were already on disk.
@@ -39,13 +33,11 @@ Hermes is a much more opinionated agent shell than a bare local chat loop. It ha
 - skills
 - multiple provider backends
 
-Hermes does not force one inference path. It works with hosted providers, but it can also point at any OpenAI-compatible local endpoint. That separation makes it much easier to keep the agent framework while swapping the model runtime underneath it.
-
-That separation ended up mattering a lot.
+Hermes does not force one inference path. It works with hosted providers, but it can also point at any OpenAI-compatible local endpoint. That separation let the agent framework stay fixed while the model runtime changed underneath it.
 
 ## The install itself was easy
 
-The Hermes install was not the hard part. This worked fine:
+The Hermes install was not the hard part:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup
@@ -59,24 +51,15 @@ That bootstrapped:
 - the `hermes` CLI symlink in `~/.local/bin`
 - the default config in `~/.hermes/config.yaml`
 
-So far, so good.
-
 The real question was what local model server Hermes should talk to.
 
 ## Ollama was the obvious first try, but it was the wrong one here
 
 Since I already had Ollama installed and local Gemma tags visible, I tried the most obvious route first.
 
-That looked promising for about five minutes.
-
 Hermes could see the local endpoint. Ollama listed local Gemma models. But actual inference failed with HTTP `500` during model load on this Apple Silicon setup. In other words, the Hermes install was fine, but the runtime below it was not stable enough for the job.
 
-That was the key realization:
-
-- Hermes was not the problem.
-- My local model server choice was the problem.
-
-Once I stopped treating those two things as the same layer, the path got cleaner.
+The key realization: Hermes was not the problem. My local model server choice was.
 
 ## What actually worked: `llama-server` plus an existing Gemma GGUF
 
@@ -114,7 +97,7 @@ Once that server was up, it exposed the OpenAI-compatible endpoint Hermes wanted
 http://127.0.0.1:18080/v1
 ```
 
-That was the turning point: Hermes could stay as the agent shell, and `llama.cpp` could do the local serving.
+That split worked: Hermes stayed as the agent shell, and `llama.cpp` handled local serving.
 
 ## The Hermes config I ended up using
 
@@ -149,7 +132,7 @@ And it returned:
 READY
 ```
 
-That was enough. At that point Hermes was no longer merely installed; it was running locally against weights that were already on disk.
+That was enough proof: Hermes was running locally against weights already on disk.
 
 ## What I would do next
 
@@ -159,10 +142,10 @@ This setup is already useful, but there are a few obvious next steps:
 - point Hermes at a stronger local model if I want better tool-use quality
 - wire in the local Qwen artifacts the same way, once I decide which exact GGUF or local server path I want to standardize on
 
-The important part is that the architecture is now right:
+The architecture is now clean:
 
 - Hermes for the agent layer
 - `llama.cpp` for the local serving layer
 - existing local weights for inference
 
-That split is cleaner than trying to make one tool do all three jobs at once. That was the real unlock here.
+That split is cleaner than asking one tool to own the agent layer, serving layer, and model artifacts at once.

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -13,11 +13,7 @@ summary: >-
 ---
 # Running Gemma 4 locally on a 64 GB MacBook Pro
 
-I wanted to answer a specific question: on a 64 GB M5 Max MacBook Pro, what is the best Gemma 4 model I can run locally, and what is the fastest way to run it?
-
-The model answer stayed simple.
-
-The runtime answer got more interesting once I stopped guessing and benchmarked it.
+I wanted one concrete answer: on a 64 GB M5 Max MacBook Pro, which Gemma 4 model should I actually run locally, and through which runtime?
 
 The short version, as of April 4, 2026:
 
@@ -26,8 +22,6 @@ The short version, as of April 4, 2026:
 - Fastest usable runtime I tested on this machine: `MLX`
 - Most direct low-level path: `llama.cpp`
 - Current Ollama status for Gemma 4 on this machine: it crashes before first token
-
-That last one surprised me the most.
 
 ## What fits
 
@@ -40,12 +34,12 @@ So on a 64 GB machine, all four models are realistic local targets, including th
 
 The `26B A4B` model is the more interesting everyday laptop option. It is MoE, so only `4B` parameters are active per generated token, even though the full model still has to sit in memory. The `31B` model is the strongest dense option that still makes sense on this machine. Google also lists `128K` context for the small models and `256K` context for the larger ones, which is powerful but not remotely free from a latency perspective ([Google docs](https://ai.google.dev/gemma/docs/core), [Gemma 4 31B card](https://huggingface.co/google/gemma-4-31B-it)).
 
-So my view did not really change here:
+My model recommendation is simple:
 
 - If you want the best Gemma 4 model that comfortably fits, start with `31B`.
 - If you want the model I would actually pay the most attention to for daily use, it is `26B A4B`.
 
-## How I benchmarked it
+## Benchmark setup
 
 I ran everything on:
 
@@ -64,7 +58,7 @@ I used two text-only suites so the results would reflect inference behavior rath
 - Short suite: `512` input tokens, `192` output tokens
 - Long suite: `8192` input tokens, `96` output tokens
 
-The output task was intentionally boring and deterministic: read background text, then print numbered lines. Temperature was pinned to `0`, and I measured:
+The output task was intentionally boring and deterministic: read background text, then print numbered lines. Temperature was `0`. I measured:
 
 - Time to first token
 - Decode tokens per second
@@ -72,17 +66,15 @@ The output task was intentionally boring and deterministic: read background text
 
 One important caveat: this is a fastest-practical-path comparison, not a perfect same-weights lab setup. I used the most direct current artifact for each runtime. That means the `E2B` comparison is not perfectly apples-to-apples: official `llama.cpp` GGUF for `E2B` is `Q8_0`, while the MLX and Ollama paths use 4-bit artifacts.
 
-## Special Things I Had To Do
+## Controls that mattered
 
-A few benchmark details mattered more than I expected:
+These details kept the comparison about runtime behavior rather than hidden work:
 
 - I disabled Gemma's thinking mode anywhere I could, because otherwise you are partly benchmarking extra reasoning tokens instead of raw runtime behavior.
 - I kept the benchmark text-only, which meant running `llama.cpp` without a multimodal projector. That was the cleanest way to measure prompt processing and decode speed instead of image overhead.
 - I used a boring deterministic output task and pinned temperature to `0`. That made throughput differences much easier to trust.
 - I split the test into short and long prompts on purpose. A runtime can look fine at `512` tokens and then feel much worse once prompt processing climbs into the `8K` range.
-- I tried Ollama with native `gemma4:*` tags, not a hacked local import path. I wanted Ollama to get the fairest possible shot before concluding that the current M5 experience is broken.
-
-None of those are exotic tricks, but they were the difference between "the model runs" and "I actually believe this comparison."
+- I tried Ollama with native `gemma4:*` tags, not a hacked local import path, so the Ollama result reflects the current easy path.
 
 ## What The Benchmarks Say
 
@@ -118,16 +110,14 @@ For the smaller models, MLX was clearly faster on this M5 Max. For `26B A4B`, th
 | `31B` | MLX | `mlx-community/gemma-4-31b-it-4bit` | `13501 ms` | `23.73` | `5.47` |
 | `31B` | llama.cpp | `ggml-org` `Q4_K_M` GGUF | `24164 ms` | `20.72` | `3.33` |
 
-The pattern is pretty clear:
+The pattern:
 
 - MLX is winning the small-model tests by a healthy margin.
 - `26B A4B` is much closer on short prompts than I expected.
 - `31B` is a meaningful step down in responsiveness compared with `26B A4B`, even though it still fits comfortably in memory.
 - `31B` also stops being a close runtime contest: MLX is simply better behaved there on this machine.
 - On longer prompts, MLX is still more comfortable because time to first token is substantially lower.
-- The difference between "weights fit" and "this feels good to use" becomes real very quickly once prompt length goes up.
-
-That last point matters more than people usually admit. Decode speed often holds up decently; prompt processing and time to first token are what start to hurt.
+- The difference between "weights fit" and "this feels good to use" shows up quickly once prompt length grows; TTFT hurts before decode speed does.
 
 ## Ollama, Right Now
 
@@ -156,6 +146,4 @@ If I cared about the fastest usable runtime on this machine, the answer is no lo
 2. `llama.cpp` second
 3. `Ollama` later, once the M5 Metal breakage is fixed
 
-If you do not want a terminal workflow, this also maps cleanly to a tiny local browser chat app. Both `MLX` and `llama.cpp` are reasonable backends if the goal is simply to serve Gemma locally and talk to it.
-
-That is a more opinionated answer than I expected going in, but it feels much less hand-wavy now. That was the point of running the benchmarks in the first place.
+If you do not want a terminal workflow, this maps cleanly to a tiny local browser chat app. Both `MLX` and `llama.cpp` are reasonable backends if the goal is simply to serve Gemma locally and talk to it.

--- a/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
@@ -13,11 +13,7 @@ summary: >-
 ---
 # Running Qwen 3.5 and Qwen 3 locally on a 64 GB MacBook Pro
 
-I wanted to answer a practical question: on a `64 GB` M5 Max MacBook Pro, which Qwen models can I actually run locally, and which ones still feel good once prompt length stops being toy-sized?
-
-The answer was partly about model size.
-
-It was also about runtime choice, prompt length, and a few boring setup details that matter more than people usually admit.
+I wanted one practical answer: on a `64 GB` M5 Max MacBook Pro, which Qwen models are pleasant locally once prompt length stops being toy-sized?
 
 One important scope note up front, as of April 4, 2026:
 
@@ -55,7 +51,7 @@ The two big family-level differences that matter for local use are:
 - [`Qwen 3.5`](https://huggingface.co/Qwen/Qwen3.5-9B) defaults to thinking mode and exposes a `262,144` token default context window, so if you do not explicitly disable thinking you are partly benchmarking chain-of-thought overhead instead of plain inference behavior.
 - [`Qwen 3`](https://huggingface.co/Qwen/Qwen3-14B-GGUF) supports both thinking and non-thinking modes in the same model, and the official GGUF releases make `llama.cpp` comparisons much easier for that family.
 
-## How I benchmarked it
+## Benchmark setup
 
 I ran everything on:
 
@@ -75,7 +71,7 @@ I used the same two text-only suites as the Gemma post:
 - Short suite: `512` input tokens, `192` output tokens
 - Long suite: `8192` input tokens, `96` output tokens
 
-The task was intentionally boring and deterministic: read repeated background text, then emit exactly twelve numbered factual lines. Temperature was pinned to `0`, and I recorded:
+The task was intentionally boring and deterministic: read repeated background text, then emit exactly twelve numbered factual lines. Temperature was `0`. I recorded:
 
 - Time to first token
 - Decode tokens per second
@@ -84,17 +80,15 @@ The task was intentionally boring and deterministic: read repeated background te
 
 I also kept the app and the benchmark harness text-only for this pass. No images, no multimodal prompts, and no hidden reasoning tokens if I could turn them off.
 
-## Special Things I Had To Do
+## Controls that mattered
 
-A few details ended up mattering more than I expected:
+These details kept the benchmark from measuring hidden work:
 
 - I forced `Qwen 3.5` into non-thinking mode anywhere I could. Otherwise the benchmark stops being about raw runtime behavior.
 - I kept the local chat app text-only even though `Qwen 3.5` ships as an image-text model family. I wanted clean text-generation comparisons first.
 - `Qwen 3.5` on MLX still needed `torch` and `torchvision` installed in this environment because the processor stack came in through `mlx-vlm`.
 - I used official Qwen GGUF releases for `Qwen 3`, but for `Qwen 3.5` I fell back to pinned community `Q4_K_M` GGUFs because I did not find an official `Qwen 3.5` GGUF release on the Qwen organization page.
-- I had to disable Hugging Face Xet downloads on this machine for some official Qwen artifacts, because otherwise a few of the larger MLX downloads would stall on incomplete blobs.
-
-None of that is glamorous, but all of it changes whether local benchmarking feels straightforward or mysteriously flaky.
+- I had to disable Hugging Face Xet downloads for some official Qwen artifacts because a few larger MLX downloads stalled on incomplete blobs.
 
 ## What The Benchmarks Say
 
@@ -130,15 +124,15 @@ The cross-runtime results sharpened the runtime recommendation. On `Qwen 3.5 9B`
 | `Qwen 3.5 9B` | MLX | `mlx-community/Qwen3.5-9B-MLX-4bit` | `2894 ms` | `92.66` | `24.53` | `8.39 GB` |
 | `Qwen 3 4B` | MLX | `mlx-community/Qwen3-4B-4bit` | `1742 ms` | `127.76` | `38.41` | `4.24 GB` |
 
-Even from this first slice, the pattern is useful:
+The pattern:
 
 - `Qwen 3 4B` is the better low-friction local baseline on this machine.
 - `Qwen 3.5 4B` is still very usable, but it carries more memory overhead in my current MLX path.
 - `Qwen 3.5 9B` still looks laptop-friendly, but it is where the latency tradeoff starts feeling materially different from the tiny models.
 - `Qwen 3.5 9B` also gave the first real runtime verdict: on this hardware, `MLX` was materially better than `llama.cpp`.
 - `Qwen 3 14B` looks like the first genuinely stronger dense option that still feels reasonable to keep around locally, but it is no longer fast in the same way.
-- `Qwen 3 14B` makes the runtime story more specific: `llama.cpp` is competitive on the short prompt, but MLX is still the better default once prompts get long.
-- Long-prompt behavior matters a lot more than short-prompt decode speed if you care about whether a local model actually feels snappy.
+- `Qwen 3 14B` makes the runtime story specific: `llama.cpp` is competitive on the short prompt, but MLX is still the better default once prompts get long.
+- Long-prompt behavior matters more than short-prompt decode speed if you care about whether a local model feels snappy.
 
 ## What I Would Actually Use
 
@@ -149,4 +143,4 @@ Right now, my practical recommendation is simple:
 3. Keep `Qwen 3.5 9B` in the mix if you specifically care about the 3.5 family behavior and do not mind the extra latency and memory overhead.
 4. Prefer `MLX` first on this Mac unless a specific `llama.cpp` model artifact or integration path gives you a reason to switch.
 
-That answer is opinionated, but it is much less hand-wavy now. It comes from running the models on this machine instead of guessing from parameter counts or release notes.
+That answer comes from this machine, not parameter counts or release notes.

--- a/src/content/posts/sequence-to-sequence-learning-with-neural-networks.md
+++ b/src/content/posts/sequence-to-sequence-learning-with-neural-networks.md
@@ -9,7 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Natural Language Processing
-summary: 2014 – Sequence to Sequence Learning with Neural Networks
+summary: Seq2seq made encoder-decoder neural translation practical before attention became the default alignment mechanism.
 ---
 ## 2014 – Sequence to Sequence Learning with Neural Networks
 

--- a/src/content/posts/sigmoid-loss-for-language-image-pre-training-siglip.md
+++ b/src/content/posts/sigmoid-loss-for-language-image-pre-training-siglip.md
@@ -9,7 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Computer Vision
-summary: 2023 – Sigmoid Loss for Language-Image Pre-Training (SigLIP)
+summary: SigLIP replaced softmax contrastive normalization with independent sigmoid losses, simplifying large-batch image-text training.
 ---
 ## 2023 – Sigmoid Loss for Language-Image Pre-Training (SigLIP)
 

--- a/src/content/posts/training-language-models-to-follow-instructions-with-human-feedback.md
+++ b/src/content/posts/training-language-models-to-follow-instructions-with-human-feedback.md
@@ -9,9 +9,7 @@ legacyPath: >-
 tags:
   - Other
 field: Alignment
-summary: >-
-  2022 – Training Language Models to Follow Instructions with Human Feedback
-  (InstructGPT)
+summary: InstructGPT showed that human preference data can make smaller language models follow instructions better than larger base models.
 ---
 ## 2022 – Training Language Models to Follow Instructions with Human Feedback (InstructGPT)
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,6 @@
 export const SITE_TITLE = 'Arunabh.BLOG';
 export const SITE_DESCRIPTION =
-  'Notes on computer vision, robotics, research, and local AI systems.';
+  'Research notes, implementation records, and essays on computer vision, robotics, and local AI systems.';
 
 export const CONTACT_LINKS = [
   { href: 'mailto:arunabh1904@gmail.com', iconName: 'email', label: 'Email' },

--- a/src/pages/ai_generated_reports.astro
+++ b/src/pages/ai_generated_reports.astro
@@ -13,24 +13,24 @@ const reportCount = posts.length + PDF_REPORTS.length;
   <SectionHeader
     eyebrow="AI Reports"
     title="Generated research summaries"
-    description="Audio and text reports made with AI assistance, kept separate from hand-written notes."
+    description="AI-generated reports kept separate from hand-written notes."
     meta={`${reportCount} reports`}
   />
 
   <section class="section-index-group">
     <h2>Audio summaries</h2>
-  {posts.length > 0 ? <PostList posts={posts} /> : <p>No audio summaries yet.</p>}
+    {posts.length > 0 ? <PostList posts={posts} /> : <p>No audio summaries yet.</p>}
   </section>
 
   <section class="section-index-group">
     <h2>Deep research summaries</h2>
-  <ul class="post-list">
-    {PDF_REPORTS.map((report) => (
-      <li>
-        <a href={report.href}>{report.label}</a>
-        <small>{report.dateLabel}</small>
-      </li>
-    ))}
-  </ul>
+    <ul class="post-list">
+      {PDF_REPORTS.map((report) => (
+        <li>
+          <a href={report.href}>{report.label}</a>
+          <small>{report.dateLabel}</small>
+        </li>
+      ))}
+    </ul>
   </section>
 </PostLayout>

--- a/src/pages/build_intuition.astro
+++ b/src/pages/build_intuition.astro
@@ -11,7 +11,7 @@ const posts = await getPostsBySection('build-intuition', 'desc');
   <SectionHeader
     eyebrow="Build Intuition"
     title="Intuition-first explainers"
-    description="Conceptual walkthroughs that prioritize the shape of an idea before the implementation details."
+    description="Conceptual walkthroughs that make the mechanism legible before adding implementation detail."
     meta={`${posts.length} entries`}
   />
   <PostList posts={posts} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,7 +27,7 @@ const sectionCards = [
     href: '/paper_summaries_field.html',
     command: 'arxiv-notes',
     title: 'Arxiv Notes',
-    description: 'Research-paper notes grouped by the ideas they connect to.',
+    description: 'Paper notes that track the contribution, tradeoff, and lasting idea.',
     count: paperPosts.length,
   },
   {
@@ -35,7 +35,7 @@ const sectionCards = [
     href: '/blog.html',
     command: 'blog',
     title: 'Blog',
-    description: 'Longer reflections on research, work, and the path here.',
+    description: 'Essays on research practice, local models, robotics, and career lessons.',
     count: blogPosts.length,
   },
   {
@@ -43,7 +43,7 @@ const sectionCards = [
     href: '/build_intuition.html',
     command: 'build-intuition',
     title: 'Build Intuition',
-    description: 'Intuition-first explainers for ideas worth really understanding.',
+    description: 'Concept-first walkthroughs for mechanisms that reward slow understanding.',
     count: buildIntuitionPosts.length,
   },
   {
@@ -51,7 +51,7 @@ const sectionCards = [
     href: '/revision_notes.html',
     command: 'revision-notes',
     title: 'Revision Notes',
-    description: 'Study notes distilled from lectures, courses, and longer material.',
+    description: 'Course notes and implementation details kept for later review.',
     count: revisionPosts.length,
   },
   {
@@ -59,7 +59,7 @@ const sectionCards = [
     href: '/ai_generated_reports.html',
     command: 'ai-reports',
     title: 'AI Generated Reports',
-    description: 'Audio and text reports produced with AI assistance.',
+    description: 'Generated summaries kept separate from hand-written notes.',
     count: aiPosts.length,
   },
   {
@@ -67,7 +67,7 @@ const sectionCards = [
     href: '/reading_list.html',
     command: 'reading-list',
     title: 'Reading List',
-    description: 'External essays, posts, and references worth keeping close.',
+    description: 'External writing worth returning to, with one reason to read each link.',
     count: READING_LIST_ITEMS.length,
   },
   {
@@ -84,37 +84,37 @@ const recentShelves = [
   {
     title: 'Arxiv Notes',
     href: '/paper_summaries_field.html',
-    summary: 'Research-paper notes grouped by the ideas they connect to.',
+    summary: 'Paper notes that track the contribution, tradeoff, and lasting idea.',
     posts: paperPosts.slice(0, 2),
-    emptyMessage: 'New research notes will show up here.',
+    emptyMessage: 'No paper notes yet.',
   },
   {
     title: 'Blog',
     href: '/blog.html',
-    summary: 'Longer reflections on research, work, and the path here.',
+    summary: 'Essays on research practice, local models, robotics, and career lessons.',
     posts: blogPosts.slice(0, 2),
-    emptyMessage: 'Blog posts will show up here.',
+    emptyMessage: 'No essays yet.',
   },
   {
     title: 'Build Intuition',
     href: '/build_intuition.html',
-    summary: 'Intuition-first explainers for ideas worth really understanding.',
+    summary: 'Concept-first walkthroughs for mechanisms that reward slow understanding.',
     posts: buildIntuitionPosts.slice(0, 2),
-    emptyMessage: 'Intuition-first explainers will show up here.',
+    emptyMessage: 'No explainers yet.',
   },
   {
     title: 'Revision Notes',
     href: '/revision_notes.html',
-    summary: 'Study notes distilled from lectures, courses, and longer material.',
+    summary: 'Course notes and implementation details kept for later review.',
     posts: revisionPosts.slice(0, 2),
-    emptyMessage: 'Revision notes will show up here.',
+    emptyMessage: 'No revision notes yet.',
   },
   {
     title: 'AI Generated Reports',
     href: '/ai_generated_reports.html',
-    summary: 'Audio and text reports produced with AI assistance.',
+    summary: 'Generated summaries kept separate from hand-written notes.',
     posts: aiPosts.slice(0, 2),
-    emptyMessage: 'This section is ready for future reports.',
+    emptyMessage: 'No generated reports yet.',
   },
 ] as const;
 
@@ -170,8 +170,8 @@ const formatDate = (date: Date) =>
       <div class="home-hero__copy">
         <h1 class="home-title">ARUNABH.BLOG</h1>
         <p class="lead">
-          I work on computer vision and robotics for autonomous systems. This is where I write
-          about the ideas, papers, and experiences that have shaped the path.
+          I work on computer vision and robotics for autonomous systems. This site is where I keep
+          the research notes, implementation records, and personal essays I expect to reuse.
         </p>
         <nav class="home-command-bar home-command-bar--hero" aria-label="Homepage sections">
           <a href="#about">/about</a>
@@ -201,23 +201,20 @@ const formatDate = (date: Date) =>
         <h2>What this site is</h2>
       </div>
       <p class="intro-text">
-        I work in computer vision research at Zoox, building learned representations for autonomous
-        driving scenes and helping shape perception research. Before that, I led parts of the
-        perception stack at DEKA for Roxo, FedEx&apos;s last-mile delivery robot, with a focus on
-        short-range perception and traffic-light understanding.
+        I work in computer vision research at Zoox, where I build learned representations for
+        autonomous driving scenes. Before that, I led parts of the perception stack at DEKA for
+        Roxo, FedEx&apos;s last-mile delivery robot, focused on short-range perception and
+        traffic-light understanding.
       </p>
 
       <p class="intro-text">
-        My path into robotics started in India during my undergraduate years at MIT, Manipal, where
-        building projects made the field feel alive. That early fascination became a deliberate
-        commitment to autonomous systems and eventually brought me to the United States for graduate
-        school at the Colorado School of Mines.
+        Robotics started as undergraduate project work at MIT, Manipal, then became a deliberate
+        commitment to autonomy during graduate school at the Colorado School of Mines.
       </p>
 
       <p class="intro-text">
-        I care deeply about building systems that make the physical world safer, more capable, and
-        easier to navigate. This site is part notebook, part archive, and part ongoing conversation
-        with the work I want to keep doing.
+        The throughline is systems that make the physical world safer and easier to navigate. The
+        site is a working archive for that throughline.
       </p>
     </article>
 
@@ -247,8 +244,7 @@ const formatDate = (date: Date) =>
       <p class="home-panel__eyebrow">Latest</p>
       <h2>Recent entries</h2>
       <p>
-        A quick scan of the newest writing across the site. Each panel links out to the section
-        and highlights the two most recent posts.
+        The newest hand-written entries across the site, grouped by the kind of work they do.
       </p>
     </div>
 

--- a/src/pages/paper_summaries_field.astro
+++ b/src/pages/paper_summaries_field.astro
@@ -12,7 +12,7 @@ const paperCount = fields.reduce((count, field) => count + field.items.length, 0
   <SectionHeader
     eyebrow="Arxiv Notes"
     title="Paper summaries by field"
-    description="Research-paper notes grouped by the ideas and systems they connect to."
+    description="Paper notes grouped by field, each focused on the contribution, tradeoff, and lasting idea."
     meta={`${paperCount} entries`}
   />
   {fields.map(({ field, items }) => (

--- a/src/pages/reading_list.astro
+++ b/src/pages/reading_list.astro
@@ -11,15 +11,12 @@ const itemCountLabel = `${READING_LIST_ITEMS.length} ${
 <PostLayout title="Reading List" showSectionsNav={false}>
   <SectionHeader
     eyebrow="Reading List"
-    title="Good things to read"
-    description="External essays, posts, and references worth keeping close."
+    title="External references"
+    description="Essays, blogs, and references worth returning to, with one reason to read each."
     meta={itemCountLabel}
   />
 
   <section class="resource-list">
-    <div class="resource-list__header">
-      <h2>Saved links</h2>
-    </div>
     <ul>
       {READING_LIST_ITEMS.map((item) => (
         <li>

--- a/src/pages/revision_notes.astro
+++ b/src/pages/revision_notes.astro
@@ -7,7 +7,7 @@ import SectionHeader from '../components/SectionHeader.astro';
   <SectionHeader
     eyebrow="Revision Notes"
     title="CS336: Language Modeling from Scratch"
-    description="Lecture notes and course references for one of the strongest intuition-building language modeling courses around."
+    description="Course notes, references, and implementation details from CS336."
     meta="2 lessons"
   />
 


### PR DESCRIPTION
## What changed
- tightened homepage and section copy so each area has a clearer purpose
- replaced duplicate or title-like post summaries with specific one-line claims
- removed redundant index/takeaway labels and trimmed repeated local-model post prose

## Why
To make the site content more intentional, easier to scan, and less repetitive.

## Testing
- npm run ci
- pre-push hook reran npm run ci successfully