### PR TITLE
Improve paper field index

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -1122,6 +1122,255 @@ h3,
   color: var(--text-secondary-color);
 }
 
+.paper-field-page {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.field-overview {
+  box-sizing: border-box;
+  min-width: 0;
+  max-width: 100%;
+  padding: 1rem;
+  border: 1px solid var(--button-border);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: var(--button-shadow);
+}
+
+.field-overview__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.65rem;
+}
+
+.field-overview__header h2 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.field-overview__header span {
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.field-overview__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10.5rem, 1fr));
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.field-overview-card {
+  display: grid;
+  gap: 0.18rem;
+  min-height: 3.35rem;
+  padding: 0.62rem 0.7rem;
+  border: 1px solid var(--button-border);
+  border-radius: 8px;
+  color: var(--text-color);
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.field-overview-card:hover {
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.field-overview-card:focus-visible,
+.paper-field-actions button:focus-visible,
+.paper-field-group summary:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.paper-field-group summary:focus {
+  outline: none;
+}
+
+.paper-field-group summary:focus-visible {
+  outline-offset: -4px;
+}
+
+:root[data-theme="light"] .field-overview-card,
+:root[data-theme="light"] .paper-field-actions button {
+  background: rgba(255, 255, 255, 0.46);
+}
+
+:root[data-theme="dark"] .field-overview-card,
+:root[data-theme="dark"] .paper-field-actions button {
+  background: rgba(255, 228, 92, 0.04);
+}
+
+:root[data-theme="light"] .field-overview-card:hover,
+:root[data-theme="light"] .paper-field-actions button:hover {
+  background: rgba(53, 109, 255, 0.1);
+  border-color: rgba(53, 109, 255, 0.3);
+}
+
+:root[data-theme="dark"] .field-overview-card:hover,
+:root[data-theme="dark"] .paper-field-actions button:hover {
+  background: rgba(255, 228, 92, 0.1);
+  border-color: rgba(255, 228, 92, 0.42);
+}
+
+.field-overview-card__name {
+  font-family: var(--font-reading);
+  font-size: 0.96rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.field-overview-card__meta {
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+}
+
+.paper-field-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.paper-field-actions button {
+  padding: 0.48rem 0.7rem;
+  border: 1px solid var(--button-border);
+  border-radius: 8px;
+  color: var(--text-color);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.paper-field-groups {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.paper-field-group {
+  box-sizing: border-box;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--button-border);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: var(--button-shadow);
+  scroll-margin-top: 5.75rem;
+}
+
+.paper-field-group summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.paper-field-group summary::-webkit-details-marker {
+  display: none;
+}
+
+.paper-field-group > summary::before,
+.paper-field-group[open] > summary::before {
+  content: none;
+  display: none;
+  margin: 0;
+}
+
+.paper-field-group__title {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 0;
+  font-family: var(--font-reading);
+  font-size: 1.08rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.paper-field-group__title::before {
+  content: "+";
+  display: grid;
+  place-items: center;
+  flex: 0 0 1.35rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  border: 1px solid var(--button-border);
+  border-radius: 50%;
+  color: var(--accent-color);
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  line-height: 1;
+}
+
+.paper-field-group[open] .paper-field-group__title::before {
+  content: "-";
+}
+
+.paper-field-group__meta {
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  white-space: nowrap;
+}
+
+.paper-field-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0.15rem 1rem 0.9rem;
+  border-top: 1px solid var(--button-border);
+}
+
+.paper-field-list li {
+  display: grid;
+  gap: 0.26rem;
+  padding: 0.78rem 0;
+  border-bottom: 1px solid var(--button-border);
+}
+
+.paper-field-list a {
+  font-family: var(--font-reading);
+  font-size: 0.98rem;
+  font-weight: 500;
+  line-height: 1.28;
+}
+
+.paper-field-list time {
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+
+.paper-field-list p {
+  display: -webkit-box;
+  max-width: none;
+  margin: 0;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: var(--text-secondary-color);
+  font-size: 0.94rem;
+  line-height: 1.45;
+}
+
 .archive-list {
   border-top: 1px solid var(--button-border);
 }
@@ -1836,6 +2085,23 @@ body.home-page small {
   .resource-list span {
     justify-content: flex-start;
   }
+
+  .paper-field-group summary {
+    grid-template-columns: 1fr;
+  }
+
+  .paper-field-group__meta {
+    padding-left: 1.9rem;
+    white-space: normal;
+  }
+
+  .paper-field-list {
+    grid-template-columns: 1fr;
+  }
+
+  .paper-field-actions {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 520px) {
@@ -1855,8 +2121,50 @@ body.home-page small {
   .home-panel,
   .links-panel,
   .timeline-panel,
-  .section-index-header {
+  .section-index-header,
+  .field-overview {
     padding: 1rem;
+  }
+
+  .field-overview__header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .field-overview__grid {
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    padding-bottom: 0.15rem;
+    scroll-snap-type: x proximity;
+  }
+
+  .field-overview-card {
+    flex: 0 0 11rem;
+    min-height: 3.8rem;
+    scroll-snap-align: start;
+  }
+
+  .field-overview-card__name {
+    font-size: 0.94rem;
+  }
+
+  .field-overview-card__meta {
+    font-size: 0.7rem;
+  }
+
+  .paper-field-actions button {
+    flex: 1 1 8rem;
+  }
+
+  .paper-field-group summary {
+    padding: 0.85rem;
+  }
+
+  .paper-field-list {
+    padding: 0 0.85rem 0.75rem;
   }
 
   .page-controls {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
-const themeStylesheetHref = '/css/override.css?v=20260705-readability-refresh-1';
+const themeStylesheetHref = '/css/override.css?v=20260706-field-index-1';
 ---
 
 <!DOCTYPE html>

--- a/src/pages/paper_summaries_field.astro
+++ b/src/pages/paper_summaries_field.astro
@@ -1,24 +1,144 @@
 ---
-import PostList from '../components/PostList.astro';
 import SectionHeader from '../components/SectionHeader.astro';
 import PostLayout from '../layouts/PostLayout.astro';
 import { getPostsByField } from '../lib/content';
 
 const fields = await getPostsByField();
 const paperCount = fields.reduce((count, field) => count + field.items.length, 0);
+
+const toFieldId = (field: string) =>
+  `field-${field
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')}`;
+
+const pluralize = (count: number, singular: string, plural = `${singular}s`) =>
+  `${count} ${count === 1 ? singular : plural}`;
+
+const fieldGroups = fields.map(({ field, items }) => {
+  const years = items.map((item) => item.data.date.getFullYear());
+  const startYear = Math.min(...years);
+  const endYear = Math.max(...years);
+  const dateRange = startYear === endYear ? `${startYear}` : `${startYear} - ${endYear}`;
+
+  return {
+    field,
+    id: toFieldId(field),
+    items,
+    count: items.length,
+    dateRange,
+  };
+});
 ---
 
 <PostLayout title="Paper Summaries by Field" showSectionsNav={false}>
-  <SectionHeader
-    eyebrow="Arxiv Notes"
-    title="Paper summaries by field"
-    description="Paper notes grouped by field, each focused on the contribution, tradeoff, and lasting idea."
-    meta={`${paperCount} entries`}
-  />
-  {fields.map(({ field, items }) => (
-    <section class="section-index-group">
-      <h2>{field}</h2>
-      <PostList posts={items} />
-    </section>
-  ))}
+  <div class="paper-field-page">
+    <SectionHeader
+      eyebrow="Arxiv Notes"
+      title="Paper summaries by field"
+      description="Paper notes grouped by field, each focused on the contribution, tradeoff, and lasting idea."
+      meta={`${paperCount} entries`}
+    />
+
+    <nav class="field-overview" aria-label="Paper fields">
+      <div class="field-overview__header">
+        <h2>Fields</h2>
+        <span>{pluralize(fieldGroups.length, 'group')}</span>
+      </div>
+      <div class="field-overview__grid">
+        {fieldGroups.map(({ field, id, count, dateRange }) => (
+          <a class="field-overview-card" href={`#${id}`}>
+            <span class="field-overview-card__name">{field}</span>
+            <span class="field-overview-card__meta">
+              {pluralize(count, 'paper')} / {dateRange}
+            </span>
+          </a>
+        ))}
+      </div>
+    </nav>
+
+    <div class="paper-field-actions" aria-label="Field display controls">
+      <button type="button" data-paper-fields-expand>Expand all</button>
+      <button type="button" data-paper-fields-collapse>Collapse all</button>
+    </div>
+
+    <div class="paper-field-groups">
+      {fieldGroups.map(({ field, id, items, count, dateRange }) => (
+        <details class="paper-field-group" id={id}>
+          <summary>
+            <span class="paper-field-group__title">{field}</span>
+            <span class="paper-field-group__meta">
+              {pluralize(count, 'paper')} / {dateRange}
+            </span>
+          </summary>
+          <ul class="paper-field-list">
+            {items.map((post) => (
+              <li>
+                <a href={post.data.legacyPath}>{post.data.title}</a>
+                <time datetime={post.data.date.toISOString()}>
+                  {
+                    post.data.date.toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: '2-digit',
+                      year: 'numeric',
+                    })
+                  }
+                </time>
+                {post.data.summary && <p>{post.data.summary}</p>}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ))}
+    </div>
+  </div>
+
+  <script is:inline>
+    (() => {
+      const groups = Array.from(document.querySelectorAll('.paper-field-group'));
+      const expandButton = document.querySelector('[data-paper-fields-expand]');
+      const collapseButton = document.querySelector('[data-paper-fields-collapse]');
+
+      const openGroupFromHash = () => {
+        const id = window.location.hash.slice(1);
+        if (!id) {
+          return;
+        }
+
+        const target = document.getElementById(id);
+        if (target instanceof HTMLDetailsElement) {
+          target.open = true;
+        }
+      };
+
+      expandButton?.addEventListener('click', () => {
+        groups.forEach((group) => {
+          if (group instanceof HTMLDetailsElement) {
+            group.open = true;
+          }
+        });
+      });
+
+      collapseButton?.addEventListener('click', () => {
+        groups.forEach((group) => {
+          if (group instanceof HTMLDetailsElement) {
+            group.open = false;
+          }
+        });
+      });
+
+      document.querySelectorAll('.field-overview-card').forEach((link) => {
+        link.addEventListener('click', () => {
+          const id = link.getAttribute('href')?.slice(1);
+          const target = id ? document.getElementById(id) : null;
+          if (target instanceof HTMLDetailsElement) {
+            target.open = true;
+          }
+        });
+      });
+
+      window.addEventListener('hashchange', openGroupFromHash);
+      openGroupFromHash();
+    })();
+  </script>
 </PostLayout>


### PR DESCRIPTION
## Summary
- replace the long paper field list with a compact field overview and collapsible field groups
- add expand/collapse controls plus hash-linked field jumps
- tighten desktop/mobile styling so the page scans faster without horizontal overflow

## Testing
- npm run ci
- verified desktop and mobile rendering locally in the Codex browser
