### PR TITLE
Add omni-model preparation blog and paper notes

### DIFF
--- a/src/content/posts/chameleon-mixed-modal-early-fusion-foundation-models.md
+++ b/src/content/posts/chameleon-mixed-modal-early-fusion-foundation-models.md
@@ -1,0 +1,32 @@
+---
+title: 'Chameleon: Mixed-Modal Early-Fusion Foundation Models'
+date: '2024-05-16T09:00:00.000Z'
+section: paper-shorts
+postSlug: chameleon-mixed-modal-early-fusion-foundation-models
+legacyPath: /paper shorts/2024/05/16/chameleon-mixed-modal-early-fusion-foundation-models.html
+tags: [Multimodal AI]
+field: Omni-Models
+summary: '2024 – Chameleon: early fusion over mixed image-and-text token sequences.'
+---
+
+## 2024 – Chameleon: Mixed-Modal Early-Fusion Foundation Models
+
+**arXiv:** [2405.09818](https://arxiv.org/abs/2405.09818)  
+**Conference:** Technical report
+
+**Summary:** Chameleon trains token-based, early-fusion models that can understand and generate images and text in arbitrary order within one sequence. The paper contributes a training and alignment recipe for keeping this unified setting stable.
+
+## Paper Insights
+
+Early fusion makes a direct architectural claim: one transformer can model mixed documents instead of bolting a vision encoder onto a language model after pre-training. The evidence spans visual question answering, captioning, text generation, image generation, and long-form mixed-modal generation.
+
+| Decision | Chameleon's answer | Tradeoff |
+| --- | --- | --- |
+| Representation | Discrete image and text tokens in one stream | Visual fidelity depends on tokenization and sequence budget. |
+| Sharing | Early fusion throughout the transformer | Shared capacity may create modality interference. |
+| Objective | Next-token prediction | A simple unified objective, but expensive for long visual sequences. |
+
+**Limits:** Strong unified generation does not establish that a fully shared representation is best for every visual understanding or action task.
+
+**Takeaway:** Chameleon is the clean baseline for asking whether early fusion is worth its sequence-length and interference costs.
+

--- a/src/content/posts/genie-generative-interactive-environments.md
+++ b/src/content/posts/genie-generative-interactive-environments.md
@@ -1,0 +1,33 @@
+---
+title: 'Genie: Generative Interactive Environments'
+date: '2024-02-23T09:00:00.000Z'
+section: paper-shorts
+postSlug: genie-generative-interactive-environments
+legacyPath: /paper shorts/2024/02/23/genie-generative-interactive-environments.html
+tags: [World Models]
+field: Omni-Models
+summary: '2024 – Genie: a latent-action generative environment learned from unlabeled Internet video.'
+---
+
+## 2024 – Genie: Generative Interactive Environments
+
+**arXiv:** [2402.15391](https://arxiv.org/abs/2402.15391)  
+**Project:** [Genie project page](https://sites.google.com/view/genie-2024/home)  
+**Conference:** Technical report
+
+**Summary:** Genie learns an interactive generative environment from unlabeled Internet videos. The 11B-parameter model combines a spatiotemporal video tokenizer, an autoregressive dynamics model, and a learned latent-action model, then generates worlds that can be controlled frame by frame.
+
+## Paper Insights
+
+Genie is valuable because it makes latent actions a trainable interface rather than requiring labeled controls. The learned action space also supports imitating behaviors from unseen videos. For a world-model program, its contribution is the separation of visual compression, dynamics prediction, and action representation.
+
+| Component | Job |
+| --- | --- |
+| Video tokenizer | Compresses observations into a temporal representation. |
+| Dynamics model | Predicts the next latent state. |
+| Latent-action model | Supplies an action-conditioned control interface without action labels. |
+
+**Limits:** Interactive plausibility in generated environments is not evidence of metric accuracy, safety, or causal fidelity in a physical robot or vehicle setting.
+
+**Takeaway:** A world model needs action-conditioned consequences; realistic video alone is not enough.
+

--- a/src/content/posts/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.md
+++ b/src/content/posts/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.md
@@ -1,0 +1,32 @@
+---
+title: 'Janus: Decoupling Visual Encoding for Unified Multimodal Understanding and Generation'
+date: '2024-10-17T09:00:00.000Z'
+section: paper-shorts
+postSlug: janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation
+legacyPath: /paper shorts/2024/10/17/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.html
+tags: [Multimodal AI]
+field: Omni-Models
+summary: '2024 – Janus: separate visual routes for understanding and generation around one transformer.'
+---
+
+## 2024 – Janus
+
+**arXiv:** [2410.13848](https://arxiv.org/abs/2410.13848)  
+**Conference:** Technical report
+
+**Summary:** Janus keeps an autoregressive multimodal transformer but separates the visual encodings used for understanding and generation. The paper argues that a single visual representation is asked to retain incompatible levels of detail for those two jobs.
+
+## Paper Insights
+
+Understanding needs semantic, task-relevant features; generation needs fine visual detail. Janus decouples those interfaces while preserving one shared transformer for multimodal processing. This is an architectural way to reduce representational conflict without giving up a unified model.
+
+| Question | Janus's answer |
+| --- | --- |
+| What is shared? | The multimodal transformer. |
+| What is specialized? | Visual encoders for understanding and generation. |
+| What decision does it inform? | Whether one visual tokenizer must serve every capability. |
+
+**Limits:** Separate routes add components and do not remove the need to measure interference in the shared transformer.
+
+**Takeaway:** Share reasoning capacity when it transfers; specialize visual representations when their information requirements differ.
+

--- a/src/content/posts/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.md
+++ b/src/content/posts/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.md
@@ -1,0 +1,32 @@
+---
+title: 'MM1: Methods, Analysis & Insights from Multimodal LLM Pre-training'
+date: '2024-03-14T09:00:00.000Z'
+section: paper-shorts
+postSlug: mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training
+legacyPath: /paper shorts/2024/03/14/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.html
+tags: [Multimodal AI]
+field: Omni-Models
+summary: '2024 – MM1: a controlled study of multimodal pre-training choices.'
+---
+
+## 2024 – MM1: Methods, Analysis & Insights from Multimodal LLM Pre-training
+
+**arXiv:** [2403.09611](https://arxiv.org/abs/2403.09611)  
+**Conference:** Technical report
+
+**Summary:** MM1 is a large ablation study of multimodal LLM pre-training. It varies the image encoder, resolution, visual-token count, vision-language connector, and data mixture before scaling the selected recipe to dense and MoE models up to 30B parameters.
+
+## Paper Insights
+
+The central result is a prioritization rule: image encoder quality, image resolution, visual-token count, and the mix of image-caption, interleaved image-text, and text-only data mattered much more than connector design. That makes MM1 a paper about experiment allocation. Before inventing a new projector, test the representation and data decisions that dominate the result.
+
+| Decision | Signal from MM1 | Why it matters |
+| --- | --- | --- |
+| Visual representation | Encoder, resolution, and token count dominate | These are the first levers to sweep. |
+| Data mixture | Mixed image-caption, interleaved, and text-only data is important | Capability is shaped by the training distribution. |
+| Connector | Smaller effect in the reported ablations | Avoid spending the whole budget on connector variants. |
+
+**Limits:** The conclusions come from MM1's model family and data pipeline; they are a strong experimental prior, not a universal ranking for every architecture.
+
+**Takeaway:** In multimodal pre-training, spend early runs on the visual representation and mixture before polishing the connector.
+

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -1,0 +1,80 @@
+---
+title: 'What Omni-Model Roles Are Really Testing'
+date: '2026-07-15T09:00:00.000Z'
+section: blog
+postSlug: omni-model-pretraining-decisions
+legacyPath: /blog/2026/07/15/omni-model-pretraining-decisions.html
+tags:
+  - Multimodal AI
+  - Research Leadership
+summary: A preparation map for making architecture, data, systems, and action-model decisions in large multimodal training runs.
+---
+
+# What Omni-Model Roles Are Really Testing
+
+An omni-model role is not a memory test for multimodal papers. It is a test of whether you can make expensive technical decisions under uncertainty: what to share across modalities, which losses and datasets belong together, which small runs predict a large one, and how to keep a months-long training job healthy.
+
+My background in vision-language-action systems, BEV representations, autonomous driving, and grounding points toward a useful thesis: preserve metric, temporally persistent entity representations for prediction and control, while letting a pretrained multimodal model provide open-vocabulary semantics and reasoning.
+
+## The architecture decision
+
+Four families cover most of the current design space.
+
+| Family | Representative papers | Core bet | Main risk |
+| --- | --- | --- | --- |
+| Discrete early fusion | [Chameleon](https://arxiv.org/abs/2405.09818), Emu3 | One token stream can model text, images, and video | Visual token budgets and cross-modal interference |
+| Hybrid autoregressive + diffusion/flow | [Transfusion](https://arxiv.org/abs/2408.11039), Show-o2 | Text and continuous visual generation need different objectives | Objective balancing and a more complicated serving path |
+| Shared transformer, separate visual routes | [Janus](https://arxiv.org/abs/2410.13848), [TokenFlow](https://arxiv.org/abs/2412.03069) | Understanding and generation require different visual information | More interfaces to train and maintain |
+| Shared trunk with modality experts | [Scaling Laws for Native Multimodal Models](https://arxiv.org/abs/2504.07951) | Preserve transfer while reducing representational conflict | Routing, utilization, and systems complexity |
+
+The question is not which paper wins a benchmark. Under a fixed compute, latency, and data budget, which design has the best expected return? A credible answer needs a small proxy run and a kill criterion for each proposal.
+
+## A twelve-week preparation plan
+
+### Weeks 1–2: map the architecture space
+
+Write an architecture decision memo. Compare representation, parameter sharing, objective, inference cost, sequence-length cost, interference, action extensibility, and expected failure modes. For every candidate, name the smallest experiment that would rule it out.
+
+### Weeks 3–4: measure objective interference
+
+Build a 100M–1B parameter prototype with text next-token prediction, image-text understanding, image reconstruction or generation, and a lightweight video or action objective. Aggregate loss is not enough. Track per-objective loss, gradient norms, pairwise gradient cosine similarity, parameter-update norms, throughput, and transfer to each evaluation.
+
+The deliverable is an objective-interaction matrix: every cell says whether one objective helps, hurts, or leaves another unchanged. [MM1](https://arxiv.org/abs/2403.09611) is especially useful because it separates the influence of image encoder, resolution, visual-token count, connector design, and data mixture.
+
+### Weeks 5–6: fit a mixture model
+
+Treat data allocation as a prediction problem. Vary model size $N$, compute $C$, data volume $D$, modality mixture $h$, visual compression, video duration, context length, and shared versus expert capacity. A useful starting form is:
+
+$$
+L_m(N,D,h)=E_m+A_mN^{-\alpha_m}+B_mD_m^{-\beta_m}+I_m(h,N,D),
+$$
+
+where $I_m$ represents cross-modal synergy or interference. Report confidence intervals and ranking stability under extrapolation; do not present one allocation as a fact. [Scaling Laws for Optimal Data Mixtures](https://arxiv.org/abs/2507.09404) provides the right mindset: use a small set of runs to estimate a policy for larger budgets.
+
+### Weeks 7–8: distinguish video from a world model
+
+Video generation produces plausible futures. A world model preserves action-conditioned consequences. A policy chooses actions to achieve an outcome. Those are related, but not interchangeable, capabilities.
+
+Study [Wan](https://arxiv.org/abs/2503.20314) for video-generation engineering and [Genie](https://arxiv.org/abs/2402.15391) for latent actions in an interactive generative environment. Evaluate controllability, state persistence, causal response to actions, geometry, object permanence, and long-horizon consistency—not only visual quality. Then compare direct regression, discretization, frequency-space tokens, diffusion or flow heads, and separate action experts. [pi0](https://arxiv.org/abs/2410.24164) and [FAST](https://arxiv.org/abs/2501.09747) make that comparison concrete.
+
+### Weeks 9–10: make the run recoverable
+
+Knowing a parallelism acronym is not a reliability plan. Design the checkpoint cadence, restart-time objective, health dashboards, online data-quality checks, and escalation ownership for a large run. [TorchTitan](https://arxiv.org/abs/2410.06511) is a practical systems reference because it composes parallelism, checkpointing, logging, and debugging tools.
+
+For loss spikes, NaNs, FP8 range errors, expert imbalance, modality dominance, corrupt shards, dataloader stalls, network stragglers, checkpoint corruption, and evaluation regressions, define a detection metric, automatic intervention, rollback rule, root-cause diagnostic, and prevention mechanism.
+
+### Weeks 11–12: turn reading into direction
+
+Propose three bets for the next six months:
+
+1. Modality-specific input and output experts around a shared transformer reduce conflict at fixed inference FLOPs.
+2. Small proxy runs can predict useful text, image, video, and action allocations better than hand-selected mixtures.
+3. Entity-grounded latent-state prediction improves long-horizon action consistency more than scaling unconditional video generation alone.
+
+Each bet needs a capability target, compute and data requirements, a three-month evidence milestone, a kill criterion, an alternative path, and named infrastructure dependencies.
+
+## Reading order
+
+The accompanying `Omni-Models` paper section contains the architecture, scaling, video, world-model, and systems set: MM1; Chameleon; Transfusion; Janus; TokenFlow; the native multimodal and data-mixture scaling-law papers; Wan; Genie; and TorchTitan. [pi0](/paper%20shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html) and [FAST](/paper%20shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html) already belong in the Robotics and VLA reading path, so their existing notes remain in those fields.
+
+For each paper, answer the same questions: what expensive decision does it inform; what is the training unit; what is shared; how are losses and data balanced; what does the scaling curve establish; what ablation is missing; and what would fail at ten times the scale? That turns a reading list into technical judgment.

--- a/src/content/posts/scaling-laws-for-generative-mixed-modal-language-models.md
+++ b/src/content/posts/scaling-laws-for-generative-mixed-modal-language-models.md
@@ -1,0 +1,32 @@
+---
+title: 'Scaling Laws for Generative Mixed-Modal Language Models'
+date: '2023-01-10T09:00:00.000Z'
+section: paper-shorts
+postSlug: scaling-laws-for-generative-mixed-modal-language-models
+legacyPath: /paper shorts/2023/01/10/scaling-laws-for-generative-mixed-modal-language-models.html
+tags: [Scaling Laws]
+field: Omni-Models
+summary: '2023 – Mixed-modal scaling laws that model both modality contributions and interactions.'
+---
+
+## 2023 – Scaling Laws for Generative Mixed-Modal Language Models
+
+**arXiv:** [2301.03728](https://arxiv.org/abs/2301.03728)  
+**Conference:** Technical report
+
+**Summary:** This work runs more than 250 experiments across seven modalities, model sizes from 8M to 30B parameters, and 5–100B training tokens. It extends unimodal scaling laws with terms for both individual modality contributions and cross-modal synergy or competition.
+
+## Paper Insights
+
+The useful shift is from asking whether a mixture is good to estimating how each modality changes loss under a particular model and data budget. The paper also reports modality alternation during training, hyperparameter guidance, and links between mixed-modal competition and training stability; a 30B speech-text model serves as a larger validation run.
+
+| Component | Role |
+| --- | --- |
+| Unimodal terms | Capture the usual model- and data-scaling effects. |
+| Interaction term | Represents synergy or competition between modalities. |
+| Proxy experiments | Estimate a mixture before the expensive run. |
+
+**Limits:** Scaling fits describe the studied training regime; interactions can change with model family, tokenization, and evaluation target.
+
+**Takeaway:** Data mixture is an optimization variable with interactions, not a fixed recipe to inherit.
+

--- a/src/content/posts/scaling-laws-for-native-multimodal-models.md
+++ b/src/content/posts/scaling-laws-for-native-multimodal-models.md
@@ -1,0 +1,32 @@
+---
+title: 'Scaling Laws for Native Multimodal Models'
+date: '2025-04-10T09:00:00.000Z'
+section: paper-shorts
+postSlug: scaling-laws-for-native-multimodal-models
+legacyPath: /paper shorts/2025/04/10/scaling-laws-for-native-multimodal-models.html
+tags: [Multimodal AI]
+field: Omni-Models
+summary: '2025 – Scaling laws comparing native early-fusion and late-fusion multimodal models.'
+---
+
+## 2025 – Scaling Laws for Native Multimodal Models
+
+**arXiv:** [2504.07951](https://arxiv.org/abs/2504.07951)  
+**Conference:** ICCV 2025 (oral)
+
+**Summary:** This paper trains 457 native multimodal models with different architectures and mixtures to compare early fusion, late fusion, and modality-expert designs. It revisits the assumption that attaching a pretrained vision encoder is inherently better than learning multimodal representations from the start.
+
+## Paper Insights
+
+The authors find no inherent late-fusion advantage in their study. Early-fusion models perform better at lower parameter counts, train more efficiently, and are simpler to deploy; adding Mixture of Experts lets the model learn modality-specific weights and improves performance.
+
+| Decision | Evidence in the paper |
+| --- | --- |
+| Early vs. late fusion | No inherent advantage for late fusion in the studied regime. |
+| Small-model efficiency | Early fusion is stronger at lower parameter counts. |
+| Specialization | MoE modality-specific weights improve the native model. |
+
+**Limits:** Scaling-law conclusions are conditional on the architectures, modalities, objectives, and mixtures studied; they should guide a proxy-run plan, not replace one.
+
+**Takeaway:** Treat early fusion plus learned specialization as a serious baseline rather than assuming a pretrained visual tower is necessary.
+

--- a/src/content/posts/scaling-laws-for-optimal-data-mixtures.md
+++ b/src/content/posts/scaling-laws-for-optimal-data-mixtures.md
@@ -1,0 +1,32 @@
+---
+title: 'Scaling Laws for Optimal Data Mixtures'
+date: '2025-07-12T09:00:00.000Z'
+section: paper-shorts
+postSlug: scaling-laws-for-optimal-data-mixtures
+legacyPath: /paper shorts/2025/07/12/scaling-laws-for-optimal-data-mixtures.html
+tags: [Scaling Laws]
+field: Omni-Models
+summary: '2025 – Estimating compute-aware data mixtures from small training runs.'
+---
+
+## 2025 – Scaling Laws for Optimal Data Mixtures
+
+**arXiv:** [2507.09404](https://arxiv.org/abs/2507.09404)  
+**Conference:** Technical report
+
+**Summary:** This paper proposes scaling laws that predict loss from model size $N$, training tokens $D$, and a domain-weight vector $h$. The objective is to choose data mixtures systematically rather than through trial and error at the full pre-training scale.
+
+## Paper Insights
+
+The authors validate the prediction framework across LLM, native multimodal, and large vision-model pre-training. Their claim is operational: a few small runs can estimate parameters that extrapolate to new mixtures and larger scales, then yield compute-aware optimal domain weights for a chosen target.
+
+| Input | Use |
+| --- | --- |
+| $N$ and $D$ | Defines the scale and budget. |
+| Domain weights $h$ | Defines the candidate mixture. |
+| Target-domain loss | Defines what “optimal” means. |
+
+**Limits:** An extrapolated optimum is only as trustworthy as the small-run fit and the stability of rankings outside the observed regime.
+
+**Takeaway:** Allocate data with an uncertainty-aware fitted model, then update the allocation as new evidence arrives.
+

--- a/src/content/posts/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.md
+++ b/src/content/posts/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.md
@@ -1,0 +1,33 @@
+---
+title: 'TokenFlow: Unified Image Tokenizer for Multimodal Understanding and Generation'
+date: '2024-12-04T09:00:00.000Z'
+section: paper-shorts
+postSlug: tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation
+legacyPath: /paper shorts/2024/12/04/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.html
+tags: [Multimodal AI]
+field: Omni-Models
+summary: '2024 – TokenFlow: a dual-codebook tokenizer for visual semantics and reconstruction detail.'
+---
+
+## 2024 – TokenFlow
+
+**arXiv:** [2412.03069](https://arxiv.org/abs/2412.03069)  
+**GitHub:** [ByteFlow-AI/TokenFlow](https://github.com/ByteFlow-AI/TokenFlow)  
+**Conference:** CVPR 2025
+
+**Summary:** TokenFlow is a unified image tokenizer built around two aligned codebooks: one for semantic features used by understanding and one for pixel-level detail used by generation. It aims to avoid the usual tradeoff of using a reconstruction-focused VQ encoder for both tasks.
+
+## Paper Insights
+
+The key mechanism is dual codebooks connected through a shared mapping, so shared indices expose both semantic and fine-grained information. The paper reports 7.2% average improvement over LLaVA-1.5 13B on its understanding comparison, FID 0.63 at 384×384 reconstruction, and GenEval 0.55 at 256×256 autoregressive generation.
+
+| Signal | Reported value | Why it matters |
+| --- | --- | --- |
+| Understanding | 7.2% average improvement over LLaVA-1.5 13B | Tests whether discrete input can retain semantic value. |
+| Reconstruction | FID 0.63 at 384×384 | Tests fine visual detail. |
+| Generation | GenEval 0.55 at 256×256 | Tests the generation side of the tokenizer. |
+
+**Limits:** The design adds tokenizer complexity; results depend on the selected comparisons and resolutions.
+
+**Takeaway:** The tokenizer is an architectural decision: semantic and reconstruction features can be aligned without being identical.
+

--- a/src/content/posts/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.md
+++ b/src/content/posts/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.md
@@ -1,0 +1,33 @@
+---
+title: 'TorchTitan: One-stop PyTorch Native Solution for Production-ready LLM Pre-training'
+date: '2024-10-09T09:00:00.000Z'
+section: paper-shorts
+postSlug: torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training
+legacyPath: /paper shorts/2024/10/09/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.html
+tags: [ML Systems]
+field: Omni-Models
+summary: '2024 – TorchTitan: composable parallelism, checkpointing, and debugging for large-scale PyTorch pre-training.'
+---
+
+## 2024 – TorchTitan
+
+**arXiv:** [2410.06511](https://arxiv.org/abs/2410.06511)  
+**GitHub:** [pytorch/torchtitan](https://github.com/pytorch/torchtitan)  
+**Conference:** Technical report
+
+**Summary:** TorchTitan is a PyTorch-native distributed training system for composing large-model training recipes. It brings modular 3D parallelism, elastic scaling, checkpointing, logging, debugging, Float8 training, and hardware-aware features into one system.
+
+## Paper Insights
+
+The contribution is operational composability: compare and combine parallelism strategies without stitching together incompatible repositories. The authors evaluate Llama 3.1 models from 8B to 405B parameters and report incremental speedups from 1D, 2D, and 3D parallelism on H100 systems.
+
+| Capability | Operational consequence |
+| --- | --- |
+| 3D parallelism | Model scale requires coordinated tensor, pipeline, and data parallelism. |
+| Checkpointing and logging | Recoverability and diagnosis belong in the training design. |
+| Modular recipes | Enables controlled comparisons instead of one-off system configurations. |
+
+**Limits:** The reported recipes are LLM-focused. Multimodal runs add long-sequence, data-pipeline, and modality-health failure modes that still need explicit monitoring.
+
+**Takeaway:** A production training stack is part of the research method because it determines what experiments can be run, compared, and recovered.
+

--- a/src/content/posts/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.md
+++ b/src/content/posts/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.md
@@ -1,0 +1,32 @@
+---
+title: 'Transfusion: Predict the Next Token and Diffuse Images with One Multi-Modal Model'
+date: '2024-08-20T09:00:00.000Z'
+section: paper-shorts
+postSlug: transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model
+legacyPath: /paper shorts/2024/08/20/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.html
+tags: [Multimodal AI]
+field: Omni-Models
+summary: '2024 – Transfusion: one transformer, next-token language modeling, and image diffusion.'
+---
+
+## 2024 – Transfusion
+
+**arXiv:** [2408.11039](https://arxiv.org/abs/2408.11039)  
+**Conference:** Technical report
+
+**Summary:** Transfusion combines next-token prediction for discrete data with diffusion for continuous image data in a single transformer. It studies models up to 7B parameters trained on text-image mixtures and compares the recipe with discrete image-token language modeling.
+
+## Paper Insights
+
+The paper separates the question of a shared transformer from the question of a shared loss. Text remains autoregressive while images use diffusion; modality-specific encoders and decoders handle the interface. The authors report that this hybrid recipe scales better than quantizing images into discrete tokens in their setting and can compress images to 16 patches with modality-specific layers.
+
+| Design choice | Why it is useful |
+| --- | --- |
+| Continuous visual objective | Avoids forcing image generation through a discrete-token bottleneck. |
+| Shared transformer | Preserves cross-modal interaction. |
+| Modality-specific I/O | Lets each modality use a suitable representation. |
+
+**Limits:** Hybrid objectives make loss weighting, training diagnostics, and serving more complicated than one next-token objective.
+
+**Takeaway:** A unified model does not require a unified loss; use the objective that matches the modality.
+

--- a/src/content/posts/wan-open-and-advanced-large-scale-video-generative-models.md
+++ b/src/content/posts/wan-open-and-advanced-large-scale-video-generative-models.md
@@ -1,0 +1,33 @@
+---
+title: 'Wan: Open and Advanced Large-Scale Video Generative Models'
+date: '2025-03-26T09:00:00.000Z'
+section: paper-shorts
+postSlug: wan-open-and-advanced-large-scale-video-generative-models
+legacyPath: /paper shorts/2025/03/26/wan-open-and-advanced-large-scale-video-generative-models.html
+tags: [Video Generation]
+field: Omni-Models
+summary: '2025 – Wan: an open video-generation suite built around diffusion transformers, a VAE, and large-scale curation.'
+---
+
+## 2025 – Wan
+
+**arXiv:** [2503.20314](https://arxiv.org/abs/2503.20314)  
+**GitHub:** [Wan-Video/Wan2.1](https://github.com/Wan-Video/Wan2.1)  
+**Conference:** Technical report
+
+**Summary:** Wan is an open suite of video foundation models built on diffusion transformers. The report centers the video VAE, scalable pre-training, data curation, automated evaluation, and model-size/data-size scaling.
+
+## Paper Insights
+
+Wan supplies a systems-oriented video reference rather than only a generative-model result. It releases 1.3B and 14B models, supports several downstream tasks such as image-to-video and editing, and reports that the 1.3B model can run with 8.19 GB of VRAM.
+
+| Component | Decision it informs |
+| --- | --- |
+| Video VAE | How aggressively to compress space and time before the transformer. |
+| Data pipeline | Caption quality, motion filtering, and curation affect the usable training signal. |
+| Model family | How to trade quality against a consumer-scale deployment target. |
+
+**Limits:** Video quality does not establish action-conditioned dynamics, causal control, or long-horizon world consistency.
+
+**Takeaway:** Treat the video autoencoder and data pipeline as first-class architecture choices, not preprocessing details.
+


### PR DESCRIPTION
## Summary
- publish the omni-model technical-decision blog post
- add eleven source-grounded Tier-1 paper notes under the new Omni-Models field
- retain the existing Robotics and VLA entries for pi0 and FAST rather than duplicating them

## Validation
- npm run ci