### PR TITLE
Enrich paper notes with visuals and tables

### DIFF
--- a/public/assets/images/driving-vlm-loop-schematic.svg
+++ b/public/assets/images/driving-vlm-loop-schematic.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="360" viewBox="0 0 960 360" role="img" aria-labelledby="title desc">
+  <title id="title">Driving VLM loop</title>
+  <desc id="desc">A schematic showing sensors and structured scene state feeding a VLM reasoning module, then planning and control, with safety benchmarks auditing grounding and trust.</desc>
+  <rect width="960" height="360" rx="24" fill="#0b1014"/>
+  <g fill="none" stroke="#8fd0ff" stroke-width="2">
+    <rect x="46" y="86" width="170" height="86" rx="14"/>
+    <rect x="46" y="206" width="170" height="86" rx="14"/>
+    <rect x="304" y="92" width="190" height="190" rx="14"/>
+    <rect x="592" y="78" width="150" height="92" rx="14"/>
+    <rect x="592" y="206" width="150" height="92" rx="14"/>
+    <rect x="794" y="118" width="118" height="122" rx="14"/>
+  </g>
+  <g fill="#d8f0ff" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="78" y="124" font-size="21">cameras</text>
+    <text x="78" y="152" font-size="21">maps</text>
+    <text x="78" y="244" font-size="21">objects</text>
+    <text x="78" y="272" font-size="21">rules</text>
+    <text x="340" y="146" font-size="22">VLM / LLM</text>
+    <text x="340" y="180" font-size="22">reasoning</text>
+    <text x="340" y="226" font-size="17">explain, rank,</text>
+    <text x="340" y="250" font-size="17">or teach planner</text>
+    <text x="624" y="116" font-size="21">planner</text>
+    <text x="624" y="144" font-size="21">intent</text>
+    <text x="624" y="244" font-size="21">control</text>
+    <text x="624" y="272" font-size="21">loop</text>
+    <text x="818" y="164" font-size="18">trust</text>
+    <text x="818" y="192" font-size="18">bench</text>
+  </g>
+  <g stroke="#8fd0ff" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M224 128 H292"/>
+    <path d="M224 252 H292"/>
+    <path d="M502 142 H580"/>
+    <path d="M502 252 H580"/>
+    <path d="M750 124 H786"/>
+    <path d="M750 252 H786"/>
+    <path d="M282 118 L296 128 L282 138"/>
+    <path d="M282 242 L296 252 L282 262"/>
+    <path d="M570 132 L584 142 L570 152"/>
+    <path d="M570 242 L584 252 L570 262"/>
+    <path d="M776 114 L790 124 L776 134"/>
+    <path d="M776 242 L790 252 L776 262"/>
+  </g>
+  <g fill="#a8c0cc" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">
+    <text x="46" y="44">Driving pattern: language helps with semantics, but safety depends on grounding, latency, and control boundaries.</text>
+    <text x="304" y="320">GPT-Driver / DriveVLM / EMMA / SENNA: different placements for the reasoning module</text>
+  </g>
+</svg>

--- a/public/assets/images/gan-game-schematic.svg
+++ b/public/assets/images/gan-game-schematic.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="360" viewBox="0 0 960 360" role="img" aria-labelledby="title desc">
+  <title id="title">GAN generator discriminator game</title>
+  <desc id="desc">A schematic showing noise feeding a generator, generated samples and real data feeding a discriminator, and gradients pushing the generator to fool the discriminator.</desc>
+  <rect width="960" height="360" rx="24" fill="#12110e"/>
+  <g fill="none" stroke="#f6c35b" stroke-width="2">
+    <rect x="54" y="80" width="150" height="86" rx="14"/>
+    <rect x="300" y="80" width="170" height="86" rx="14"/>
+    <rect x="300" y="216" width="170" height="86" rx="14"/>
+    <rect x="616" y="138" width="200" height="100" rx="14"/>
+  </g>
+  <g fill="#ffe4a8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="92" y="130" font-size="22">noise z</text>
+    <text x="332" y="130" font-size="22">generator</text>
+    <text x="348" y="268" font-size="22">real data</text>
+    <text x="648" y="182" font-size="22">discriminator</text>
+    <text x="656" y="214" font-size="18">real or fake?</text>
+  </g>
+  <g stroke="#f6c35b" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M214 123 H288"/>
+    <path d="M478 123 C548 123 574 160 604 176"/>
+    <path d="M478 260 C548 260 574 216 604 198"/>
+    <path d="M714 132 C700 72 388 48 384 76"/>
+    <path d="M278 113 L292 123 L278 133"/>
+    <path d="M594 166 L608 176 L594 186"/>
+    <path d="M594 188 L608 198 L594 208"/>
+  </g>
+  <g fill="#c8ad72" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">
+    <text x="54" y="44">GAN pattern: train a generator by making a discriminator's classification task harder.</text>
+    <text x="520" y="72">gradient signal back to G</text>
+  </g>
+</svg>

--- a/public/assets/images/robot-vla-stack-schematic.svg
+++ b/public/assets/images/robot-vla-stack-schematic.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="360" viewBox="0 0 960 360" role="img" aria-labelledby="title desc">
+  <title id="title">Vision-language-action stack</title>
+  <desc id="desc">A schematic showing visual observations and language instructions feeding a VLA policy, action tokenization or diffusion control, and a robot acting in the world.</desc>
+  <rect width="960" height="360" rx="24" fill="#111014"/>
+  <g fill="none" stroke="#d4b4ff" stroke-width="2">
+    <rect x="52" y="76" width="176" height="86" rx="14"/>
+    <rect x="52" y="206" width="176" height="86" rx="14"/>
+    <rect x="318" y="86" width="198" height="196" rx="14"/>
+    <rect x="612" y="76" width="162" height="86" rx="14"/>
+    <rect x="612" y="206" width="162" height="86" rx="14"/>
+    <circle cx="856" cy="182" r="58"/>
+  </g>
+  <g fill="#efe0ff" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="86" y="114" font-size="21">image</text>
+    <text x="86" y="142" font-size="21">stream</text>
+    <text x="86" y="244" font-size="21">language</text>
+    <text x="86" y="272" font-size="21">goal</text>
+    <text x="356" y="140" font-size="22">VLA policy</text>
+    <text x="356" y="176" font-size="17">vision + language</text>
+    <text x="356" y="202" font-size="17">+ embodiment data</text>
+    <text x="640" y="116" font-size="20">action</text>
+    <text x="640" y="144" font-size="20">tokens</text>
+    <text x="640" y="244" font-size="20">diffusion</text>
+    <text x="640" y="272" font-size="20">control</text>
+    <text x="824" y="178" font-size="19">robot</text>
+    <text x="824" y="206" font-size="19">world</text>
+  </g>
+  <g stroke="#d4b4ff" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M236 120 H306"/>
+    <path d="M236 250 H306"/>
+    <path d="M524 120 H600"/>
+    <path d="M524 250 H600"/>
+    <path d="M782 120 C820 126 836 142 846 158"/>
+    <path d="M782 250 C820 244 836 224 846 206"/>
+    <path d="M296 110 L310 120 L296 130"/>
+    <path d="M296 240 L310 250 L296 260"/>
+    <path d="M590 110 L604 120 L590 130"/>
+    <path d="M590 240 L604 250 L590 260"/>
+  </g>
+  <g fill="#c6b3da" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">
+    <text x="52" y="44">VLA pattern: visual-language understanding becomes useful only after it can produce valid actions.</text>
+    <text x="318" y="320">Pi0 / FAST / OpenVLA / DexVLA: different answers to action representation and control</text>
+  </g>
+</svg>

--- a/public/assets/images/vlm-stack-schematic.svg
+++ b/public/assets/images/vlm-stack-schematic.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="360" viewBox="0 0 960 360" role="img" aria-labelledby="title desc">
+  <title id="title">Vision-language model stack</title>
+  <desc id="desc">A schematic showing an image encoder and text encoder or language model joined by a connector, then trained with contrastive, instruction, or post-training data.</desc>
+  <rect width="960" height="360" rx="24" fill="#10120f"/>
+  <g fill="none" stroke="#f4df6a" stroke-width="2">
+    <rect x="52" y="76" width="190" height="92" rx="14"/>
+    <rect x="52" y="196" width="190" height="92" rx="14"/>
+    <rect x="342" y="118" width="150" height="124" rx="14"/>
+    <rect x="592" y="78" width="250" height="210" rx="14"/>
+  </g>
+  <g fill="#fff2a8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="86" y="118" font-size="22">image</text>
+    <text x="86" y="146" font-size="22">encoder</text>
+    <text x="86" y="238" font-size="22">text or</text>
+    <text x="86" y="266" font-size="22">instruction</text>
+    <text x="372" y="166" font-size="22">projector</text>
+    <text x="378" y="198" font-size="22">/ loss</text>
+    <text x="636" y="124" font-size="22">shared space</text>
+    <text x="636" y="158" font-size="22">or LLM tokens</text>
+    <text x="636" y="214" font-size="18">retrieval</text>
+    <text x="636" y="242" font-size="18">visual chat</text>
+    <text x="636" y="270" font-size="18">reasoning</text>
+  </g>
+  <g stroke="#f4df6a" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M250 122 H330"/>
+    <path d="M250 242 H330"/>
+    <path d="M500 180 H580"/>
+    <path d="M320 112 L334 122 L320 132"/>
+    <path d="M320 232 L334 242 L320 252"/>
+    <path d="M570 170 L584 180 L570 190"/>
+  </g>
+  <g fill="#c9c08a" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15">
+    <text x="52" y="42">VLM pattern: preserve visual evidence, align it with language, then tune the interface.</text>
+    <text x="342" y="282">CLIP/SigLIP: loss</text>
+    <text x="342" y="306">LLaVA: connector</text>
+    <text x="342" y="330">Qwen/Molmo/etc.: data + tokens</text>
+  </g>
+</svg>

--- a/src/content/posts/are-vlms-ready-for-autonomous-driving-drivebench.md
+++ b/src/content/posts/are-vlms-ready-for-autonomous-driving-drivebench.md
@@ -17,6 +17,21 @@ summary: DriveBench tested whether VLM driving answers are visually grounded or 
 
 The important finding is uncomfortable: models can give confident and plausible answers without grounding them in the visual input. Corruptions expose this because the answer often should change when the evidence changes.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- DriveBench compares clean, corrupted, and text-only conditions.
+- The key failure is plausible answers that ignore visual evidence.
+- Look for grounding metrics, not just QA accuracy.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Dataset | 19,200 frames / 20,498 QA pairs | Tests multiple driving tasks and question types. |
+| Stress test | 17 input conditions | Checks corruption and text-only reliance. |
+| Main failure | Weak visual grounding | Models can answer from priors instead of perception. |
+
 **Why it mattered:** Capability benchmarks can flatter VLMs. Driving needs reliability benchmarks that ask whether the model actually looked at the scene.
 
 **Take-home message:** A VLM that sounds right is not necessarily grounded. For driving, grounding under degradation is the benchmark that matters.

--- a/src/content/posts/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.md
+++ b/src/content/posts/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.md
@@ -17,6 +17,21 @@ summary: AsyncDriver separated slow LLM reasoning from fast motion planning so s
 
 Those instructions can guide the planner through complex or ambiguous situations without requiring the LLM to produce every control update.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- The key design is two clocks: fast planner, slow LLM.
+- LLM outputs scene-associated instructions instead of direct controls.
+- The latency solution is the contribution.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Runtime design | Asynchronous reasoning loop | Avoids blocking high-frequency planning. |
+| Planner role | Fast conventional motion planner | Keeps control responsive. |
+| Caveat | LLM advice must be bounded | Bad slow guidance should not override safety. |
+
 **Why it mattered:** It is a sober architecture. Instead of pretending language models are real-time controllers, AsyncDriver gives them a slower advisory role.
 
 **Take-home message:** In autonomy, reasoning and control do not need to run at the same frequency. VLM/LLM components can be useful if the system boundary respects latency.

--- a/src/content/posts/attention-is-all-you-need.mdx
+++ b/src/content/posts/attention-is-all-you-need.mdx
@@ -86,6 +86,12 @@ These fixed oscillations encode position without recurrence and extrapolate to l
 
 Self-attention gives every pair of tokens a constant-length path, but it pays for that access with quadratic memory and compute in sequence length. For machine translation, the tradeoff was worth it: the model parallelized well on GPUs, and the "big" Transformer reached 41.0 BLEU on English to French, far ahead of contemporary CNN and RNN baselines.
 
+| Setting | Result | Why it matters |
+| ------- | ------ | -------------- |
+| WMT 2014 English-German | 28.4 BLEU | Beat strong recurrent and convolutional baselines with a fully attention-based model. |
+| WMT 2014 English-French | 41.0 BLEU | Showed the architecture scaled to a larger translation benchmark. |
+| Training cost | 8 P100 GPUs for 3.5 days on English-German | Parallelism was part of the paper's practical impact, not just the accuracy. |
+
 ---
 
 ### Ongoing challenges

--- a/src/content/posts/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.md
+++ b/src/content/posts/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.md
@@ -17,6 +17,21 @@ summary: AutoTrust evaluated driving VLMs across hallucination, safety, robustne
 
 That means questions can test whether a model hallucinates, gives unsafe advice, leaks sensitive information, breaks under perturbations, or behaves inconsistently across groups and regions.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- Trustworthiness is split into truthfulness, safety, robustness, privacy, and fairness.
+- The benchmark includes adversarial and sensitive-information probes.
+- A driving-specialized model can still be less trustworthy than a general model.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Dataset | 10k scenes / 18k queries | Designed around trust dimensions. |
+| Axes | Truthfulness, safety, robustness, privacy, fairness | Evaluates more than accuracy. |
+| Main finding | Hidden unsafe behaviors | Capability can improve while trust still lags. |
+
 **Why it mattered:** Trustworthiness is not one metric. A model can improve on standard driving QA while still becoming less safe or less private.
 
 **Take-home message:** Driving VLM evaluation needs adversarial and ethical dimensions baked in from the start. Accuracy alone is too small a target.

--- a/src/content/posts/cambrian-1-vision-centric-exploration-of-multimodal-llms.md
+++ b/src/content/posts/cambrian-1-vision-centric-exploration-of-multimodal-llms.md
@@ -17,6 +17,21 @@ summary: Cambrian-1 treated VLM design as a vision problem first, systematically
 
 The paper tests many vision encoders and introduces a Spatial Vision Aggregator to preserve richer visual information before it reaches the language model.
 
+![Vision-language model stack schematic](/assets/images/vlm-stack-schematic.svg)
+
+**What to look at:**
+- Vision encoder choice and connector design are treated as first-order variables.
+- Spatial Vision Aggregator preserves high-resolution features before the LLM sees them.
+- CV-Bench is useful because it stresses visual evidence rather than language priors.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Design axis | 20+ vision encoders tested | Shows visual backbone choice changes downstream VLM behavior. |
+| Connector | Spatial Vision Aggregator | Keeps more local visual evidence for the LLM. |
+| Benchmark | CV-Bench | Evaluates vision-centric reasoning failures. |
+
 **Why it mattered:** A lot of VLM work implicitly assumes the LLM is the hard part. Cambrian-1 pushes back: the quality of the visual representation and connector can decide whether the language model is reasoning over evidence or filling gaps from priors.
 
 **Take-home message:** Better multimodal models are not only bigger language models. They also need better visual plumbing.

--- a/src/content/posts/can-lvlms-obtain-a-drivers-license-idkb.md
+++ b/src/content/posts/can-lvlms-obtain-a-drivers-license-idkb.md
@@ -17,6 +17,21 @@ summary: IDKB tested whether vision-language models know explicit driving rules,
 
 The result is a useful warning: a model may recognize cars and pedestrians but still fail rule-based reasoning that every licensed human driver is expected to know.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- IDKB focuses on explicit driving rules and written-test knowledge.
+- The benchmark includes handbooks, exams, and scenario QA.
+- Fine-tuning gains show that general VLM pretraining does not guarantee domain rules.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Dataset | 1M+ driving knowledge items | Covers rules, exams, and applied scenarios. |
+| Evaluation | 15 LVLMs | Tests whether general models know driving theory. |
+| Main failure | Missing specialized rule knowledge | Perception alone is not driving competence. |
+
 **Why it mattered:** Driving competence is not only perception. It is perception plus rule knowledge plus judgment under context.
 
 **Take-home message:** Autonomous driving VLMs need a written test as well as a road test.

--- a/src/content/posts/deepseek-vl2-mixture-of-experts-vision-language-models.md
+++ b/src/content/posts/deepseek-vl2-mixture-of-experts-vision-language-models.md
@@ -19,6 +19,21 @@ summary: DeepSeek-VL2 combined dynamic high-resolution tiling with sparse MoE la
 
 The result is especially relevant for OCR, documents, tables, charts, and visual grounding, where resizing or compressing the image too aggressively destroys the answer.
 
+![Vision-language model stack schematic](/assets/images/vlm-stack-schematic.svg)
+
+**What to look at:**
+- Dynamic tiling keeps high-resolution images readable.
+- Sparse MoE language modeling keeps active parameters lower than total parameters.
+- Document, chart, table, and OCR tasks are the main evidence surface.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Vision | Dynamic tiling | Keeps details from high-res and odd-aspect images. |
+| Language | DeepSeekMoE with latent attention | Improves inference efficiency for a large-capacity model. |
+| Best fit | OCR and documents | Text-heavy visual tasks expose the benefit. |
+
 **Why it mattered:** It is a practical answer to the "large but usable" problem. The model can have broad capacity without paying dense-model cost on every token.
 
 **Take-home message:** High-resolution vision and efficient language modeling have to be designed together; otherwise document VLMs either miss details or become too expensive.

--- a/src/content/posts/dexvla-vision-language-model-with-plug-in-diffusion-expert.md
+++ b/src/content/posts/dexvla-vision-language-model-with-plug-in-diffusion-expert.md
@@ -17,6 +17,21 @@ summary: DexVLA paired VLM reasoning with a diffusion policy expert for long-hor
 
 This hybrid design is useful for dexterous, long-horizon tasks where pure language-model action generation may be too coarse and pure diffusion may lack semantic planning.
 
+![Vision-language-action stack schematic](/assets/images/robot-vla-stack-schematic.svg)
+
+**What to look at:**
+- The VLM handles high-level reasoning tokens and action guidance.
+- A diffusion policy expert generates continuous low-level actions.
+- The curriculum separates general motor skill, embodiment adaptation, and task tuning.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Architecture | VLM plus diffusion expert | Splits planning from precise control. |
+| Training | Three-stage embodied curriculum | Moves from general motor skills to task specialization. |
+| Best fit | Dexterous long-horizon tasks | Where pure VLM action output is too coarse. |
+
 **Why it mattered:** DexVLA shows how robotics can borrow from both sides of modern AI: language models for task structure and diffusion models for continuous trajectory generation.
 
 **Take-home message:** The strongest robot policies may be coordinated systems, not monoliths. Let the VLM plan; let the control expert execute.

--- a/src/content/posts/distilling-multimodal-large-language-models-for-autonomous-driving.md
+++ b/src/content/posts/distilling-multimodal-large-language-models-for-autonomous-driving.md
@@ -17,6 +17,21 @@ summary: DIMA used a large multimodal driving model as a teacher, distilling its
 
 The result is a model that keeps more of the teacher's traffic knowledge while avoiding a full LLM in the runtime loop.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- A large multimodal planner is used as an offline teacher.
+- The runtime model is a smaller vision-based student.
+- This is mainly about latency and deployability.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Teacher | Multimodal LLM planner | Provides richer traffic reasoning during training. |
+| Student | Vision-only planner | Keeps inference cheaper and faster. |
+| Reported signal | Lower trajectory error and collisions | Measures whether distilled reasoning survives compression. |
+
 **Why it mattered:** Distillation is a plausible path from impressive VLM demos to deployable autonomy components. The expensive model teaches; the small model acts.
 
 **Take-home message:** LLMs may enter driving stacks indirectly, as offline teachers that shape compact planners.

--- a/src/content/posts/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.md
+++ b/src/content/posts/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.md
@@ -17,6 +17,21 @@ summary: DriveMM trained one multimodal transformer across perception, predictio
 
 The system takes multi-view driving imagery and produces a unified token sequence that can be decoded into task-specific outputs.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- One transformer is trained across perception, prediction, and planning tasks.
+- Curriculum learning moves from visual comprehension toward harder driving outputs.
+- Zero-shot transfer is the evidence to inspect.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Training | Driving curriculum | Stages task difficulty for a generalist model. |
+| Inputs | Multi-view driving imagery | Matches surround-camera AV settings. |
+| Evidence | Multiple public benchmarks | Tests whether one model can replace specialists. |
+
 **Why it mattered:** DriveMM pushed against the assumption that every driving subproblem needs a separate specialized network. The paper asks whether shared multimodal representations can support the full stack.
 
 **Take-home message:** End-to-end driving models are becoming multitask foundation models. The hard question is not only performance, but whether shared training improves closed-loop reliability.

--- a/src/content/posts/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.md
+++ b/src/content/posts/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.md
@@ -17,6 +17,21 @@ summary: DriveVLM combined VLM reasoning with hierarchical planning, then paired
 
 That hybrid design is the interesting part. The VLM contributes semantic reasoning about rare or complex situations; the conventional stack keeps the control loop more grounded.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- Hierarchical VLM reasoning is split into scene description, analysis, and planning.
+- DriveVLM-Dual keeps a traditional stack around the VLM to recover spatial precision.
+- Real-time and geometry limits are the main deployment pressure.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Architecture | VLM plus hierarchical planning | Uses language to decompose complex scenes. |
+| Hybrid variant | DriveVLM-Dual | Combines VLM semantics with conventional driving modules. |
+| Evidence | nuScenes, SUP-AD, vehicle deployment | Tests both public and production-style settings. |
+
 **Why it mattered:** DriveVLM captures the field's tension clearly: VLMs are useful for understanding and explanation, but driving still needs precise geometry and real-time behavior.
 
 **Take-home message:** The near-term role for VLMs in driving may be as semantic planners and critics, not as the only system between sensors and steering.

--- a/src/content/posts/driving-with-llms-fusing-object-level-vector-modality.md
+++ b/src/content/posts/driving-with-llms-fusing-object-level-vector-modality.md
@@ -19,6 +19,21 @@ summary: Driving with LLMs fed object-level vector scene state into language mod
 
 The bet is that language models may reason better when perception has already converted pixels into meaningful objects, positions, and relationships.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- Object-level vectors are the multimodal interface, not raw pixels.
+- The language model reasons over structured actors and relations.
+- The main value is explainable decisions from a cleaner scene representation.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Input | Object vectors | Structured state reduces visual ambiguity. |
+| Task | Driving QA and action generation | Tests scene interpretation and decisions. |
+| Tradeoff | Depends on upstream perception | Bad object state still misleads the LLM. |
+
 **Why it mattered:** The paper made object-centric driving language models a serious baseline. It also clarified a recurring theme in autonomy: sometimes the right multimodal interface is not raw pixels, but structured state.
 
 **Take-home message:** For safety-critical planning, language can be useful if it is grounded in the right representation. Object vectors give the LLM a cleaner substrate than raw visual impressions.

--- a/src/content/posts/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.md
+++ b/src/content/posts/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.md
@@ -19,6 +19,21 @@ summary: Eagle 2 made the post-training data recipe the main contribution, showi
 
 The main lesson is that strong VLMs are not just pretrained once and then lightly tuned. Their behavior is shaped by a careful curriculum of visual tasks and response styles.
 
+![Vision-language model stack schematic](/assets/images/vlm-stack-schematic.svg)
+
+**What to look at:**
+- Post-training data strategy is the primary contribution.
+- The paper is useful because it exposes data mixture choices normally hidden in model releases.
+- Benchmarks should be read as evidence for the recipe, not only for the final checkpoint.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Main lever | Post-training data mixture | Turns a general VLM into a benchmark-strong assistant. |
+| Transparency | Recipe-focused release | Documents data strategy instead of only final weights. |
+| Scale signal | Eagle2-9B competitive with larger models | Suggests curation can buy efficiency. |
+
 **Why it mattered:** Eagle 2 is valuable because it makes the data engineering visible. That helps turn VLM building from folklore into something closer to an inspectable recipe.
 
 **Take-home message:** Post-training is where a general multimodal model becomes useful. The data mixture is a control surface.

--- a/src/content/posts/emma-end-to-end-multimodal-model-for-autonomous-driving.md
+++ b/src/content/posts/emma-end-to-end-multimodal-model-for-autonomous-driving.md
@@ -19,6 +19,21 @@ summary: EMMA represented driving inputs and outputs as language tokens so one m
 
 The striking design choice is to represent many non-sensor inputs and outputs as text. That lets the model reuse the structure and world knowledge of a multimodal language model while training across several driving tasks.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- Inputs and outputs are represented in a language-like space.
+- Planning, perception objects, and road graph elements are trained together.
+- The limitations section matters: camera-only, limited frames, heavy compute.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Model role | Generalist driving model | One multimodal model handles several driving outputs. |
+| Output format | Text-encoded trajectories and objects | Lets prompts select task-specific outputs. |
+| Caveat | Limited temporal and 3D sensing | Promising architecture, not a complete AV stack. |
+
 **Why it mattered:** EMMA is a strong example of the generalist-model thesis entering autonomous driving: one model, many outputs, shared representations.
 
 **Take-home message:** Language can be a unifying interface for driving tasks, but EMMA also makes the costs obvious: limited temporal context, no full 3D sensor stack, and heavy compute.

--- a/src/content/posts/fast-efficient-action-tokenization-for-vision-language-action-models.md
+++ b/src/content/posts/fast-efficient-action-tokenization-for-vision-language-action-models.md
@@ -17,6 +17,21 @@ summary: FAST compressed robot action trajectories into tokens so autoregressive
 
 That enables autoregressive VLA models to train on complex manipulation trajectories without sequence lengths exploding.
 
+![Vision-language-action stack schematic](/assets/images/robot-vla-stack-schematic.svg)
+
+**What to look at:**
+- FAST compresses dense action trajectories into discrete tokens.
+- The goal is autoregressive VLA training without huge action sequences.
+- This is an action-representation paper more than a new robot brain.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Problem | High-frequency continuous actions | Naive tokenization makes sequences too long. |
+| Method | Time-series compression | Creates compact action tokens. |
+| Signal | Faster VLA training | Makes autoregressive robot policies more practical. |
+
 **Why it mattered:** Action representation is one of the hidden make-or-break details in robot foundation models. If actions are tokenized poorly, the model wastes capacity on formatting instead of behavior.
 
 **Take-home message:** Robotics needs its own tokenization work. The action vocabulary matters as much as the text vocabulary.

--- a/src/content/posts/generative-adversarial-networks.md
+++ b/src/content/posts/generative-adversarial-networks.md
@@ -19,13 +19,21 @@ summary: GANs framed generation as a two-player game between a generator and dis
 
 **Conference:** NIPS 2014
 
+![GAN generator discriminator game](/assets/images/gan-game-schematic.svg)
+
 **Summary:** GANs turn generative modelling into a contest. A generator $G$ maps random noise into synthetic samples, while a discriminator $D$ learns to tell real data from generated data. Training alternates between making $D$ better at the classification problem and making $G$ better at fooling $D$.
 
 The paper's central promise is elegant: with enough capacity and ideal optimization, the generator recovers the true data distribution and the discriminator becomes maximally uncertain, outputting 0.5 everywhere. That framing recasts density estimation as a differentiable game rather than an explicit likelihood problem. It also gives the generator direct feedback in pixel space, which helped avoid some of the blurry samples associated with early likelihood-based models.
 
 **Why it mattered:** The first experiments were small, mostly multilayer perceptrons on MNIST-like data, but the idea opened a much larger path. GANs made high-quality sample generation feel less like approximate density estimation and more like learned counterfeiting.
 
-**Evals / Latency benchmarks:** The original paper reports qualitative results on MNIST and small CIFAR-like images, not likelihood metrics. A small model on a single K20Xm GPU trained in minutes; ImageNet-scale synthesis came later. The evaluation gap is part of the legacy: GANs eventually pushed the community toward sample-quality metrics such as Inception Score and FID.
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Evaluation style | Qualitative MNIST and small natural-image samples | The original evidence was visual sample quality, not a mature metric. |
+| Compute | Small models trained on a single K20Xm GPU | The idea was cheap to demonstrate before later GANs scaled up. |
+| Legacy metric gap | No likelihood-style benchmark | Helped push the field toward sample-quality metrics such as Inception Score and FID. |
 
 **Critiques & limitations:** The formulation is beautiful, but the optimization is fragile. Training can diverge, generators can collapse to a small set of modes, and discriminators can saturate until the generator receives weak gradients. Much of the later GAN literature, including Wasserstein GANs and gradient penalties, is really a response to those failure modes.
 

--- a/src/content/posts/gpt-driver-learning-to-drive-with-gpt.md
+++ b/src/content/posts/gpt-driver-learning-to-drive-with-gpt.md
@@ -19,6 +19,21 @@ summary: GPT-Driver reframed motion planning as language modeling over scene tok
 
 This is not a deployable AV stack by itself. It is a useful probe: language models can absorb structured scene descriptions and generate plausible plans, but latency, grounding, and closed-loop reliability remain hard.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- Driving scene state is serialized into language tokens.
+- The model predicts future waypoints and rationales, not low-level control directly.
+- Open-loop planning metrics are useful but do not prove closed-loop safety.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Input | Structured scene tokens | Makes the driving problem legible to GPT-style models. |
+| Output | Future waypoints plus rationale | Adds interpretability to motion planning. |
+| Caveat | Open-loop and LLM latency | Needs closed-loop validation before real deployment. |
+
 **Why it mattered:** It opened a line of work where language is not just for explanation after the fact. It becomes an intermediate representation for planning.
 
 **Take-home message:** LLMs can help expose the reasoning behind a plan, but driving needs that reasoning to stay grounded, fast, and controllable.

--- a/src/content/posts/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.md
+++ b/src/content/posts/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.md
@@ -19,6 +19,21 @@ summary: InternVL 2.5 scaled open multimodal models with better data, training s
 
 The paper is useful because it studies several axes together: vision encoder size, language model size, dataset size, and chain-of-thought style inference. The story is not "just scale everything"; it is that scaling only pays off when the data and training recipe stay balanced.
 
+![Vision-language model stack schematic](/assets/images/vlm-stack-schematic.svg)
+
+**What to look at:**
+- Progressive scaling across vision encoder, LLM, data size, and inference settings.
+- Training details such as augmentation and loss balancing matter as much as model scale.
+- Test-time reasoning can improve difficult multimodal benchmarks but may change latency/cost.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Scale | 1B to 78B family | Studies where open VLM scaling pays off. |
+| Training | Data quality and balancing | Reduces failures that pure scale does not fix. |
+| Evaluation | MMMU and hallucination-style tests | Looks beyond simple captioning/VQA. |
+
 **Why it mattered:** InternVL 2.5 showed that open models could compete with leading closed systems on difficult multimodal benchmarks while exposing more of the training recipe.
 
 **Take-home message:** Open VLMs started becoming systems engineering projects: data mixture, encoder choice, LLM scale, and inference strategy all interact.

--- a/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
+++ b/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
@@ -26,9 +26,12 @@ summary: MuZero learned just enough model dynamics to plan with MCTS, without re
 The important design choice is what MuZero chooses not to model. It predicts only the quantities needed for planning, not future pixels or full board states. That makes one architecture work across Go, chess, shogi, and 57 Atari games, with MCTS continually producing stronger targets for the networks to imitate.
 
 **Evals / Benchmarks**
-- **Atari-57** – mean human-normalised score exceeds 1000%, surpassing prior agents.
-- **Go (19×19)** – achieves AlphaZero-level Elo ratings.
-- **Chess / Shogi** – matches AlphaZero with fewer training games.
+
+| Setting | Signal | Why it matters |
+| ------- | ------ | -------------- |
+| Atari-57 | Mean human-normalized score exceeds 1000% | Shows the learned latent model works beyond perfect-information board games. |
+| Go 19x19 | Achieves AlphaZero-level Elo ratings | Matches a search-based expert system without hand-coded game rules. |
+| Chess / Shogi | Matches AlphaZero with fewer training games | Tests whether the same model-based planning recipe transfers across rule systems. |
 
 **Critiques & limitations:** MuZero is elegant because it preserves the strength of search without requiring explicit rules. The cost is large. Training used enormous compute, inference requires MCTS, and the learned dynamics remain hard to interpret: the model plans well, but it is not obvious what environment structure it has actually learned.
 

--- a/src/content/posts/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.md
+++ b/src/content/posts/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.md
@@ -19,6 +19,21 @@ summary: Molmo argued that high-quality open multimodal data can matter more tha
 
 This matters because many VLMs are hard to inspect. Molmo makes the data story more visible, which makes the model easier to study and reuse.
 
+![Vision-language model stack schematic](/assets/images/vlm-stack-schematic.svg)
+
+**What to look at:**
+- PixMo data quality is the main mechanism: detailed human captions and pointing supervision.
+- Open weights plus open data make the model easier to audit than closed VLMs.
+- The interesting comparison is data quality versus raw data quantity.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Data | PixMo collection | Rich captions and pointing supervision improve grounding. |
+| Openness | Open weights and data | Makes the training story inspectable. |
+| Signal | Small models compete strongly | Suggests annotation quality can substitute for some scale. |
+
 **Why it mattered:** The paper strengthened the case that VLM progress is not just architecture scale. Annotation style, spatial grounding, and openness can move the frontier too.
 
 **Take-home message:** For multimodal models, the caption is part of the architecture. Better supervision changes what the model can see.

--- a/src/content/posts/openvla-open-source-vision-language-action-model.md
+++ b/src/content/posts/openvla-open-source-vision-language-action-model.md
@@ -19,6 +19,21 @@ summary: OpenVLA released a 7B open robot policy trained on 970k real robot demo
 
 The open release matters: checkpoints, code, and fine-tuning recipes make generalist robot policies easier to study and adapt.
 
+![Vision-language-action stack schematic](/assets/images/robot-vla-stack-schematic.svg)
+
+**What to look at:**
+- The visual encoder fuses SigLIP and DINOv2 features.
+- The policy is trained on Open X-Embodiment robot demonstrations.
+- The open checkpoints and fine-tuning notebooks are core artifacts.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Scale | 7B VLA | Large enough to reuse language-model priors. |
+| Data | 970k robot demonstrations | Gives the model cross-embodiment behavior. |
+| Artifact | Open code/checkpoints | Makes generalist robot policies inspectable. |
+
 **Why it mattered:** OpenVLA made the VLA recipe concrete and public. It also showed that Internet-scale vision-language pretraining can combine with robot demonstration data to produce transferable manipulation policies.
 
 **Take-home message:** OpenVLA is the CLIP-to-actions moment: visual-language representations become a starting point for robot control.

--- a/src/content/posts/pi0-vision-language-action-flow-model-for-general-robot-control.md
+++ b/src/content/posts/pi0-vision-language-action-flow-model-for-general-robot-control.md
@@ -19,6 +19,21 @@ summary: Pi0 used a VLM backbone and flow matching to turn visual-language conte
 
 The paper adds an action generation mechanism based on flow matching, allowing the model to map images and language instructions into robot trajectories across tasks.
 
+![Vision-language-action stack schematic](/assets/images/robot-vla-stack-schematic.svg)
+
+**What to look at:**
+- A pretrained VLM backbone is adapted to output continuous robot actions.
+- Flow matching is the action-generation mechanism.
+- The model tests whether a generalist policy can transfer across tasks and embodiments.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Input | Images plus language goals | Uses VLM semantics for robot context. |
+| Output | Continuous actions | Requires smooth control, not text. |
+| Mechanism | Flow matching | Models action trajectories for dexterous behavior. |
+
 **Why it mattered:** Pi0 is part of the shift from models that understand scenes to models that act in them. It treats robot control as a foundation-model problem rather than a collection of isolated policies.
 
 **Take-home message:** Embodied VLMs need an action head that respects physics. Language understanding is useful, but control requires smooth continuous outputs.

--- a/src/content/posts/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.md
+++ b/src/content/posts/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.md
@@ -19,6 +19,21 @@ summary: Qwen2-VL made resolution and video length more flexible by letting visu
 
 The model family also handles images and video with a shared multimodal position encoding, making it useful for OCR-heavy tasks, documents, visual reasoning, and longer temporal inputs.
 
+![Vision-language model stack schematic](/assets/images/vlm-stack-schematic.svg)
+
+**What to look at:**
+- Naive dynamic resolution makes visual token count follow the input rather than a fixed resize.
+- Multimodal RoPE supports images and video in one positional scheme.
+- OCR, documents, and long-video tasks are the best places to look for the payoff.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Resolution | Dynamic visual tokens | Preserves small text and high-resolution detail. |
+| Modalities | Image plus video | One model handles static and temporal inputs. |
+| Artifact | Qwen2-VL docs/project | Useful for OCR-heavy and multilingual multimodal tasks. |
+
 **Why it mattered:** Resolution is not cosmetic. If a model cannot preserve the evidence, the language model hallucinates around it. Qwen2-VL showed that flexible tokenization can make generalist VLMs much more usable.
 
 **Take-home message:** VLMs need adaptive visual bandwidth. A receipt, a street scene, and a video clip should not all be squeezed through the same fixed visual bottleneck.

--- a/src/content/posts/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.md
+++ b/src/content/posts/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.md
@@ -17,6 +17,21 @@ summary: SENNA split driving into high-level language planning and low-level tra
 
 This makes the language layer inspectable. A planner can say what it intends to do before the control module turns that intent into geometry.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- Senna-VLM produces high-level textual plans.
+- Senna-E2E turns those plans into precise trajectories.
+- The interface is inspectable and potentially editable.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Decomposition | Language plan plus control module | Separates semantic intent from numeric control. |
+| Training | Planning-oriented QA and curriculum | Tunes the VLM for traffic decisions. |
+| Caveat | Language plan is not a guarantee | Control still needs safety validation. |
+
 **Why it mattered:** SENNA captures a useful decomposition for safety-critical systems: use language for semantic planning, but keep numeric control in a component designed for precision.
 
 **Take-home message:** The most useful VLM in a driving stack may be the one that thinks out loud at the right abstraction level.

--- a/src/content/posts/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.md
+++ b/src/content/posts/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.md
@@ -17,6 +17,21 @@ summary: TOD3Cap asked driving models to detect outdoor 3D objects and caption t
 
 That is harder than standard object detection because it requires attributes, context, and grounded descriptions, not just boxes and class IDs.
 
+![Driving VLM loop schematic](/assets/images/driving-vlm-loop-schematic.svg)
+
+**What to look at:**
+- The task combines 3D localization with object-level captions.
+- LiDAR plus RGB fusion matters because captions are grounded to 3D boxes.
+- This is a perception-to-explanation benchmark.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Dataset | 850 scenes / 64.3k objects / 2.3M captions | Large outdoor dense-captioning setup. |
+| Task | 3D object captioning | Requires boxes plus descriptions. |
+| Use case | Scene explanation and planner context | Turns perception into grounded language. |
+
 **Why it mattered:** Dense captioning is a bridge between perception and explanation. A driving system that can say what every relevant object is doing has a better interface to planners, annotators, and safety reviewers.
 
 **Take-home message:** Rich scene understanding requires language that is spatially grounded. Captions without 3D grounding are not enough for driving.

--- a/src/content/posts/videollama-3-frontier-multimodal-foundation-models.md
+++ b/src/content/posts/videollama-3-frontier-multimodal-foundation-models.md
@@ -19,6 +19,21 @@ summary: VideoLLaMA 3 showed that strong image understanding can be the foundati
 
 The key claim is that high-quality image-text learning carries a lot of the load for video. Video data still matters, but the model does not need to learn all semantics from video clips alone.
 
+![Vision-language model stack schematic](/assets/images/vlm-stack-schematic.svg)
+
+**What to look at:**
+- High-quality image-text alignment is treated as the foundation for video.
+- Variable-resolution visual encoding helps preserve image detail.
+- Token merging makes longer video contexts cheaper.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Training stages | Image alignment then video tuning | Uses image semantics before temporal specialization. |
+| Efficiency | Dynamic token merging | Compresses redundant visual tokens across frames. |
+| Evidence | Image and video benchmarks | Checks whether video gains preserve image understanding. |
+
 **Why it mattered:** It connects the image VLM and video VLM stories. If static visual grounding is strong, video becomes a temporal extension rather than a separate world.
 
 **Take-home message:** Video VLMs are constrained by visual token budgets. Good image features plus careful temporal compression are the practical path.

--- a/src/content/posts/visual-instruction-tuning-llava.md
+++ b/src/content/posts/visual-instruction-tuning-llava.md
@@ -19,6 +19,21 @@ summary: LLaVA showed that a frozen vision encoder, an LLM, and synthetic instru
 
 That made image understanding feel like chat. A model could describe an image, answer questions, and follow open-ended visual instructions instead of only producing class labels or retrieval scores.
 
+![Vision-language model stack schematic](/assets/images/vlm-stack-schematic.svg)
+
+**What to look at:**
+- CLIP image encoder plus Vicuna language model joined by a learned projection layer.
+- GPT-4-generated visual instruction data is the enabling data trick, not a new visual backbone.
+- Use ScienceQA/chat behavior as a signal, but remember this is still synthetic-instruction tuning.
+
+**Evals / Benchmarks / Artifacts:**
+
+| Signal | Detail | Why it matters |
+| ------ | ------ | -------------- |
+| Interface | Image-to-chat assistant | Turns visual representations into dialogue. |
+| Training signal | Visual instruction tuning | Synthetic QA data teaches the model how to answer about images. |
+| Artifact | Project page and code | The LLaVA recipe became a common open baseline. |
+
 **Why it mattered:** LLaVA made the VLM stack modular: vision encoder, projector, LLM, instruction data. That template became the default starting point for many open multimodal assistants.
 
 **Take-home message:** The jump from CLIP to LLaVA is the jump from representation to interface. Once vision features were wired into an instruction-tuned LLM, VLMs became conversational systems.


### PR DESCRIPTION
## What changed
- added reusable SVG schematics for VLM, driving VLM, robotics VLA, and GAN notes
- enriched VLM/driving/robotics Arxiv Notes with diagrams, what-to-look-at bullets, and compact evidence/artifact tables
- added missing benchmark tables for Attention, MuZero, and GAN

## Why
Paper notes should preserve the relevant mechanism, evidence, artifacts, and caveats on the page rather than stopping at prose summaries.

## Testing
- npm run ci
- pre-push hook reran npm run ci successfully

## Note
The local Codex paper-writing skill was also updated to require visuals/tables/artifacts for future Arxiv Notes; that lives outside this repository.