### PR TITLE
[codex] Clean up homepage section headings

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1355,7 +1355,6 @@ body.home-page small {
   z-index: 1;
 }
 
-.home-hero__bar,
 .home-hero__content,
 .home-shelf__header {
   display: flex;
@@ -1363,16 +1362,6 @@ body.home-page small {
   gap: 0.85rem;
 }
 
-.home-hero__bar {
-  align-items: center;
-  margin-bottom: 0.8rem;
-}
-
-.home-kicker,
-.home-hero__context,
-.home-panel__eyebrow,
-.links-panel__eyebrow,
-.timeline-panel__eyebrow,
 .home-stat-list dt,
 .home-post-list small {
   margin: 0;
@@ -1382,16 +1371,8 @@ body.home-page small {
   text-transform: uppercase;
 }
 
-.home-kicker,
-.home-panel__eyebrow,
-.links-panel__eyebrow,
-.timeline-panel__eyebrow,
 .home-stat-list dt {
   color: var(--home-shell-accent);
-}
-
-.home-hero__context {
-  color: var(--home-shell-muted);
 }
 
 .home-hero__content {
@@ -1508,6 +1489,8 @@ body.home-page small {
   display: grid;
   gap: 0.25rem;
   margin-bottom: 0.85rem;
+  font-size: clamp(1.55rem, 2.2vw, 2rem);
+  line-height: 1.08;
 }
 
 .home-panel__heading h2 {

--- a/src/components/LinksPanel.astro
+++ b/src/components/LinksPanel.astro
@@ -4,7 +4,6 @@ import { CONTACT_LINKS } from '../lib/site';
 ---
 
 <section class="links-panel">
-  <p class="links-panel__eyebrow">Connect</p>
   <h2 class="links-panel__title">Contact Me</h2>
   <ul class="link-list">
     {CONTACT_LINKS.map((link) => (

--- a/src/components/TimelinePanel.astro
+++ b/src/components/TimelinePanel.astro
@@ -13,7 +13,6 @@ const { entries } = Astro.props;
 ---
 
 <section class="timeline-panel" aria-labelledby="timeline-title">
-  <p class="timeline-panel__eyebrow">Timeline</p>
   <h2 class="timeline-panel__title" id="timeline-title">Journey Through Robotics</h2>
   <ol class="timeline-list">
     {entries.map((entry) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -144,11 +144,6 @@ const formatDate = (date: Date) =>
 
 <HomeLayout title="Home" timelineEntries={timelineEntries}>
   <section class="home-hero" id="top">
-    <div class="home-hero__bar">
-      <p class="home-kicker">Arunabh.BLOG</p>
-      <p class="home-hero__context">Computer vision / robotics / notes</p>
-    </div>
-
     <div class="home-hero__content">
       <div class="home-hero__copy">
         <h1 class="home-title">ARUNABH.BLOG</h1>
@@ -178,10 +173,9 @@ const formatDate = (date: Date) =>
   </section>
 
   <section class="home-story-grid" id="about">
-    <article class="home-panel home-panel--story">
+    <article class="home-panel home-panel--story" aria-labelledby="about-title">
       <div class="home-panel__heading">
-        <p class="home-panel__eyebrow">About</p>
-        <h2>What this site is</h2>
+        <h2 id="about-title">About me</h2>
       </div>
       <p class="intro-text">
         I work in computer vision research at Zoox, where I build learned representations for
@@ -201,10 +195,9 @@ const formatDate = (date: Date) =>
       </p>
     </article>
 
-    <article class="home-panel home-panel--map" id="sections">
+    <article class="home-panel home-panel--map" id="sections" aria-labelledby="sections-title">
       <div class="home-panel__heading">
-        <p class="home-panel__eyebrow">Start here</p>
-        <h2>Reading paths</h2>
+        <h2 id="sections-title">Writing and notes</h2>
       </div>
       <ul class="home-section-map">
         {sectionCards.map((section) => (
@@ -224,8 +217,7 @@ const formatDate = (date: Date) =>
 
   <section class="home-shelves" id="latest">
     <div class="home-section-heading">
-      <p class="home-panel__eyebrow">Latest</p>
-      <h2>Recent entries</h2>
+      <h2>Latest writing</h2>
       <p>
         The newest hand-written entries across the site, grouped by the kind of work they do.
       </p>


### PR DESCRIPTION
## Summary

- Remove redundant homepage eyebrow labels from the hero, about, section map, latest, contact, and timeline panels.
- Rename the visible homepage headings so they match the content: About me, Writing and notes, and Latest writing.
- Drop the now-unused homepage label selectors from the shared stylesheet.

## Validation

- `npm run check`
- `npm run build`
- pre-push `npm run ci` including tests and build verification