### PR TITLE
Enrich arXiv paper notes

### DIFF
--- a/src/content/posts/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
+++ b/src/content/posts/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
@@ -21,6 +21,10 @@ summary: ViT showed that patchified images and standard Transformer encoders can
 
 **Conference:** ICLR 2021
 
+## Paper map
+
+ViT treats an image as a sequence problem: split the image into fixed-size patches, linearly embed each patch, add a class token plus positional embeddings, and run a standard Transformer encoder. The paper's important condition is scale. Pure attention underperforms CNN inductive bias on smaller datasets, but large pretraining on JFT-300M or ImageNet-21k lets the architecture transfer strongly to ImageNet, CIFAR, Oxford Flowers/Pets, and VTAB. The evidence is not just accuracy; it is the compute tradeoff showing that large ViTs can match or beat strong convolutional models with fewer training resources once enough pretraining data is available. The main caveat is data hunger: ViT deliberately removes locality and translation bias, so it needs pretraining scale or regularization to learn those patterns.
+
 ![Figure 1: Model overview from An Image Is Worth 16×16 Words: Transformers for Image Recognition at Scale](/assets/images/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale-paper-figure.png)
 _Figure 1: Model overview. From the [An Image Is Worth 16×16 Words: Transformers for Image Recognition at Scale paper](https://arxiv.org/abs/2010.11929), via arXiv HTML._
 

--- a/src/content/posts/are-vlms-ready-for-autonomous-driving-drivebench.md
+++ b/src/content/posts/are-vlms-ready-for-autonomous-driving-drivebench.md
@@ -17,6 +17,10 @@ summary: DriveBench tested whether VLM driving answers are visually grounded or 
 
 The important finding is uncomfortable: models can give confident and plausible answers without grounding them in the visual input. Corruptions expose this because the answer often should change when the evidence changes.
 
+## Paper map
+
+DriveBench asks whether VLMs are reliable enough for autonomous driving, not just whether they answer clean image questions. It evaluates visual grounding, robustness, and task metrics across perception, prediction, planning, and text QA. The benchmark corrupts driving inputs with conditions such as brightness shifts, fog, snow, rain, blur, zoom, compression, and bit errors. The central result is that VLMs can look capable on normal scenes while failing under realistic sensor degradation or poor grounding. The paper is useful because it changes the evaluation target from capability demos to reliability under driving-specific stress.
+
 ![Figure 1 from DriveBench: benchmark overview across perception, prediction, behavior, and planning](/assets/images/drivebench-paper-figure-1-overview.png)
 _Figure 1 from the [DriveBench paper](https://arxiv.org/abs/2501.04003), cropped from the arXiv PDF._
 

--- a/src/content/posts/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.md
+++ b/src/content/posts/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.md
@@ -17,6 +17,10 @@ summary: AsyncDriver separated slow LLM reasoning from fast motion planning so s
 
 Those instructions can guide the planner through complex or ambiguous situations without requiring the LLM to produce every control update.
 
+## Paper map
+
+AsyncDriver uses an LLM as a high-level driving advisor without putting that LLM directly in the synchronous planning loop. The planner keeps generating trajectories while the language model asynchronously contributes scene reasoning or strategic guidance. This design tries to preserve real-time control while still benefiting from language-level interpretation of traffic context. The key tradeoff is staleness: asynchronous advice can reduce latency, but the system must know when guidance no longer matches the current scene. The paper matters as a pattern for using foundation models near safety-critical loops instead of making every control update wait on them.
+
 ![Figure 2: Overview of our proposed AsyncDriver framework from AsyncDriver: Asynchronous Large Language Model Enhanced Planner for Autonomous Driving](/assets/images/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving-paper-figure.png)
 _Figure 2: Overview of our proposed AsyncDriver framework. From the [AsyncDriver: Asynchronous Large Language Model Enhanced Planner for Autonomous Driving paper](https://arxiv.org/abs/2406.14556), via arXiv HTML._
 

--- a/src/content/posts/attention-is-all-you-need.mdx
+++ b/src/content/posts/attention-is-all-you-need.mdx
@@ -56,6 +56,10 @@ The paper's core math is easier to trust when you can poke at small numbers your
 
 <PythonPlayground client:visible {...attentionIsAllYouNeedPlayground} />
 
+## Paper map
+
+The Transformer replaces recurrence with stacked self-attention and position-wise feed-forward layers. The encoder lets every source token attend to every other source token; the decoder adds masked self-attention so future target tokens remain hidden, then cross-attends to encoder states. Multi-head attention splits representation space so different heads can track different relations, while residual connections, layer normalization, label smoothing, and dropout stabilize training. The empirical case is machine translation: strong BLEU on WMT English-German and English-French with much more parallel training than RNNs. The core limitation is quadratic attention cost in sequence length. The lasting idea is that sequence modeling can be built around content-addressed token interaction rather than step-by-step recurrence.
+
 <img src="/assets/images/attention.png" alt="Transformer" style="max-width:60%;margin:1rem auto;display:block;" />
 
 ### Positional encoding

--- a/src/content/posts/auto-encoding-variational-bayes.md
+++ b/src/content/posts/auto-encoding-variational-bayes.md
@@ -19,6 +19,10 @@ summary: VAEs made latent-variable models trainable with SGD by turning stochast
 
 **Conference:** ICLR 2014
 
+## Paper map
+
+The VAE paper solves inference for latent-variable models whose posterior is intractable but differentiable. It introduces the reparameterization trick: sample noise from a fixed distribution, transform it through encoder outputs, and backpropagate through the stochastic latent variable. The objective is the evidence lower bound, combining reconstruction likelihood with a KL term that keeps the approximate posterior near the prior. An encoder, or recognition model, amortizes inference across datapoints instead of optimizing a separate variational distribution for each one. The experiments show generative modeling and semi-supervised learning can be trained with stochastic gradient descent. The caveat is the usual VAE tradeoff: simple likelihoods and strong KL pressure can produce blurry samples or underused latents.
+
 ![Figure from Auto-Encoding Variational Bayes: AEVB improves the variational lower bound over wake-sleep](/assets/images/vae-paper-figure-1.png)
 _Figure from the [AEVB paper](https://arxiv.org/abs/1312.6114), via ar5iv._
 

--- a/src/content/posts/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.md
+++ b/src/content/posts/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.md
@@ -17,6 +17,10 @@ summary: AutoTrust evaluated driving VLMs across hallucination, safety, robustne
 
 That means questions can test whether a model hallucinates, gives unsafe advice, leaks sensitive information, breaks under perturbations, or behaves inconsistently across groups and regions.
 
+## Paper map
+
+AutoTrust reframes driving VLM evaluation around trustworthiness. It tests truthfulness, safety, robustness, privacy, and fairness over more than 10k scenes and 18k queries. The benchmark is designed to expose hallucination, unsafe advice, sensitive-information leakage, adversarial brittleness, and unfair or inconsistent behavior across driving contexts. One important finding is that driving specialization does not automatically improve trustworthiness; general VLMs can outperform specialist driving models on some axes. The limitation is that VQA-style trust tests still do not replace closed-loop validation, but they reveal failures ordinary accuracy benchmarks miss.
+
 ![Figure 1 from AutoTrust: benchmark overview for DriveVLM trustworthiness](/assets/images/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driv-paper-figure.png)
 _Figure 1 from the [AutoTrust paper](https://arxiv.org/abs/2412.15206), via arXiv HTML._
 

--- a/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
+++ b/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
@@ -24,6 +24,10 @@ import { bertPlayground } from '../../lib/python-playground-examples';
 **Project page / blog:** [Google AI Blog – "Open Sourcing BERT"](https://ai.googleblog.com/2018/11/open-sourcing-bert-state-of-art-pre.html)  
 **Conference:** NAACL 2019
 
+## Paper map
+
+BERT makes bidirectional pretraining practical by training a Transformer encoder with masked language modeling and next-sentence prediction, then fine-tuning the same backbone for downstream tasks. Masked LM lets each token condition on both left and right context, unlike left-to-right language models. Fine-tuning adds only small task-specific heads for classification, span extraction, or sentence-pair tasks. The empirical case spans GLUE, MultiNLI, SQuAD, and other NLU benchmarks, where deeper bidirectional pretraining beats feature-based and unidirectional baselines. The caveats are the pretrain-finetune mismatch from mask tokens and the later-questioned value of next-sentence prediction. The lasting idea is that one pretrained encoder can become a general language-understanding substrate.
+
 ![Figure 1: Overall pre-training and fine-tuning procedures for BERT from BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](/assets/images/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding-paper-figure.png)
 _Figure 1: Overall pre-training and fine-tuning procedures for BERT. From the [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding paper](https://arxiv.org/abs/1810.04805), via arXiv HTML._
 

--- a/src/content/posts/cambrian-1-vision-centric-exploration-of-multimodal-llms.md
+++ b/src/content/posts/cambrian-1-vision-centric-exploration-of-multimodal-llms.md
@@ -17,6 +17,10 @@ summary: Cambrian-1 treated VLM design as a vision problem first, systematically
 
 The paper tests many vision encoders and introduces a Spatial Vision Aggregator to preserve richer visual information before it reaches the language model.
 
+## Paper map
+
+Cambrian-1 studies the vision components of multimodal LLMs instead of treating the visual encoder as a fixed detail. It compares many visual encoders, examines supervised and self-supervised representations, and introduces CV-Bench to focus on visual grounding. The paper's contribution is both a model family and an evaluation framework for understanding which visual choices actually improve MLLM behavior. The main lesson is that a stronger language model cannot fully compensate for weak perception. The caveat is benchmark interpretation: multimodal scores often mix language priors, OCR, grounding, and reasoning, so improvements need careful attribution.
+
 ![Figure 8 from Cambrian-1: Spatial Vision Aggregator connects multiple vision encoders to the LLM](/assets/images/cambrian-1-paper-figure-8-sva.png)
 _Figure 8 from the [Cambrian-1 paper](https://arxiv.org/abs/2406.16860), cropped from the arXiv PDF._
 

--- a/src/content/posts/can-lvlms-obtain-a-drivers-license-idkb.md
+++ b/src/content/posts/can-lvlms-obtain-a-drivers-license-idkb.md
@@ -17,6 +17,10 @@ summary: IDKB tested whether vision-language models know explicit driving rules,
 
 The result is a useful warning: a model may recognize cars and pedestrians but still fail rule-based reasoning that every licensed human driver is expected to know.
 
+## Paper map
+
+IDKB tests whether LVLMs know driving rules and applied traffic knowledge. The benchmark covers signs, laws, exam-style questions, and scenario reasoning, then evaluates 15 representative LVLMs. Its central claim is that visual-language capability is not the same as driving competence: a model may recognize a road scene but still choose an illegal or unsafe action. The benchmark is valuable because autonomous driving needs rule knowledge, not only perception. The caveat is scope: passing IDKB would show specialized knowledge, but it would not prove planning, control, or closed-loop safety.
+
 ![Figure 1: Performance of 15 representative Large Vision-Language Models on IDKB, evaluated by three driving knowledge understanding metrics from Can LVLMs Obtain a Driver's License?](/assets/images/can-lvlms-obtain-a-drivers-license-idkb-paper-figure.png)
 _Figure 1: Performance of 15 representative Large Vision-Language Models on IDKB, evaluated by three driving knowledge understanding metrics. From the [Can LVLMs Obtain a Driver's License? paper](https://arxiv.org/abs/2409.02914), via arXiv HTML._
 

--- a/src/content/posts/deep-residual-learning-for-image-recognition.md
+++ b/src/content/posts/deep-residual-learning-for-image-recognition.md
@@ -19,6 +19,10 @@ summary: ResNet made very deep CNNs practical by learning residual updates and c
 
 **Conference:** CVPR 2016 (1st place ILSVRC 2015 classifier)
 
+## Paper map
+
+ResNet addresses the degradation problem: deeper plain networks can have higher training error even though, in principle, extra layers could learn identity mappings. The residual block changes the target from learning H(x) directly to learning F(x) = H(x) - x, then adds the shortcut x back. Identity shortcuts add almost no parameters or compute but make very deep optimization tractable. The evidence covers ImageNet and CIFAR, including 50-, 101-, and 152-layer networks that outperform shallower baselines and win major recognition/detection tasks. The limitation is not conceptual but architectural: later work still had to refine normalization, bottlenecks, width, and training recipes. The lasting idea is that skip connections make depth usable.
+
 ![Residual block schematic](/assets/images/resnet.png)
 _Residual-block diagram from the ResNet paper/project materials._
 

--- a/src/content/posts/deepseek-vl2-mixture-of-experts-vision-language-models.md
+++ b/src/content/posts/deepseek-vl2-mixture-of-experts-vision-language-models.md
@@ -19,6 +19,10 @@ summary: DeepSeek-VL2 combined dynamic high-resolution tiling with sparse MoE la
 
 The result is especially relevant for OCR, documents, tables, charts, and visual grounding, where resizing or compressing the image too aggressively destroys the answer.
 
+## Paper map
+
+DeepSeek-VL2 combines high-resolution visual processing with a sparse MoE language backbone. Dynamic tiling lets the vision encoder preserve detail across different image sizes and aspect ratios, which helps OCR, documents, tables, charts, and grounding. DeepSeekMoE with Multi-head Latent Attention improves inference efficiency by activating only part of the model and compressing KV cache information. The paper evaluates a family of model sizes across broad multimodal tasks. The tradeoff is serving complexity: dynamic visual tokens and MoE routing improve capability per active parameter, but they make implementation, batching, and latency management harder.
+
 ![Figure 1 from DeepSeek-VL2: average performance versus activated parameters](/assets/images/deepseek-vl2-mixture-of-experts-vision-language-models-paper-figure.png)
 _Figure 1 from the [DeepSeek-VL2 paper](https://arxiv.org/abs/2412.10302), via arXiv HTML._
 

--- a/src/content/posts/denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/denoising-diffusion-probabilistic-models.md
@@ -21,6 +21,10 @@ summary: DDPMs turned generation into learned denoising, trading slow sampling f
 
 **Conference:** NeurIPS 2020
 
+## Paper map
+
+DDPM frames generation as learning to reverse a gradual noising process. The forward chain adds Gaussian noise until data becomes nearly pure noise; the reverse model learns denoising transitions that reconstruct samples step by step. The training objective can be written as a variational bound, but the practical loss predicts noise and connects to denoising score matching. The paper's evidence is high-quality image synthesis on CIFAR-10 and LSUN, with strong FID and a useful progressive decompression interpretation. The main cost is sampling: generation requires many sequential denoising steps, making early DDPMs slower than GANs. The lasting idea is that likelihood-based latent-variable models can produce strong samples when trained as iterative denoisers.
+
 ![Figure 2 from DDPM: the directed graphical model for forward noising and learned reverse denoising](/assets/images/ddpm-paper-figure-2-graphical-model.png)
 _Figure 2 from the [DDPM paper](https://arxiv.org/abs/2006.11239), via ar5iv._
 

--- a/src/content/posts/dexvla-vision-language-model-with-plug-in-diffusion-expert.md
+++ b/src/content/posts/dexvla-vision-language-model-with-plug-in-diffusion-expert.md
@@ -17,6 +17,10 @@ summary: DexVLA paired VLM reasoning with a diffusion policy expert for long-hor
 
 This hybrid design is useful for dexterous, long-horizon tasks where pure language-model action generation may be too coarse and pure diffusion may lack semantic planning.
 
+## Paper map
+
+DexVLA argues that action modeling is a bottleneck for vision-language-action systems. It adds a large diffusion-based action expert to a VLM so the system can model continuous, multi-step robot behavior rather than only discrete tokens. The training recipe uses cross-embodiment pretraining and curriculum learning before adapting to dexterous, long-horizon tasks. The evidence focuses on diverse manipulation skills across robot embodiments. The main caveat is cost: a billion-parameter action expert can represent smoother control, but it is expensive to train and must still be validated under real robot distribution shift.
+
 ![Figure 1: DexVLA architecture and embodied curriculum learning from DexVLA: Vision-Language Model with Plug-In Diffusion Expert for General Robot Control](/assets/images/dexvla-vision-language-model-with-plug-in-diffusion-expert-paper-figure.png)
 _Figure 1: DexVLA architecture and embodied curriculum learning. From the [DexVLA: Vision-Language Model with Plug-In Diffusion Expert for General Robot Control paper](https://arxiv.org/abs/2502.05855), via arXiv HTML._
 

--- a/src/content/posts/direct-preference-optimization-dpo.md
+++ b/src/content/posts/direct-preference-optimization-dpo.md
@@ -19,6 +19,10 @@ summary: DPO replaced explicit reward modeling and PPO with a direct preference 
 
 **Conference:** NeurIPS 2023 (spotlight)
 
+## Paper map
+
+DPO turns preference optimization into a supervised classification-style objective and removes the explicit reward model plus RL loop used in RLHF. Starting from a reference policy and preference pairs, the derivation shows that the optimal policy under a KL-constrained reward objective can be written directly in terms of preference likelihoods. Training then increases the log-probability gap between chosen and rejected responses while keeping the policy near the reference model through the implicit KL term. The empirical case compares against PPO-style RLHF on summarization, dialogue, and instruction-following style tasks. The caveat is that DPO inherits the preference dataset's coverage and quality; it is simpler than RLHF, but not a replacement for good preference data or careful safety evaluation.
+
 ![Figure 1: DPO optimizes for human preferences while avoiding reinforcement learning from Direct Preference Optimization](/assets/images/direct-preference-optimization-dpo-paper-figure.png)
 _Figure 1: DPO optimizes for human preferences while avoiding reinforcement learning. From the [Direct Preference Optimization paper](https://arxiv.org/abs/2305.18290), via arXiv HTML._
 

--- a/src/content/posts/distilling-multimodal-large-language-models-for-autonomous-driving.md
+++ b/src/content/posts/distilling-multimodal-large-language-models-for-autonomous-driving.md
@@ -17,6 +17,10 @@ summary: DIMA used a large multimodal driving model as a teacher, distilling its
 
 The result is a model that keeps more of the teacher's traffic knowledge while avoiding a full LLM in the runtime loop.
 
+## Paper map
+
+DiMA distills an expensive multimodal or language-enhanced driving planner into an efficient LLM-free planner. The teacher contributes world knowledge and long-tail reasoning; the student learns to reproduce useful planning behavior without calling an LLM at deployment time. The target setting is rare or difficult maneuvers where language reasoning can help, such as overtaking and three-point turns. The key benefit is latency and compute reduction. The caveat is that distillation freezes the teacher's behavior into the student, so the deployed model cannot ask new questions or recover reasoning traces at test time.
+
 ![Figure from DiMA: long-tail and zero-shot driving scenarios compared against prior planners](/assets/images/distilling-multimodal-large-language-models-for-autonomous-driving-paper-figure.png)
 _Source figure from the [DiMA paper](https://arxiv.org/abs/2501.09757), via arXiv HTML._
 

--- a/src/content/posts/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.md
+++ b/src/content/posts/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.md
@@ -17,6 +17,10 @@ summary: DriveMM trained one multimodal transformer across perception, predictio
 
 The system takes multi-view driving imagery and produces a unified token sequence that can be decoded into task-specific outputs.
 
+## Paper map
+
+DriveMM, presented as RoboTron-Drive in the paper, tries to unify autonomous-driving tasks in one large multimodal model. It handles multiple datasets and task types through a shared model and prompt formulation instead of training separate specialized networks for every perception, prediction, or planning task. The main evidence is broad performance across six datasets and 13 tasks, including zero-shot generalization to unseen datasets. The limitation is that all-in-one benchmark performance does not prove closed-loop driving safety. The paper is best read as a generalization study for driving LMMs, not as a complete autonomy stack.
+
 ![Figure 1: RoboTron-Drive achieves SOTA in both general capabilities and generalization ability from DriveMM: All-in-One Large Multimodal Model for Autonomous Driving](/assets/images/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving-paper-figure.jpg)
 _Figure 1: RoboTron-Drive achieves SOTA in both general capabilities and generalization ability. From the [DriveMM: All-in-One Large Multimodal Model for Autonomous Driving paper](https://arxiv.org/abs/2412.07689), via arXiv HTML._
 

--- a/src/content/posts/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.md
+++ b/src/content/posts/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.md
@@ -17,6 +17,10 @@ summary: DriveVLM combined VLM reasoning with hierarchical planning, then paired
 
 That hybrid design is the interesting part. The VLM contributes semantic reasoning about rare or complex situations; the conventional stack keeps the control loop more grounded.
 
+## Paper map
+
+DriveVLM explores how VLM reasoning can support autonomous driving. It uses language-level scene understanding and hierarchical planning, with a dual variant that combines VLM semantics with conventional driving modules. The evaluation covers public driving datasets and deployment-oriented tests, aiming to show that VLMs can help decompose complex scenes and decisions. The design question is where the VLM belongs: it can reason and explain, but low-level control still needs geometry, timing, and safety constraints. The caveat is standard for driving VLMs: semantic competence is not the same as robust closed-loop planning.
+
 ![Figure 1: DriveVLM and DriveVLM-Dual model pipelines from DriveVLM: The Convergence of Autonomous Driving and Large Vision-Language Models](/assets/images/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models-paper-figure.png)
 _Figure 1: DriveVLM and DriveVLM-Dual model pipelines. From the [DriveVLM: The Convergence of Autonomous Driving and Large Vision-Language Models paper](https://arxiv.org/abs/2402.12289), via arXiv HTML._
 

--- a/src/content/posts/driving-with-llms-fusing-object-level-vector-modality.md
+++ b/src/content/posts/driving-with-llms-fusing-object-level-vector-modality.md
@@ -19,6 +19,10 @@ summary: Driving with LLMs fed object-level vector scene state into language mod
 
 The bet is that language models may reason better when perception has already converted pixels into meaningful objects, positions, and relationships.
 
+## Paper map
+
+Driving with LLMs feeds structured object-level vectors into a language model instead of raw pixels. A Vector-Former converts detected agents, lanes, and scene state into tokens that the LLM can use for QA and action generation. This makes the driving state more explicit and the model's outputs easier to explain. The method depends heavily on upstream perception: missing or incorrect objects become misleading language-model input. The paper matters as an interface design for combining modular autonomy state with LLM reasoning.
+
 ![Figure from Driving with LLMs: object-level vector modality feeds a Vector-Former and LLM control loop](/assets/images/driving-with-llms-fusing-object-level-vector-modality-paper-figure.png)
 _Source figure from the [Driving with LLMs paper](https://arxiv.org/abs/2310.01957), via arXiv HTML._
 

--- a/src/content/posts/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.md
+++ b/src/content/posts/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.md
@@ -19,6 +19,10 @@ summary: Eagle 2 made the post-training data recipe the main contribution, showi
 
 The main lesson is that strong VLMs are not just pretrained once and then lightly tuned. Their behavior is shaped by a careful curriculum of visual tasks and response styles.
 
+## Paper map
+
+Eagle 2 is a data-strategy paper for post-training VLMs. Instead of only releasing a final model, it studies how instruction data, ordering, filtering, and staged tuning affect frontier multimodal performance. The contribution is a transparent recipe and ablation trail showing which data choices move OCR, grounding, visual reasoning, and instruction-following behavior. The evidence comes from step-by-step ablations and broad benchmarks. The caveat is reproducibility: post-training data quality and filtering details are hard to copy exactly, and benchmark leakage must be watched closely.
+
 ![Figure 1: Overview of Eagle2-9B’s result across different multimodal benchmarks, in comparison to state-of-the-art open-source and commercial frontier models from Eagle 2: Building Post-Training Data Strategies from Scratch for Frontier Vision-Language Models](/assets/images/eagle-2-post-training-data-strategies-for-frontier-vision-language-models-paper-figure.png)
 _Figure 1: Overview of Eagle2-9B’s result across different multimodal benchmarks, in comparison to state-of-the-art open-source and commercial frontier models. From the [Eagle 2: Building Post-Training Data Strategies from Scratch for Frontier Vision-Language Models paper](https://arxiv.org/abs/2501.14818), via arXiv HTML._
 

--- a/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
+++ b/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
@@ -21,6 +21,10 @@ summary: EfficientDet paired BiFPN feature fusion with compound scaling to make 
 
 **Conference:** CVPR 2020
 
+## Paper map
+
+EfficientDet adapts EfficientNet-style scaling to object detection. Its first ingredient is BiFPN, a weighted bidirectional feature pyramid that repeatedly fuses multi-scale features while learning how much each input matters. Its second ingredient is compound scaling across backbone, feature network, prediction heads, and input resolution. The model family D0 through D7 gives a smooth compute-accuracy ladder. The evidence is COCO detection performance versus FLOPs and parameters, where EfficientDet reaches strong accuracy at much lower cost than prior detectors. The caveat is that efficiency depends on the whole recipe: backbone, feature fusion, scaling, and training settings all contribute. The paper matters because it made detector scaling systematic rather than hand-tuned.
+
 ![Figure 2 from EfficientDet: feature pyramid variants compared against BiFPN](/assets/images/efficientdet-paper-figure-2-bifpn.png)
 _Figure 2 from the [EfficientDet paper](https://arxiv.org/abs/1911.09070), via ar5iv._
 

--- a/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
+++ b/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
@@ -21,6 +21,10 @@ summary: EfficientNet made CNN scaling more systematic by growing depth, width, 
 
 **Conference:** ICML 2019
 
+## Paper map
+
+EfficientNet asks how to scale a ConvNet once a good baseline exists. Instead of independently increasing depth, width, or input resolution, compound scaling uses one coefficient to grow all three dimensions in a balanced way. The authors first search for an efficient baseline, EfficientNet-B0, then scale it to B1-B7 under resource constraints. The empirical case is ImageNet accuracy versus parameters/FLOPs, with transfer results showing that the same family works beyond ImageNet. The key insight is that more resolution needs enough depth and width to use the extra pixels, while more width/depth alone wastes compute. The caveat is that the baseline architecture and search space still matter; compound scaling is not magic for a weak base model.
+
 ![Figure 2 from EfficientNet: compound scaling balances network width, depth, and resolution](/assets/images/efficientnet-paper-figure-2-model-scaling.png)
 _Figure 2 from the [EfficientNet paper](https://arxiv.org/abs/1905.11946), via ar5iv._
 

--- a/src/content/posts/emma-end-to-end-multimodal-model-for-autonomous-driving.md
+++ b/src/content/posts/emma-end-to-end-multimodal-model-for-autonomous-driving.md
@@ -19,6 +19,10 @@ summary: EMMA represented driving inputs and outputs as language tokens so one m
 
 The striking design choice is to represent many non-sensor inputs and outputs as text. That lets the model reuse the structure and world knowledge of a multimodal language model while training across several driving tasks.
 
+## Paper map
+
+EMMA builds autonomous-driving outputs on top of a multimodal foundation model. It maps camera inputs, navigation instructions, ego state, road graph elements, objects, and trajectories into a unified language-like interface with task-specific prompts. The paper's evidence includes strong motion planning on nuScenes and competitive Waymo motion results. The appeal is one model for several driving outputs; the risk is precision. Text-style serialization must still produce exact geometry, calibrated trajectories, and low-latency behavior for safety-critical driving.
+
 ![Figure 1: EMMA overview diagram from EMMA: End-to-End Multimodal Model for Autonomous Driving](/assets/images/emma-end-to-end-multimodal-model-for-autonomous-driving-paper-figure.png)
 _Figure 1: EMMA overview diagram. From the [EMMA: End-to-End Multimodal Model for Autonomous Driving paper](https://arxiv.org/abs/2410.23262), via arXiv HTML._
 

--- a/src/content/posts/fast-efficient-action-tokenization-for-vision-language-action-models.md
+++ b/src/content/posts/fast-efficient-action-tokenization-for-vision-language-action-models.md
@@ -17,6 +17,10 @@ summary: FAST compressed robot action trajectories into tokens so autoregressive
 
 That enables autoregressive VLA models to train on complex manipulation trajectories without sequence lengths exploding.
 
+## Paper map
+
+FAST improves action tokenization for autoregressive VLA policies. Simple per-timestep, per-dimension bins create long token sequences and handle high-frequency dexterous actions poorly. FAST compresses action chunks in frequency space using a discrete cosine transform, then quantizes the compact coefficients into action tokens. This preserves smooth temporal structure while shortening the sequence the model must generate. The evidence is better training and task performance for high-frequency robot behaviors. The caveat is compression design: too much compression loses control detail, while too little gives up the efficiency benefit.
+
 ![Figure 1: We propose FAST, a simple yet effective approach for tokenization of robot action trajectories via time-series compression from FAST: Efficient Action Tokenization for Vision-Language-Action Models](/assets/images/fast-efficient-action-tokenization-for-vision-language-action-models-paper-figure.jpg)
 _Figure 1: We propose FAST, a simple yet effective approach for tokenization of robot action trajectories via time-series compression. From the [FAST: Efficient Action Tokenization for Vision-Language-Action Models paper](https://arxiv.org/abs/2501.09747), via arXiv HTML._
 

--- a/src/content/posts/generative-adversarial-networks.md
+++ b/src/content/posts/generative-adversarial-networks.md
@@ -19,6 +19,10 @@ summary: GANs framed generation as a two-player game between a generator and dis
 
 **Conference:** NIPS 2014
 
+## Paper map
+
+GANs train a generator and discriminator in a minimax game. The discriminator learns to distinguish real data from generated samples; the generator learns to make samples that fool the discriminator. In the idealized infinite-capacity case, the game reaches the data distribution and the discriminator cannot do better than chance. The practical appeal is that sampling is direct: no Markov chain, no explicit likelihood, and ordinary backpropagation through neural networks. The original experiments use small image datasets and qualitative samples, so the evidence is much weaker than later GAN work. The main caveats are training instability, mode collapse, and the absence of a likelihood metric. The lasting idea is adversarial learning as a generative modeling objective.
+
 ![Figure 1 from GAN: generator samples move through latent space while the discriminator separates real and generated data](/assets/images/generative-adversarial-networks-paper-figure.png)
 _Figure 1 from the [GAN paper](https://arxiv.org/abs/1406.2661), via arXiv HTML._
 

--- a/src/content/posts/gpt-driver-learning-to-drive-with-gpt.md
+++ b/src/content/posts/gpt-driver-learning-to-drive-with-gpt.md
@@ -19,6 +19,10 @@ summary: GPT-Driver reframed motion planning as language modeling over scene tok
 
 This is not a deployable AV stack by itself. It is a useful probe: language models can absorb structured scene descriptions and generate plausible plans, but latency, grounding, and closed-loop reliability remain hard.
 
+## Paper map
+
+GPT-Driver reformulates motion planning as GPT-style sequence generation. It serializes structured scene state into language-model tokens and predicts future waypoints plus a rationale. This gives the model an interpretable interface: the generated plan can be paired with an explanation of the driving decision. The evidence focuses on open-loop planning quality. The caveat is that open-loop waypoint prediction does not prove closed-loop safety, and LLM latency remains a deployment problem. The paper is useful as an early example of adapting pretrained language models to structured planning rather than raw perception.
+
 ![Figure 1: Overview of GPT-Driver from GPT-Driver: Learning to Drive with GPT](/assets/images/gpt-driver-learning-to-drive-with-gpt-paper-figure.png)
 _Figure 1: Overview of GPT-Driver. From the [GPT-Driver: Learning to Drive with GPT paper](https://arxiv.org/abs/2310.01415), via arXiv HTML._
 

--- a/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
@@ -19,6 +19,10 @@ summary: Improved DDPM tightened diffusion likelihoods and made sampling faster 
 
 **Conference:** ICML 2021
 
+## Paper map
+
+Improved DDPM keeps the diffusion framework but fixes practical weaknesses in likelihood and sampling speed. The paper learns reverse-process variances instead of using a fixed variance schedule, studies hybrid objectives that balance sample quality and likelihood, and introduces a cosine noise schedule that allocates denoising difficulty more smoothly. It also shows that fewer sampling steps can preserve quality better than expected. The evidence includes ImageNet and other image-generation experiments comparing FID, negative log-likelihood, and precision/recall. The caveat is that diffusion still requires sequential denoising, so faster sampling is an improvement rather than a full solution. The paper is important because it turned DDPM from a promising sampler into a more scalable generative modeling recipe.
+
 ![Figure 3 from Improved DDPM: linear and cosine noise schedules preserve signal at different rates](/assets/images/improved-ddpm-paper-figure-3-noise-schedule.png)
 _Figure 3 from the [Improved DDPM paper](https://arxiv.org/abs/2102.09672), via ar5iv._
 

--- a/src/content/posts/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.md
+++ b/src/content/posts/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.md
@@ -19,6 +19,10 @@ summary: InternVL 2.5 scaled open multimodal models with better data, training s
 
 The paper is useful because it studies several axes together: vision encoder size, language model size, dataset size, and chain-of-thought style inference. The story is not "just scale everything"; it is that scaling only pays off when the data and training recipe stay balanced.
 
+## Paper map
+
+InternVL 2.5 is an open MLLM scaling and training study. It keeps the InternVL architecture family but improves data quality, model scale, test-time settings, and coverage across images, documents, video, multilingual tasks, grounding, and hallucination benchmarks. The paper compares against strong open and commercial systems, arguing that open models can approach frontier performance when data and inference strategy improve together. The caveat is that broad benchmark averages can hide reliability gaps. The takeaway is that open multimodal progress depends on data, scale, and test-time configuration as a combined system.
+
 ![Figure 1: Performance of various MLLMs on the OpenCompass leaderboard from InternVL 2.5: Expanding Performance Boundaries of Open-Source Multimodal Models](/assets/images/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models-paper-figure.png)
 _Figure 1: Performance of various MLLMs on the OpenCompass leaderboard. From the [InternVL 2.5: Expanding Performance Boundaries of Open-Source Multimodal Models paper](https://arxiv.org/abs/2412.05271), via arXiv HTML._
 

--- a/src/content/posts/language-models-are-few-shot-learners.md
+++ b/src/content/posts/language-models-are-few-shot-learners.md
@@ -19,6 +19,10 @@ summary: GPT-3 showed that scale can turn language models into few-shot learners
 
 **Conference:** NeurIPS 2020 (oral)
 
+## Paper map
+
+GPT-3 tests whether scale can turn next-token pretraining into in-context learning. The model is a 175B-parameter autoregressive Transformer trained on a large mixed text corpus, then evaluated with zero-shot, one-shot, and few-shot prompts instead of task-specific fine-tuning. The paper's core evidence is broad: language modeling, translation, QA, cloze tasks, reasoning-style benchmarks, and synthetic tasks. Performance improves predictably with scale, and few-shot prompting sometimes approaches fine-tuned systems. The caveats are equally central: high compute cost, bias and toxicity inherited from web data, brittle reasoning, and weak performance on some tasks. The lasting idea is that prompts can become the task interface for a general pretrained model.
+
 ![Figure 2.1 from GPT-3: zero-shot, one-shot, few-shot, and fine-tuning evaluation strategies](/assets/images/gpt3-paper-figure-2-1-eval-strategies.png)
 _Figure 2.1 from the [GPT-3 paper](https://arxiv.org/abs/2005.14165), via ar5iv._
 

--- a/src/content/posts/learning-transferable-visual-models-from-natural-language-supervision.md
+++ b/src/content/posts/learning-transferable-visual-models-from-natural-language-supervision.md
@@ -21,6 +21,10 @@ summary: CLIP used image-text contrastive training to make visual representation
 
 **Conference:** Released as a tech report; widely cited (ICML 2021 oral-style spotlight)
 
+## Paper map
+
+CLIP learns visual representations from natural-language supervision instead of fixed class labels. It trains an image encoder and text encoder contrastively so matching image-caption pairs have high similarity and mismatched pairs have low similarity. At inference, classification becomes text retrieval: write prompts for candidate labels and choose the label whose text embedding best matches the image. The evidence is broad zero-shot transfer across many image benchmarks, with strong robustness to distribution shift compared with supervised ImageNet models. The caveat is data dependence: web-scale captions bring noise, bias, and uneven coverage, and prompt wording can change results. The lasting idea is that language can define open-ended visual categories without retraining a classifier.
+
 ![Figure 1 from CLIP: contrastive language-image pre-training and zero-shot transfer](/assets/images/clip-paper-figure-1-contrastive-pretraining.png)
 _Figure 1 from the [CLIP paper](https://arxiv.org/abs/2103.00020), via ar5iv._
 

--- a/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
+++ b/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
@@ -19,6 +19,10 @@ summary: MuZero learned just enough model dynamics to plan with MCTS, without re
 
 **Journal / Conference:** Nature 2020 (pre-print Nov 2019)
 
+## Paper map
+
+MuZero combines learned dynamics with tree search without requiring known game rules. It learns three functions: representation from observations to latent state, dynamics from latent state/action to next latent state plus reward, and prediction from latent state to policy and value. Planning uses MCTS over the learned latent model, optimizing only the quantities needed for control rather than reconstructing observations. The evidence spans Atari-57 and board games such as Go, chess, and shogi, showing one algorithm can plan in visual and perfect-information domains. The caveat is compute and data intensity: MuZero is powerful but expensive, and the learned model is task-specific. The lasting idea is model-based RL without explicit environment simulators.
+
 ![Figure 1: Planning, acting, and training with a learned model from Mastering Atari, Go, Chess & Shogi by Planning with a Learned Model](/assets/images/mastering-atari-go-chess-shogi-muzero-paper-figure.png)
 _Figure 1: Planning, acting, and training with a learned model. From the [Mastering Atari, Go, Chess & Shogi by Planning with a Learned Model paper](https://arxiv.org/abs/1911.08265), via arXiv HTML._
 

--- a/src/content/posts/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.md
+++ b/src/content/posts/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.md
@@ -19,6 +19,10 @@ summary: Molmo argued that high-quality open multimodal data can matter more tha
 
 This matters because many VLMs are hard to inspect. Molmo makes the data story more visible, which makes the model easier to study and reuse.
 
+## Paper map
+
+Molmo is the model family and PixMo is the open data recipe behind it. The paper argues that high-quality, inspectable multimodal data can make open VLMs competitive. PixMo includes dense captions, pointing and grounding supervision, and related annotations that teach localization and visual description. Molmo uses that data to build open-weight models with strong visual understanding. The caveat is that openness does not remove data collection cost or annotation bias; it makes those choices auditable. The lasting idea is that data quality and transparency can substitute for some closed-model scale.
+
 ![Figure 1: Datasets in PixMo (left) and the capabilities they enable in Molmo (right) from Molmo and PixMo: Open Weights and Open Data for State-of-the-Art Vision-Language Models](/assets/images/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models-paper-figure.png)
 _Figure 1: Datasets in PixMo (left) and the capabilities they enable in Molmo (right). From the [Molmo and PixMo: Open Weights and Open Data for State-of-the-Art Vision-Language Models paper](https://arxiv.org/abs/2409.17146), via arXiv HTML._
 

--- a/src/content/posts/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.md
+++ b/src/content/posts/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.md
@@ -21,6 +21,10 @@ summary: mSFT adapts multitask fine-tuning mixtures by tracking which datasets o
 
 **Conference:** Preprint
 
+## Paper map
+
+MSFT studies multi-task supervised fine-tuning when datasets learn and overfit at different speeds. A fixed mixture can keep updating an easy task after it has overfit while harder tasks still need training. MSFT trains on an active mixture, detects the earliest-overfitting sub-dataset, removes it, rolls back to that dataset's best checkpoint, and continues. The paper reports gains across benchmarks, base models, dataset sizes, and task granularities. The operational caveat is that the method needs per-dataset validation signals and checkpoint management. The core idea is to allocate SFT compute by task dynamics rather than static mixture weights.
+
 ![Figure 2a from mSFT: test accuracy curves peak at different epochs across sub-datasets](/assets/images/msft-arxiv-x2.png)
 _Figure 2a from the [mSFT paper](https://arxiv.org/abs/2603.21606), CC BY 4.0._
 

--- a/src/content/posts/openvla-open-source-vision-language-action-model.md
+++ b/src/content/posts/openvla-open-source-vision-language-action-model.md
@@ -19,6 +19,10 @@ summary: OpenVLA released a 7B open robot policy trained on 970k real robot demo
 
 The open release matters: checkpoints, code, and fine-tuning recipes make generalist robot policies easier to study and adapt.
 
+## Paper map
+
+OpenVLA adapts a pretrained vision-language model into an action-generating robot policy and releases the result as an open baseline. The model takes robot observations and language instructions, then predicts actions for manipulation tasks. Its contribution is partly technical and partly ecosystem-oriented: provide an inspectable VLA recipe rather than leaving robot foundation policies closed. The evidence tests generalization across robot tasks and datasets. The caveat is action representation: a VLM backbone helps semantic grounding, but precise continuous control and embodiment transfer still require robot-specific data and validation.
+
 ![Figure 1: OpenVLA model architecture from OpenVLA: An Open-Source Vision-Language-Action Model](/assets/images/openvla-open-source-vision-language-action-model-paper-figure.png)
 _Figure 1: OpenVLA model architecture. From the [OpenVLA: An Open-Source Vision-Language-Action Model paper](https://arxiv.org/abs/2406.09246), via arXiv HTML._
 

--- a/src/content/posts/pi0-vision-language-action-flow-model-for-general-robot-control.md
+++ b/src/content/posts/pi0-vision-language-action-flow-model-for-general-robot-control.md
@@ -19,6 +19,10 @@ summary: Pi0 used a VLM backbone and flow matching to turn visual-language conte
 
 The paper adds an action generation mechanism based on flow matching, allowing the model to map images and language instructions into robot trajectories across tasks.
 
+## Paper map
+
+Pi0 connects a pretrained vision-language backbone to continuous robot control through an action model trained with flow matching. The VLM supplies semantic grounding from images and language, while the flow action head models smooth trajectories. Training spans multiple robot embodiments, including single-arm, dual-arm, and mobile manipulation settings. The evaluation emphasizes language-prompted generalist behavior and dexterous tasks. The key caveat is data and robustness: broad robot policies need diverse demonstrations and careful safety validation under distribution shift.
+
 ![Figure 2 from pi0: a mobile manipulator follows a natural-language instruction to fold laundry](/assets/images/pi0-vision-language-action-flow-model-for-general-robot-control-paper-figure.jpeg)
 _Figure 2 from the [pi0 paper](https://arxiv.org/abs/2410.24164), via arXiv HTML._
 

--- a/src/content/posts/playing-atari-with-dqn.md
+++ b/src/content/posts/playing-atari-with-dqn.md
@@ -19,6 +19,10 @@ summary: DQN combined Q-learning, replay, and target networks to make pixel-base
 
 **Conference:** NIPS Deep Learning Workshop 2013 (expanded Nature version published 2015)
 
+## Paper map
+
+DQN combines Q-learning with deep convolutional networks to learn control directly from pixels. The input is a stack of recent Atari frames; the output is one Q-value per action. Two stabilizers make the method work: experience replay breaks temporal correlations by sampling past transitions, and a target network slows down bootstrapping targets. The same architecture and hyperparameters are applied across seven Atari games, which was the important generality claim at the time. The evidence shows performance above previous methods on six games and above a human expert on three. The caveat is sample inefficiency and instability; later deep RL work spent years improving exploration, targets, replay, and evaluation.
+
 ![Figure 1 provides sample screenshots from five of the games used for training from Playing Atari with Deep Reinforcement Learning](/assets/images/playing-atari-with-dqn-paper-figure.png)
 _Figure 1 provides sample screenshots from five of the games used for training. From the [Playing Atari with Deep Reinforcement Learning paper](https://arxiv.org/abs/1312.5602), via arXiv HTML._
 

--- a/src/content/posts/proximal-policy-optimization-ppo.mdx
+++ b/src/content/posts/proximal-policy-optimization-ppo.mdx
@@ -22,6 +22,10 @@ import { ppoPlayground } from '../../lib/python-playground-examples';
 
 **Conference:** Not formally peer-reviewed; influential tech report later presented at ICML workshops and widely adopted.
 
+## Paper map
+
+PPO is a practical policy-gradient method that reuses fresh rollout data for several minibatch epochs without letting the policy move too far. The clipped objective compares the new policy probability ratio to the old one and limits the incentive when the update exceeds an epsilon band. This approximates the trust-region spirit of TRPO while avoiding second-order optimization and conjugate-gradient machinery. The paper evaluates continuous-control and Atari tasks, where PPO gives a strong balance of simplicity, stability, and sample efficiency among online policy-gradient methods. The caveats are that clipping is heuristic, performance depends on advantage estimation and reward scaling, and the method still needs new on-policy data after each update cycle.
+
 ![PPO clipped objective schematic](/assets/images/ppo-clipped-objective-schematic.svg)
 _Local explainer diagram; the PPO paper does not expose a useful source figure through ar5iv._
 

--- a/src/content/posts/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.md
+++ b/src/content/posts/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.md
@@ -19,6 +19,10 @@ summary: Qwen2-VL made resolution and video length more flexible by letting visu
 
 The model family also handles images and video with a shared multimodal position encoding, making it useful for OCR-heavy tasks, documents, visual reasoning, and longer temporal inputs.
 
+## Paper map
+
+Qwen2-VL makes resolution handling a core VLM design choice. Naive Dynamic Resolution converts images of different sizes into different numbers of visual tokens, preserving detail for OCR, documents, charts, and high-resolution scenes. M-RoPE extends positional encoding across text, image, and video so spatial and temporal positions stay aligned. The evaluation covers image understanding, video understanding, multilingual OCR, and reasoning. The tradeoff is token cost: dynamic resolution gives more detail when needed, but large inputs still consume context and compute.
+
 ![Figure 1: Qwen2-VL capabilities: Multilingual image text understanding, code/math reasoning, video analysis, live chat, agent potential, and more from Qwen2-VL: Enhancing Vision-Language Model's Perception of the World at Any Resolution](/assets/images/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution-paper-figure.jpg)
 _Figure 1: Qwen2-VL capabilities: Multilingual image text understanding, code/math reasoning, video analysis, live chat, agent potential, and more. From the [Qwen2-VL: Enhancing Vision-Language Model's Perception of the World at Any Resolution paper](https://arxiv.org/abs/2409.12191), via arXiv HTML._
 

--- a/src/content/posts/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.md
+++ b/src/content/posts/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.md
@@ -17,6 +17,10 @@ summary: SENNA split driving into high-level language planning and low-level tra
 
 This makes the language layer inspectable. A planner can say what it intends to do before the control module turns that intent into geometry.
 
+## Paper map
+
+SENNA separates driving into a VLM-based decision layer and an end-to-end trajectory layer. Senna-VLM produces structured scene understanding, decisions, and explanations; Senna-E2E turns those semantics into planning outputs. Training uses staged pretraining and driving-specific instruction data so the language model learns traffic context rather than generic image chat. The paper's value is making the semantic decision step explicit. The caveat is that language plans are not safety guarantees: downstream control still has to handle geometry, timing, and uncertainty.
+
 ![Figure 1: Previous methods plan trajectories without a decision-making step, making model learning difficult from SENNA: Bridging Large Vision-Language Models and End-to-End Autonomous Driving](/assets/images/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving-paper-figure.png)
 _Figure 1: Previous methods plan trajectories without a decision-making step, making model learning difficult. From the [SENNA: Bridging Large Vision-Language Models and End-to-End Autonomous Driving paper](https://arxiv.org/abs/2410.22313), via arXiv HTML._
 

--- a/src/content/posts/sequence-to-sequence-learning-with-neural-networks.md
+++ b/src/content/posts/sequence-to-sequence-learning-with-neural-networks.md
@@ -20,6 +20,11 @@ summary: Seq2seq made encoder-decoder neural translation practical before attent
 **Project page / blog:** [Google Research Blog – "A neural network for machine translation"](https://research.googleblog.com/2014/12/a-neural-network-for-machine-translation.html)
 
 **Conference:** NeurIPS 2014
+
+## Paper map
+
+This paper shows that a neural network can map variable-length input sequences to variable-length output sequences with an encoder-decoder LSTM. The encoder reads the source sentence into a fixed vector; the decoder generates the target sentence from that vector. A crucial trick is reversing the source sentence, which shortens the effective dependency path between corresponding source and target words. The main evidence is WMT 2014 English-French translation, where a deep LSTM achieves strong BLEU and improves an SMT system through reranking. The caveat is the fixed-vector bottleneck: long or information-dense inputs strain the representation, which later attention mechanisms addressed. The lasting idea is end-to-end sequence transduction with learned representations.
+
 ![Figure 1: Our model reads an input sentence “ABC” and produces “WXYZ” as the output sentence from Sequence to Sequence Learning with Neural Networks](/assets/images/sequence-to-sequence-learning-with-neural-networks-paper-figure.png)
 _Figure 1: Our model reads an input sentence “ABC” and produces “WXYZ” as the output sentence. From the [Sequence to Sequence Learning with Neural Networks paper](https://arxiv.org/abs/1409.3215), via arXiv HTML._
 

--- a/src/content/posts/sigmoid-loss-for-language-image-pre-training-siglip.md
+++ b/src/content/posts/sigmoid-loss-for-language-image-pre-training-siglip.md
@@ -21,6 +21,10 @@ summary: SigLIP replaced softmax contrastive normalization with independent sigm
 
 **Conference:** ICCV 2023 (oral)
 
+## Paper map
+
+SigLIP replaces CLIP's softmax contrastive loss with independent pairwise sigmoid losses over image-text pairs. CLIP's softmax needs a global view of pairwise similarities across the batch, which pushes toward large batches and cross-device communication. Sigmoid loss treats each pair as a binary classification problem, making training more memory efficient and easier to scale on fewer accelerators. The evidence compares zero-shot ImageNet and related transfer results, showing strong performance with smaller hardware budgets and practical batch sizes. The caveat is that loss simplicity does not remove the need for high-quality image-text data or careful temperature/bias handling. The paper matters because it made language-image pretraining less tied to enormous synchronized batches.
+
 ![CLIP and SigLIP objective schematic](/assets/images/clip-siglip-objective-schematic.svg)
 _Local explainer diagram; the SigLIP paper's ar5iv conversion does not expose useful source figures._
 

--- a/src/content/posts/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.md
+++ b/src/content/posts/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.md
@@ -17,6 +17,10 @@ summary: TOD3Cap asked driving models to detect outdoor 3D objects and caption t
 
 That is harder than standard object detection because it requires attributes, context, and grounded descriptions, not just boxes and class IDs.
 
+## Paper map
+
+TOD3Cap introduces outdoor 3D dense captioning: localize objects in 3D scenes and generate grounded descriptions for them. The dataset contains 850 scenes, 64.3k objects, and 2.3M captions, making it much larger and more driving-relevant than small indoor captioning setups. The task requires geometry, object detection, and language generation together. It matters for autonomous driving because planners and assistants need grounded object descriptions, not just boxes. The caveat is evaluation: a fluent caption can still miss safety-critical geometry.
+
 ![Figure 1: We introduce the task of 3D dense captioning in outdoor scenes (right) from TOD3Cap: Towards 3D Dense Captioning in Outdoor Scenes](/assets/images/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes-paper-figure.png)
 _Figure 1: We introduce the task of 3D dense captioning in outdoor scenes (right). From the [TOD3Cap: Towards 3D Dense Captioning in Outdoor Scenes paper](https://arxiv.org/abs/2403.19589), via arXiv HTML._
 

--- a/src/content/posts/training-language-models-to-follow-instructions-with-human-feedback.md
+++ b/src/content/posts/training-language-models-to-follow-instructions-with-human-feedback.md
@@ -21,6 +21,10 @@ summary: InstructGPT showed that human preference data can make smaller language
 
 **Conference:** NeurIPS 2022 (spotlight)
 
+## Paper map
+
+InstructGPT aligns GPT-3-style models to user intent through supervised demonstrations and preference-based reinforcement learning. The pipeline first fine-tunes on labeler-written ideal responses, then trains a reward model from ranked model outputs, then optimizes the policy with PPO against that reward while controlling drift from the supervised model. The central result is that smaller InstructGPT models can be preferred over much larger base GPT-3 models on real API prompts. The paper also measures truthfulness, toxicity, and academic NLP performance to check side effects. The caveat is that RLHF optimizes for labeler preference under a specific prompt distribution, so reward-model errors and preference coverage matter. The lasting idea is instruction following as an alignment target, not just scale.
+
 ![Figure 1: Human evaluations of various models on our API prompt distribution, evaluated by how often outputs from each model were preferred to those from the 175B SFT model from Training Language Models to Follow Instructions with Human Feedback](/assets/images/training-language-models-to-follow-instructions-with-human-feedback-paper-figure.png)
 _Figure 1: Human evaluations of various models on our API prompt distribution, evaluated by how often outputs from each model were preferred to those from the 175B SFT model. From the [Training Language Models to Follow Instructions with Human Feedback paper](https://arxiv.org/abs/2203.02155), via arXiv HTML._
 

--- a/src/content/posts/videollama-3-frontier-multimodal-foundation-models.md
+++ b/src/content/posts/videollama-3-frontier-multimodal-foundation-models.md
@@ -19,6 +19,10 @@ summary: VideoLLaMA 3 showed that strong image understanding can be the foundati
 
 The key claim is that high-quality image-text learning carries a lot of the load for video. Video data still matters, but the model does not need to learn all semantics from video clips alone.
 
+## Paper map
+
+VideoLLaMA 3 is a vision-centric model for image and video understanding. Its training recipe treats high-quality image-text data as the base for video capability, then adds video-specific tuning instead of treating video as a separate problem. The framework also uses visual-token efficiency techniques so longer videos do not overwhelm the language context. The evidence compares image and video benchmarks against prior MLLMs. The caveat is that benchmark videos are still cleaner and shorter than many real temporal reasoning tasks. The takeaway is that video MLLMs need both temporal data and strong visual representation design.
+
 ![Figure 1: Performance Comparison of VideoLLaMA3 with the previous advanced image/video MLLM on various representative benchmarks from VideoLLaMA 3: Frontier Multimodal Foundation Models for Image and Video Understanding](/assets/images/videollama-3-frontier-multimodal-foundation-models-paper-figure.png)
 _Figure 1: Performance Comparison of VideoLLaMA3 with the previous advanced image/video MLLM on various representative benchmarks. From the [VideoLLaMA 3: Frontier Multimodal Foundation Models for Image and Video Understanding paper](https://arxiv.org/abs/2501.13106), via arXiv HTML._
 

--- a/src/content/posts/visual-instruction-tuning-llava.md
+++ b/src/content/posts/visual-instruction-tuning-llava.md
@@ -19,6 +19,10 @@ summary: LLaVA showed that a frozen vision encoder, an LLM, and synthetic instru
 
 That made image understanding feel like chat. A model could describe an image, answer questions, and follow open-ended visual instructions instead of only producing class labels or retrieval scores.
 
+## Paper map
+
+LLaVA connects a CLIP-style vision encoder to an LLM and instruction-tunes the combined model for visual dialogue. The data move is the key: use GPT-4 to generate image-grounded instruction-following conversations from captions and visual context. Training first aligns visual features to the language model, then tunes for multimodal chat and reasoning. The paper demonstrates that instruction tuning transfers from text-only assistants to visual assistants. The caveat is synthetic supervision: generated data can teach useful behavior, but it may also preserve language priors or miss fine visual details.
+
 ![Figure 1: LLaVA network architecture from Visual Instruction Tuning (LLaVA)](/assets/images/visual-instruction-tuning-llava-paper-figure.png)
 _Figure 1: LLaVA network architecture. From the [Visual Instruction Tuning (LLaVA) paper](https://arxiv.org/abs/2304.08485), via arXiv HTML._
 


### PR DESCRIPTION
## Summary
- add concise Paper map sections to all 44 arXiv paper notes
- keep the existing note sections intact while capturing problem, method, evidence, and caveat
- verify all referenced paper-note images resolve from public assets

## Testing
- npm run ci
- image reference audit: 44 paper notes, 44 Paper maps, no missing referenced images