### PR TITLE
Add decision lenses and reorganize paper taxonomy

### DIFF
--- a/src/content/posts/a-survey-on-vision-language-action-models-for-autonomous-driving.md
+++ b/src/content/posts/a-survey-on-vision-language-action-models-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: a-survey-on-vision-language-action-models-for-autonomous-driving
 legacyPath: /paper shorts/2025/06/30/a-survey-on-vision-language-action-models-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: This survey organizes VLA-for-autonomous-driving work around architecture blocks, model evolution, datasets, benchmarks, and open deployment challenges.
 ---
 ## 2025 - A Survey on VLA Models for Autonomous Driving
@@ -41,6 +41,12 @@ _Figure 2 summarizes the VLA4AD architecture blocks, connecting visual inputs, l
 | Modular VLA | Use language reasoning as an intermediate signal | Hybrid VLM plus planner systems |
 | End-to-end VLA | Map scene inputs and instructions toward actions | OpenDriveVLA and related action models |
 | Augmented VLA | Add tools, chains of thought, or world models | DiffVLA and DriveVLA-W0-style extensions |
+
+## Decision Lens
+
+This survey informs how to partition a driving-VLA research portfolio across perception-language alignment, world modeling, action generation, datasets, and closed-loop evaluation. Its comparison unit is not one token or trajectory but a system interface: visual representation, language/reasoning backbone, action head, and deployment loop.
+
+The taxonomy is useful only if it predicts which interfaces transfer across papers. A controlled benchmark that fixes sensors, backbone, data, latency, and action space would test that causal value. As the field expands, inconsistent action definitions and mostly open-loop metrics will age the taxonomy faster than model names. The survey's organizing claim would fail if capability and safety differences were explained better by data quality or evaluation protocol than by the proposed architecture categories.
 
 **Context:** The survey gives a shared vocabulary for a field where "VLA" can mean anything from QA to closed-loop trajectory generation.
 

--- a/src/content/posts/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
+++ b/src/content/posts/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2020/10/01/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.html
 tags:
   - Other
-field: Computer Vision
+field: 'Vision Foundations'
 summary: ViT showed that patchified images and standard Transformer encoders can rival CNNs when pre-training data is large enough.
 ---
 ## 2020 – An Image Is Worth 16×16 Words: Transformers for Image Recognition at Scale
@@ -68,5 +68,13 @@ class PatchEmbed(nn.Module):
 ```
 
 **Critiques & limitations:** ViT's appeal is its plainness: patchify the image and reuse the Transformer stack. That simplicity helped unify vision and NLP research. The cost is data hunger. Vanilla ViT needs huge pre-training datasets such as JFT-300M, and quadratic attention makes very high resolutions and dense prediction tasks expensive.
+
+## Decision Lens
+
+ViT informs the decision to buy visual scale with learned attention instead of convolutional inductive bias. The atomic unit is a fixed-size image patch embedded as a token; the same attention and feed-forward parameters process every patch position.
+
+The result establishes a data-regime crossover, not universal Transformer superiority: large supervised pre-training makes the plain patch sequence competitive, while smaller datasets still favor stronger visual priors. Patch size is therefore a compression decision as well as an architectural one—smaller patches preserve detail but increase attention cost quadratically.
+
+The decisive missing comparison is a CNN and ViT sweep with identical data, augmentation, parameters, FLOPs, and transfer protocol across several data scales. At 10× resolution, token count and activation memory would fail before parameter count. The central claim would weaken if a convolutional baseline matched transfer accuracy and throughput throughout that controlled crossover study.
 
 **Takeaway:** With enough data, a plain Transformer can rival convolutional backbones for image classification. ViT did not make convolutions obsolete overnight, but it made attention-first vision models credible.

--- a/src/content/posts/are-vlms-ready-for-autonomous-driving-drivebench.md
+++ b/src/content/posts/are-vlms-ready-for-autonomous-driving-drivebench.md
@@ -6,7 +6,7 @@ postSlug: are-vlms-ready-for-autonomous-driving-drivebench
 legacyPath: /paper shorts/2025/01/01/are-vlms-ready-for-autonomous-driving-drivebench.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: DriveBench tested whether VLM driving answers are visually grounded or merely plausible.
 ---
 ## 2025 - Are VLMs Ready for Autonomous Driving?
@@ -36,6 +36,12 @@ _Figure 1 from the [DriveBench paper](https://arxiv.org/abs/2501.04003), cropped
 | Dataset | 19,200 frames / 20,498 QA pairs | Tests multiple driving tasks and question types. |
 | Stress test | 17 input conditions | Checks corruption and text-only reliance. |
 | Main failure | Weak visual grounding | Models can answer from priors instead of perception. |
+
+## Decision Lens
+
+DriveBench informs whether a VLM's plausible driving language is grounded enough to support deployment claims. Its atomic evaluation item couples a driving frame with a question and answer, then stresses visual corruption and text-only shortcuts to separate perception from learned priors.
+
+The benchmark shows that fluent answers can survive when visual evidence is removed or degraded, so aggregate QA accuracy is not a grounding metric. The missing validation is replication on new geographies, camera rigs, and freshly collected questions with contamination checks and human disagreement estimates. At 10× scale, annotation consistency and shortcut diversity dominate example count. DriveBench's conclusion would weaken if model rankings and failure modes did not reproduce on that independent set.
 
 **Context:** Capability benchmarks can flatter VLMs. Driving needs reliability benchmarks that ask whether the model actually looked at the scene.
 

--- a/src/content/posts/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.md
+++ b/src/content/posts/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving
 legacyPath: /paper shorts/2024/06/01/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: AsyncDriver separated slow LLM reasoning from fast motion planning so semantic guidance could enter the loop without blocking control.
 ---
 ## 2024 - AsyncDriver
@@ -36,6 +36,12 @@ _Figure 2: Overview of our proposed AsyncDriver framework. From the [AsyncDriver
 | Runtime design | Asynchronous reasoning loop | Avoids blocking high-frequency planning. |
 | Planner role | Fast conventional motion planner | Keeps control responsive. |
 | Caveat | LLM advice must be bounded | Bad slow guidance should not override safety. |
+
+## Decision Lens
+
+AsyncDriver informs where a slow semantic model can enter a fast control stack without setting the control-loop latency. The operative units run at two clocks: infrequent LLM guidance summarizes scene-level intent, while a conventional planner produces high-frequency trajectories from current perception.
+
+The asynchronous boundary buys latency but risks stale guidance during rapid scene changes. The decisive ablation varies guidance age and event-trigger policy while matching planner capacity against no-LLM and synchronous-LLM baselines in closed loop. At 10× traffic complexity, semantic updates and planner state can diverge. The architecture would fail if delayed guidance produced no safety or progress gain over a smaller fast planner, or if rare stale-command failures erased the average benefit.
 
 **Context:** It is a sober architecture. Instead of pretending language models are real-time controllers, AsyncDriver gives them a slower advisory role.
 

--- a/src/content/posts/attention-is-all-you-need.mdx
+++ b/src/content/posts/attention-is-all-you-need.mdx
@@ -6,7 +6,7 @@ postSlug: attention-is-all-you-need
 legacyPath: /paper shorts/2017/06/01/attention-is-all-you-need.html
 tags:
   - Other
-field: Natural Language Processing
+field: 'Language Models'
 summary: The Transformer removed recurrence from sequence modeling and made attention-first architectures practical at scale.
 ---
 import PythonPlayground from '../../components/PythonPlayground';
@@ -104,3 +104,9 @@ Self-attention gives every pair of tokens a constant-length path, but it pays fo
 ### Ongoing challenges
 
 The same quadratic cost limits long contexts, and smaller datasets did not immediately erase the case for RNNs. Still, the direction was clear. Transformers became the backbone for BERT, GPT, Vision Transformers, and most of the modern sequence-modeling stack.
+
+## Decision Lens
+
+The Transformer informs the decision to replace recurrent state updates with globally addressable token-to-token communication. Its training unit is a source-target token pair under teacher-forced next-token prediction; position enters through an encoding, while attention and feed-forward weights are shared across sequence positions.
+
+The original translation experiments established parallel training efficiency and strong sequence transduction, not efficient arbitrarily long context. A cleaner ablation would compare attention, recurrence, and convolution with matched parameters, training FLOPs, wall-clock time, and sequence lengths. At 10× context, quadratic attention memory and all-to-all communication become the primary failure mode. The architectural claim would fail if a recurrent or state-space model matched translation quality and training throughput under the same budget while scaling more gracefully with length.

--- a/src/content/posts/auto-encoding-variational-bayes.md
+++ b/src/content/posts/auto-encoding-variational-bayes.md
@@ -6,7 +6,7 @@ postSlug: auto-encoding-variational-bayes
 legacyPath: /paper shorts/2014/04/01/auto-encoding-variational-bayes.html
 tags:
   - Other
-field: Variational Inference
+field: 'Generative Modeling'
 summary: VAEs made latent-variable models trainable with SGD by turning stochastic sampling into a differentiable reparameterized path.
 ---
 ## 2014 – Auto-Encoding Variational Bayes
@@ -29,6 +29,14 @@ _Figure from the [AEVB paper](https://arxiv.org/abs/1312.6114), via ar5iv._
 **Summary:** Kingma and Welling made variational inference feel like ordinary neural-network training. Their variational autoencoder pairs an encoder $q_\phi(z \mid x)$, which approximates the posterior over latent variables, with a decoder $p_\theta(x \mid z)$, which reconstructs observations from those latents. The key move is the reparameterisation trick: instead of sampling $z$ in a way that blocks gradients, sample fixed noise and transform it through differentiable parameters.
 
 That trick turns Monte Carlo estimates of the evidence lower bound (ELBO) into low-variance gradients that work with standard stochastic gradient descent. The paper also made amortised inference practical at scale: the encoder learns to predict posterior parameters directly, rather than solving a separate inference problem for every datapoint.
+
+## Decision Lens
+
+The paper clarifies which latent representation and generative objective give the best quality, likelihood, and sampling-cost tradeoff. Its fundamental training unit is a datapoint and a sampled latent variable.
+
+For optimization, the ELBO adds an expected reconstruction term and a KL term per example; the original formulation does not introduce a separate $\beta$ reweighting coefficient. The encoder maps each observation to the parameters of a compact latent distribution sampled through reparameterization.
+
+The most important missing comparison is a matched-compute comparison that separates objective choice, latent compression, sampler steps, and data quality. At 10× scale, data curation, latent bottlenecks, sampling cost, and training instability would dominate simple parameter scaling. The central claim would fail under this test: Hold data, parameters, and sampling compute fixed; reject the objective if a simpler likelihood or adversarial baseline matches quality and coverage.
 
 **Context:** VAEs gave deep generative modelling a stable likelihood-based recipe. They did not produce the sharpest samples, but they made latent-variable models trainable, inspectable, and useful for representation learning. Later work such as $\beta$-VAE, conditional VAEs, and flow-based models all build on this basic encoder-decoder view of probabilistic inference.
 

--- a/src/content/posts/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.md
+++ b/src/content/posts/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: autotrust-benchmarking-trustworthiness-in-large-vision-language-models
 legacyPath: /paper shorts/2024/12/01/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: AutoTrust evaluated driving VLMs across hallucination, safety, robustness, privacy, and fairness.
 ---
 ## 2024 - AutoTrust
@@ -36,6 +36,12 @@ _Figure 1 from the [AutoTrust paper](https://arxiv.org/abs/2412.15206), via arXi
 | Dataset | 10k scenes / 18k queries | Designed around trust dimensions. |
 | Axes | Truthfulness, safety, robustness, privacy, fairness | Evaluates more than accuracy. |
 | Main finding | Hidden unsafe behaviors | Capability can improve while trust still lags. |
+
+## Decision Lens
+
+AutoTrust informs which failure dimensions must be measured before a driving VLM can be treated as a trustworthy component. The evaluation unit is a scenario-prompt pair scored across hallucination, safety, robustness, privacy, and fairness rather than one average QA metric.
+
+The benchmark exposes multidimensional risk, but its weights do not define the operational cost of each failure. The missing study validates benchmark scores against human driving-review outcomes and real intervention rates on held-out fleets. At 10× coverage, scenario curation, demographic balance, adversarial diversity, and leakage dominate. AutoTrust would fail as a gate if benchmark rankings did not predict failures on fresh, naturally occurring driving incidents.
 
 **Context:** Trustworthiness is not one metric. A model can improve on standard driving QA while still becoming less safe or less private.
 

--- a/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
+++ b/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
@@ -11,7 +11,7 @@ legacyPath: >-
   shorts/2019/06/01/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.html
 tags:
   - Other
-field: Natural Language Processing
+field: 'Language Models'
 summary: BERT made bidirectional encoder pre-training reusable across NLP tasks through masked-language modeling and fine-tuning.
 ---
 import PythonPlayground from '../../components/PythonPlayground';
@@ -118,3 +118,11 @@ BERT was compute-hungry in 2018 and still non-trivial to reproduce casually. NSP
 ## Looking Forward
 
 BERT's recipe became a floor, not a ceiling. Better corruption schemes, cheaper compressors, and longer-context attention methods all stand on top of the same basic idea: mask some tokens, optionally test sentence order, backpropagate, and reuse the encoder everywhere. That elegance is why BERT is still worth teaching.
+
+## Decision Lens
+
+BERT informs the decision to spend pre-training compute on a bidirectional encoder that transfers through fine-tuning rather than train a task-specific model or a left-to-right representation. Its atomic unit is a masked token sequence, optionally paired with a second segment for next-sentence prediction.
+
+The pre-training recipe mixes masked-language modeling and next-sentence prediction over BooksCorpus and English Wikipedia, with shorter sequences used for most steps before a smaller number of length-512 updates. That curriculum makes sequence length a compute-allocation choice, not merely a tokenizer setting.
+
+The most consequential missing ablation is a matched-token comparison of MLM with and without next-sentence prediction and with alternative corruption schemes; later work showed that NSP was not generally necessary. At 10× scale, sparse corruption wastes prediction opportunities and long-sequence attention dominates cost. BERT's central recipe would be falsified if a simpler encoder objective matched downstream transfer under identical data, parameters, tokens, and fine-tuning sweeps.

--- a/src/content/posts/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.md
+++ b/src/content/posts/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.md
@@ -6,7 +6,7 @@ postSlug: bevformer-learning-birds-eye-view-representation-from-multi-camera-ima
 legacyPath: /paper shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html
 tags:
   - Other
-field: BEV
+field: 'BEV Perception & Mapping'
 summary: BEVFormer learns dense BEV features from multi-camera images with spatial cross-attention and temporal self-attention, making BEV a reusable perception representation.
 ---
 ## 2022 - BEVFormer
@@ -41,6 +41,12 @@ _Figure 2 shows the BEVFormer encoder: camera features, BEV queries, spatial cro
 | Spatial attention | BEV queries attend to multi-camera features | Bridges image space and ground-plane reasoning. |
 | Temporal attention | Current BEV attends to previous BEV | Adds motion/history with low extra structure. |
 | Result | 56.9% nuScenes NDS reported in the abstract | Marked BEVFormer as a strong camera-only perception baseline. |
+
+## Decision Lens
+
+BEVFormer informs whether multi-camera perception should first build a persistent metric BEV grid or reason directly in camera views. Its atomic unit is a learned BEV query tied to a ground-plane location; spatial cross-attention samples projected image features, while temporal self-attention carries the same grid across frames.
+
+The representation buys a reusable geometry for 3D detection at the cost of projection assumptions and a dense query budget. The key missing control compares dense BEV queries with sparse object queries under identical backbone, temporal context, and latency. At 10× camera resolution or temporal length, feature sampling and BEV-query attention dominate. The BEV-first claim would fail if a view-space or sparse model matched 3D accuracy and temporal stability with materially lower memory and latency.
 
 **Context:** BEVFormer became one of the reference points for dense BEV-oriented autonomous driving stacks.
 

--- a/src/content/posts/cambrian-1-vision-centric-exploration-of-multimodal-llms.md
+++ b/src/content/posts/cambrian-1-vision-centric-exploration-of-multimodal-llms.md
@@ -6,7 +6,7 @@ postSlug: cambrian-1-vision-centric-exploration-of-multimodal-llms
 legacyPath: /paper shorts/2024/06/01/cambrian-1-vision-centric-exploration-of-multimodal-llms.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: Cambrian-1 treated VLM design as a vision problem first, systematically studying encoders, connectors, data, and evaluation.
 ---
 ## 2024 - Cambrian-1
@@ -36,6 +36,12 @@ _Figure 8 from the [Cambrian-1 paper](https://arxiv.org/abs/2406.16860), cropped
 | Design axis | 20+ vision encoders tested | Shows visual backbone choice changes downstream VLM behavior. |
 | Connector | Spatial Vision Aggregator | Keeps more local visual evidence for the LLM. |
 | Benchmark | CV-Bench | Evaluates vision-centric reasoning failures. |
+
+## Decision Lens
+
+Cambrian-1 informs where to spend the next unit of MLLM compute: on a larger language model, or on perception that preserves spatial evidence. Its experiments make the vision encoder and connector first-order design variables. Multiple visual backbones feed a Spatial Vision Aggregator, which retains local, high-resolution features before projecting them into the language stream; CV-Bench is then used to separate genuine visual competence from answers recoverable through language priors.
+
+The paper establishes that weak perception remains a binding constraint even when the language model is strong, but it does not fully isolate whether gains come from complementary encoder features, extra visual compute, or the aggregator itself. That matched-compute ablation is the expensive missing comparison. At ten times the scale, feeding ever more spatial tokens and encoders could make context cost and data quality dominate. The central claim would be weakened if a single encoder with the same token and FLOP budget matched the multi-encoder system on grounding-heavy tests while retaining its general benchmark performance.
 
 **Context:** A lot of VLM work implicitly assumes the LLM is the hard part. Cambrian-1 pushes back: the quality of the visual representation and connector can decide whether the language model is reasoning over evidence or filling gaps from priors.
 

--- a/src/content/posts/can-lvlms-obtain-a-drivers-license-idkb.md
+++ b/src/content/posts/can-lvlms-obtain-a-drivers-license-idkb.md
@@ -6,7 +6,7 @@ postSlug: can-lvlms-obtain-a-drivers-license-idkb
 legacyPath: /paper shorts/2024/09/01/can-lvlms-obtain-a-drivers-license-idkb.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: IDKB tested whether vision-language models know explicit driving rules, not just visual scene facts.
 ---
 ## 2024 - Can LVLMs Obtain a Driver's License?
@@ -36,6 +36,12 @@ _Figure 1: Performance of 15 representative Large Vision-Language Models on IDKB
 | Dataset | 1M+ driving knowledge items | Covers rules, exams, and applied scenarios. |
 | Evaluation | 15 LVLMs | Tests whether general models know driving theory. |
 | Main failure | Missing specialized rule knowledge | Perception alone is not driving competence. |
+
+## Decision Lens
+
+IDKB informs whether a driving LVLM needs explicit traffic-rule knowledge in addition to visual scene description. Its atomic item is a rule-grounded image-question pair that tests recognition, regulation recall, and application of the rule to a scene.
+
+The benchmark distinguishes legal knowledge from generic visual fluency, but written-test competence is not closed-loop driving competence. The missing comparison controls for text-only rule memorization by using counterfactual scenes and jurisdiction changes. At 10× rule coverage, contradictory local regulations and rare signage make annotation and retrieval the bottlenecks. The licensing analogy would fail if high IDKB scores did not predict correct decisions on unseen rule-scene combinations.
 
 **Context:** Driving competence is not only perception. It is perception plus rule knowledge plus judgment under context.
 

--- a/src/content/posts/chameleon-mixed-modal-early-fusion-foundation-models.md
+++ b/src/content/posts/chameleon-mixed-modal-early-fusion-foundation-models.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: chameleon-mixed-modal-early-fusion-foundation-models
 legacyPath: /paper shorts/2024/05/16/chameleon-mixed-modal-early-fusion-foundation-models.html
 tags: [Multimodal AI]
-field: Omni-Models
+field: 'Omni-Model Architectures'
 summary: '2024 – Chameleon: early fusion over mixed image-and-text token sequences.'
 ---
 
@@ -26,7 +26,14 @@ Early fusion makes a direct architectural claim: one transformer can model mixed
 | Sharing | Early fusion throughout the transformer | Shared capacity may create modality interference. |
 | Objective | Next-token prediction | A simple unified objective, but expensive for long visual sequences. |
 
+## Decision Lens
+
+Chameleon informs the decision to use one early-fusion token stream for multimodal understanding and generation instead of separate language and image systems. Its atomic unit is a discrete text or image token, and one Transformer shares sequence processing across arbitrary image-text orderings after modality-specific tokenization.
+
+The single next-token objective makes the interface clean, but image quantization and visual-token count determine both reconstruction quality and sequence cost. The paper's stable-training recipe shows that early fusion can work at useful scale; it does not establish that discrete visual tokens are compute-optimal against continuous diffusion or decoupled visual encoders.
+
+A decisive comparison would hold data, parameters, and training FLOPs fixed across discrete early fusion, a continuous-image hybrid, and a shared backbone with separate visual routes. At 10× visual context, token length and modality interference are the likely bottlenecks. The early-fusion claim would fail if a separated design matched mixed-document quality and generation while using materially less training and inference compute.
+
 **Limits:** Strong unified generation does not establish that a fully shared representation is best for every visual understanding or action task.
 
 **Takeaway:** Chameleon is the clean baseline for asking whether early fusion is worth its sequence-length and interference costs.
-

--- a/src/content/posts/deep-residual-learning-for-image-recognition.md
+++ b/src/content/posts/deep-residual-learning-for-image-recognition.md
@@ -6,7 +6,7 @@ postSlug: deep-residual-learning-for-image-recognition
 legacyPath: /paper shorts/2015/12/01/deep-residual-learning-for-image-recognition.html
 tags:
   - Other
-field: Computer Vision
+field: 'Vision Foundations'
 summary: ResNet made very deep CNNs practical by learning residual updates and carrying gradients through identity shortcuts.
 ---
 ## 2015 – Deep Residual Learning for Image Recognition
@@ -29,6 +29,14 @@ _Residual-block diagram from the ResNet paper/project materials._
 **Summary:** ResNet made depth easier to optimize by changing what each block has to learn. Instead of learning a direct mapping $H(x)$, a residual block learns $F(x)=H(x)-x$ and adds the input back through an identity shortcut: $H(x)=F(x)+x$. If the best transformation is close to identity, the block can push $F(x)$ toward zero rather than forcing a stack of layers to relearn the input.
 
 Those shortcuts act like gradient highways without adding parameters or inference cost. They let the authors train 152-layer networks that were both deeper and more accurate than plain CNNs. Bottleneck blocks, built from 1x1, 3x3, and 1x1 convolutions, kept the compute manageable: ResNet-152 was far deeper than VGG-19 while using fewer FLOPs. An ensemble of ResNets achieved 3.57% top-5 error on ImageNet and won ILSVRC 2015.
+
+## Decision Lens
+
+ResNet informs the decision to add depth through residual updates rather than ask each block to relearn a complete transformation. The operative unit is a residual block applied across a mini-batch of images, with identity shortcuts carrying both activations and gradients across depth.
+
+The ImageNet-to-detection transfer results show that the optimization benefit survives beyond classification. They do not isolate identity shortcuts from batch normalization, initialization, or the bottleneck block design as cleanly as a modern controlled study could.
+
+At 10× depth, activation memory, normalization behavior, communication, and diminishing returns dominate the original degradation problem. The residual-learning claim would weaken if a plain network with matched depth, normalization, initialization, FLOPs, and training time reached the same accuracy and optimization stability.
 
 **Context:** The residual connection is a tiny architectural change with huge practical reach. It fixed the degradation problem in very deep CNNs, transferred well to detection and segmentation, and later became part of the default design vocabulary for modern deep networks, including Transformers.
 

--- a/src/content/posts/deepseek-vl2-mixture-of-experts-vision-language-models.md
+++ b/src/content/posts/deepseek-vl2-mixture-of-experts-vision-language-models.md
@@ -6,7 +6,7 @@ postSlug: deepseek-vl2-mixture-of-experts-vision-language-models
 legacyPath: /paper shorts/2024/12/01/deepseek-vl2-mixture-of-experts-vision-language-models.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: DeepSeek-VL2 combined dynamic high-resolution tiling with sparse MoE language modeling for efficient document-heavy multimodal understanding.
 ---
 ## 2024 - DeepSeek-VL2
@@ -38,6 +38,12 @@ _Figure 1 from the [DeepSeek-VL2 paper](https://arxiv.org/abs/2412.10302), via a
 | Vision | Dynamic tiling | Keeps details from high-res and odd-aspect images. |
 | Language | DeepSeekMoE with latent attention | Improves inference efficiency for a large-capacity model. |
 | Best fit | OCR and documents | Text-heavy visual tasks expose the benefit. |
+
+## Decision Lens
+
+DeepSeek-VL2 informs whether a high-capacity VLM can remain economical by making both visual resolution and language computation conditional. The visual unit is a dynamically tiled patch sequence whose length follows the image, while the language backbone activates only a sparse subset of experts; Multi-head Latent Attention further compresses the inference-time attention state. The shared language space integrates modalities, but capacity and compute are deliberately not uniform across examples or tokens.
+
+Its results support the combination for OCR, documents, charts, and grounding, where fixed resizing destroys information, yet they do not cleanly price each gain in serving terms. A decisive ablation would hold latency, memory, and total visual tokens constant while varying tiling, MoE routing, and latent attention separately. At ten times the traffic or context length, irregular image-token counts and expert imbalance could erode the advertised efficiency through poor batching. The architectural case fails operationally if a dense, fixed-resolution model matches quality at equal end-to-end latency and memory.
 
 **Context:** It is a practical answer to the "large but usable" problem. The model can have broad capacity without paying dense-model cost on every token.
 

--- a/src/content/posts/denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/denoising-diffusion-probabilistic-models.md
@@ -6,7 +6,7 @@ postSlug: denoising-diffusion-probabilistic-models
 legacyPath: /paper shorts/2020/06/01/denoising-diffusion-probabilistic-models.html
 tags:
   - Other
-field: Generative Models
+field: 'Generative Modeling'
 summary: DDPMs turned generation into learned denoising, trading slow sampling for stable training and strong image quality.
 ---
 ## 2020 – Denoising Diffusion Probabilistic Models (DDPM)
@@ -31,6 +31,12 @@ _Figure 2 from the [DDPM paper](https://arxiv.org/abs/2006.11239), via ar5iv._
 **Summary:** DDPMs generate data by learning to reverse noise. The forward process gradually corrupts real examples into near-isotropic Gaussian noise. The learned reverse process, usually parameterized by a UNet, removes that noise step by step. Training asks the model to predict the noise $\hat{\epsilon}$ that was added at each timestep, then minimizes a weighted MSE against the true noise $\epsilon$.
 
 The payoff is stability. With 1000 denoising steps, DDPM reached FID 3.17 and IS 9.46 on CIFAR-10, matching StyleGAN-v2 without adversarial training. The framework also connects noise-conditioned denoising to score matching and score-based SDE models, giving diffusion a strong probabilistic interpretation rather than just a good sample generator.
+
+## Decision Lens
+
+DDPM informs the choice between stable iterative denoising and one-shot adversarial generation. The atomic example is an image corrupted at a sampled diffusion timestep; one network learns the reverse direction across the entire noise schedule.
+
+The paper established strong image quality and stable optimization at the cost of hundreds or thousands of sequential denoising steps. The key missing comparison separates the value of the variational formulation from the noise parameterization and sampling schedule at equal training and inference compute. At 10× resolution or duration, latent size and repeated network evaluations dominate. The claim would weaken if a flow, consistency, or adversarial model matched coverage and FID with materially fewer sequential evaluations.
 
 **Context:** Diffusion models made high-quality generation feel less fragile than GAN training. Later improvements, including learned reverse-process variance, faster samplers, and classifier-free guidance, turned the original slow denoising loop into the foundation for modern text-to-image systems.
 

--- a/src/content/posts/densetnt-end-to-end-trajectory-prediction-from-dense-goal-sets.md
+++ b/src/content/posts/densetnt-end-to-end-trajectory-prediction-from-dense-goal-sets.md
@@ -6,7 +6,7 @@ postSlug: densetnt-end-to-end-trajectory-prediction-from-dense-goal-sets
 legacyPath: /paper shorts/2021/08/22/densetnt-end-to-end-trajectory-prediction-from-dense-goal-sets.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: DenseTNT removes sparse goal anchors and heuristic goal selection by predicting dense goal probabilities and learning an online goal-set predictor.
 ---
 ## 2021 - DenseTNT
@@ -67,6 +67,12 @@ Waymo used mAP as the official ranking metric, so this table is about calibrated
 | TVN | 0.7558 | 1.5859 | 0.2032 | 0.3168 |
 | SceneTransformer | 0.6117 | 1.2116 | 0.1564 | 0.2788 |
 | DenseTNT | 1.0387 | 1.5514 | 0.1779 | 0.3281 |
+
+## Decision Lens
+
+DenseTNT informs whether multimodal forecasting should rely on hand-designed sparse goal anchors or learn a dense distribution over reachable endpoints. The training unit is one agent history paired with a future trajectory; endpoint probabilities define candidate modes before target-conditioned trajectories are decoded and scored.
+
+The method removes anchor engineering, but dense goal coverage makes map resolution and candidate pruning part of the compute budget. A decisive ablation would match proposal count and decoder capacity across sparse anchors, dense goals, and direct trajectory generation. At 10× scene density, goal scoring and duplicate modes can dominate while rare maneuvers remain underrepresented. DenseTNT's claim would fail if adaptive sparse proposals matched minFDE and miss rate with fewer candidates and better calibration.
 
 **Context:** DenseTNT pushed goal-conditioned forecasting away from sparse anchor heuristics and toward dense probability maps plus learned set prediction.
 

--- a/src/content/posts/dexvla-vision-language-model-with-plug-in-diffusion-expert.md
+++ b/src/content/posts/dexvla-vision-language-model-with-plug-in-diffusion-expert.md
@@ -6,7 +6,7 @@ postSlug: dexvla-vision-language-model-with-plug-in-diffusion-expert
 legacyPath: /paper shorts/2025/02/01/dexvla-vision-language-model-with-plug-in-diffusion-expert.html
 tags:
   - Other
-field: Robotics
+field: 'Vision-Language-Action & Robotics'
 summary: DexVLA paired VLM reasoning with a diffusion policy expert for long-horizon dexterous robot control.
 ---
 ## 2025 - DexVLA
@@ -36,6 +36,12 @@ _Figure 1: DexVLA architecture and embodied curriculum learning. From the [DexVL
 | Architecture | VLM plus diffusion expert | Splits planning from precise control. |
 | Training | Three-stage embodied curriculum | Moves from general motor skills to task specialization. |
 | Best fit | Dexterous long-horizon tasks | Where pure VLM action output is too coarse. |
+
+## Decision Lens
+
+DexVLA informs whether dexterous, long-horizon control should be forced through a VLM's discrete token head or delegated to a continuous action specialist. The VLM supplies semantic state and high-level guidance, while a billion-parameter diffusion expert generates multi-step action trajectories. A staged cross-embodiment curriculum moves from broad motor priors to embodiment adaptation and then task-specific dexterity.
+
+The results support specialization for precise control, but the architecture adds enough capacity and training complexity that its causal advantage over data and compute is unclear. The missing comparison is a parameter-, latency-, and demonstration-matched action head without diffusion, plus transfer tests where the VLM is frozen. At ten times the task and embodiment count, contradictory control conventions and diffusion sampling latency may dominate. The plug-in-expert claim would fail if a smaller shared action decoder matches closed-loop success and adapts with fewer demonstrations.
 
 **Context:** DexVLA shows how robotics can borrow from both sides of modern AI: language models for task structure and diffusion models for continuous trajectory generation.
 

--- a/src/content/posts/diffvla-vision-language-guided-diffusion-planning-for-autonomous-driving.md
+++ b/src/content/posts/diffvla-vision-language-guided-diffusion-planning-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: diffvla-vision-language-guided-diffusion-planning-for-autonomous-drivi
 legacyPath: /paper shorts/2025/05/26/diffvla-vision-language-guided-diffusion-planning-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: DiffVLA uses VLM-guided hybrid sparse-dense diffusion planning to generate diverse driving trajectories with explicit agent-map interaction.
 ---
 ## 2025 - DiffVLA
@@ -39,6 +39,12 @@ _Figure 1 shows DiffVLA's perception-enhanced diffusion VLA framework, where vis
 | Guidance | VLM-conditioned planning | Adds semantic driving cues to geometric planning. |
 | Interaction | Agent-map-language fusion | Makes planning depend on actors, road structure, and language context. |
 | Reported signal | 45.0 PDMS in the 2025 challenge setting | Gives a public planning-oriented comparison point. |
+
+## Decision Lens
+
+DiffVLA informs whether a driving VLM should autoregressively emit one trajectory or guide a diffusion planner over a multimodal continuous trajectory distribution. The atomic training unit is a noisy future trajectory at a sampled diffusion timestep, conditioned on language-aware scene features and explicit agent-map interactions.
+
+Diffusion can preserve multiple feasible maneuvers, but denoising steps, guidance strength, and candidate rescoring determine real-time utility. The missing matched-latency study compares diffusion, autoregressive, and direct-set planners with the same backbone and candidate budget. At 10× horizon, denoising cost and interaction tensors dominate. The diffusion choice would fail if a simpler continuous decoder matched closed-loop safety, diversity, and calibration within the same latency envelope.
 
 **Context:** DiffVLA shows one path from VLA semantics to action generation: use language to guide a generative planner rather than asking the language model to emit control alone.
 

--- a/src/content/posts/direct-preference-optimization-dpo.md
+++ b/src/content/posts/direct-preference-optimization-dpo.md
@@ -6,7 +6,7 @@ postSlug: direct-preference-optimization-dpo
 legacyPath: /paper shorts/2023/05/01/direct-preference-optimization-dpo.html
 tags:
   - Other
-field: Reinforcement Learning
+field: 'Alignment & Post-Training'
 summary: DPO replaced explicit reward modeling and PPO with a direct preference loss derived from the RLHF objective.
 ---
 ## 2023 – Direct Preference Optimization: Your Language Model Is Secretly a Reward Model
@@ -53,5 +53,11 @@ def dpo_loss(policy, ref_policy, batch, beta=0.1):
     logits = beta * ((chosen_logp - reject_logp) - (chosen_ref - reject_ref))
     return F.binary_cross_entropy_with_logits(logits, torch.ones_like(logits))
 ```
+
+## Decision Lens
+
+DPO informs whether preference alignment requires a separately trained reward model and online RL loop. The atomic example is a prompt with chosen and rejected responses; the policy and frozen reference model turn that pair into one logistic preference loss.
+
+The derivation makes the KL-regularized reward optimum directly estimable, but the empirical result does not separate objective quality from preference-data quality and reference-policy coverage. The missing study holds prompts, labels, samples, and base model fixed across DPO, reward-model-plus-PPO, and supervised baselines. At 10× data and model scale, mislabeled preferences and off-policy coverage become dominant. DPO's claim would fail if explicit reward modeling delivered better calibrated preferences and downstream safety at equal total compute.
 
 **Takeaway:** DPO reduces preference optimization to a contrastive classification loss. By removing the reward model and RL loop, it matches or beats PPO while being much cheaper and easier to train.

--- a/src/content/posts/distilling-multimodal-large-language-models-for-autonomous-driving.md
+++ b/src/content/posts/distilling-multimodal-large-language-models-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: distilling-multimodal-large-language-models-for-autonomous-driving
 legacyPath: /paper shorts/2025/01/01/distilling-multimodal-large-language-models-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: DIMA used a large multimodal driving model as a teacher, distilling its behavior into a faster vision-based planner.
 ---
 ## 2025 - Distilling Multi-modal Large Language Models for Autonomous Driving
@@ -36,6 +36,12 @@ _Source figure from the [DiMA paper](https://arxiv.org/abs/2501.09757), via arXi
 | Teacher | Multimodal LLM planner | Provides richer traffic reasoning during training. |
 | Student | Vision-only planner | Keeps inference cheaper and faster. |
 | Reported signal | Lower trajectory error and collisions | Measures whether distilled reasoning survives compression. |
+
+## Decision Lens
+
+DIMA informs whether an expensive multimodal driving reasoner should run online or serve as a training-time teacher for a compact vision planner. The atomic supervision unit pairs a driving observation with teacher-produced reasoning or action targets; the student absorbs that signal but executes without the teacher.
+
+Distillation can preserve semantic structure at low latency, but gains may come from extra labels rather than teacher reasoning. The missing factorial ablation compares teacher actions, rationales, intermediate features, and equal-volume human annotations under one student architecture. At 10× teacher size, label-generation cost and systematic teacher errors dominate. The approach would fail if a student trained on simpler privileged labels matched closed-loop safety and progress without the multimodal teacher.
 
 **Context:** Distillation is a plausible path from impressive VLM demos to deployable autonomy components. The expensive model teaches; the small model acts.
 

--- a/src/content/posts/drivelm-driving-with-graph-visual-question-answering.md
+++ b/src/content/posts/drivelm-driving-with-graph-visual-question-answering.md
@@ -6,7 +6,7 @@ postSlug: drivelm-driving-with-graph-visual-question-answering
 legacyPath: /paper shorts/2023/12/21/drivelm-driving-with-graph-visual-question-answering.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: DriveLM formulates driving reasoning as graph visual question answering, linking perception, prediction, planning, behavior, and motion questions into a structured reasoning chain.
 ---
 ## 2023 - DriveLM
@@ -43,6 +43,12 @@ _Figure 1 shows DriveLM's task and artifacts: graph VQA, data construction, the 
 | Dataset | DriveLM-Data | Provides graph-structured QA supervision. |
 | Baseline | DriveLM-Agent | Shows how a VLM can use the graph to produce driving behavior. |
 | Evaluation | DriveLM-Metrics and generalization settings | Tests semantic accuracy, trajectory quality, and unseen conditions. |
+
+## Decision Lens
+
+DriveLM informs whether driving reasoning should be supervised as isolated QA pairs or as a graph connecting perception, prediction, planning, behavior, and motion. The atomic item is a node question-answer pair with directed dependencies that encode which earlier facts support a later decision.
+
+The graph makes reasoning supervision inspectable, but it can reward verbal consistency without improving control. The decisive study holds images and answer volume fixed while comparing graph-structured supervision, independent QA, and direct action labels on downstream closed-loop planning. At 10× graph depth, annotation cost and propagated label errors dominate. The formulation would fail if graph accuracy did not predict intervention rate or trajectory quality better than flat QA accuracy.
 
 **Context:** DriveLM gave VLM-for-driving work a structured reasoning target instead of only asking open-ended scene questions.
 

--- a/src/content/posts/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.md
+++ b/src/content/posts/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: drivemm-all-in-one-large-multimodal-model-for-autonomous-driving
 legacyPath: /paper shorts/2024/12/01/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: DriveMM trained one multimodal transformer across perception, prediction, and planning with a driving curriculum.
 ---
 ## 2024 - DriveMM
@@ -36,6 +36,12 @@ _Figure 1: RoboTron-Drive achieves SOTA in both general capabilities and general
 | Training | Driving curriculum | Stages task difficulty for a generalist model. |
 | Inputs | Multi-view driving imagery | Matches surround-camera AV settings. |
 | Evidence | Multiple public benchmarks | Tests whether one model can replace specialists. |
+
+## Decision Lens
+
+DriveMM informs whether perception, prediction, and planning should share one multimodal token-processing model and curriculum. Its atomic examples come from different driving tasks; task prompts and output formats route them through a shared backbone while stage-specific data teaches increasingly action-oriented behavior.
+
+The all-in-one model promises transfer, but mixture proportions and gradient conflict determine whether low-resource tasks benefit or disappear. The missing study measures per-task gradient alignment and transfer while matching total parameters against specialized models and a shared-backbone multi-head baseline. At 10× tasks, sequence formats, sampling weights, and negative transfer dominate. The unified claim would fail if specialists achieved better worst-task and closed-loop performance at equal aggregate inference cost.
 
 **Context:** DriveMM pushed against the assumption that every driving subproblem needs a separate specialized network. The paper asks whether shared multimodal representations can support the full stack.
 

--- a/src/content/posts/drivevla-w0-world-models-amplify-data-scaling-law-in-autonomous-driving.md
+++ b/src/content/posts/drivevla-w0-world-models-amplify-data-scaling-law-in-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: drivevla-w0-world-models-amplify-data-scaling-law-in-autonomous-drivin
 legacyPath: /paper shorts/2025/10/14/drivevla-w0-world-models-amplify-data-scaling-law-in-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: DriveVLA-W0 argues that driving VLAs need dense world-model supervision, using future image prediction to complement sparse low-dimensional action labels.
 ---
 ## 2025 - DriveVLA-W0
@@ -41,6 +41,12 @@ _Figure 2 shows the two world-modeling variants: autoregressive discrete visual-
 | World model | AR visual-token and diffusion latent variants | Tests two dense prediction routes. |
 | Action head | Lightweight action expert | Keeps inference practical after heavy representation learning. |
 | Evaluation | NAVSIM v1/v2 and large in-house data | Tests whether world modeling improves data scaling. |
+
+## Decision Lens
+
+DriveVLA-W0 informs whether additional driving data should supervise only sparse actions or also dense future visual dynamics. The training unit couples current observations and actions with future images; a shared representation learns both control and world prediction so each logged frame supplies more than a low-dimensional trajectory label.
+
+The reported scaling result suggests world-model supervision improves the return from more data in the tested NAVSIM and internal regimes. It does not isolate future-image prediction from extra decoder capacity or richer augmentation. A held-out scale sweep with equal parameters and target count is decisive. At 10× data, video redundancy and prediction of irrelevant appearance can consume the budget. The claim would fail if action-only training recovered the same scaling slope after matching auxiliary compute and regularization.
 
 **Context:** DriveVLA-W0 makes a strong case that driving VLAs should learn world dynamics, not just imitate sparse action labels.
 

--- a/src/content/posts/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.md
+++ b/src/content/posts/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.md
@@ -6,7 +6,7 @@ postSlug: drivevlm-convergence-of-autonomous-driving-and-large-vision-language-m
 legacyPath: /paper shorts/2024/02/01/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: DriveVLM combined VLM reasoning with hierarchical planning, then paired it with a traditional pipeline for real-time driving.
 ---
 ## 2024 - DriveVLM
@@ -36,6 +36,12 @@ _Figure 1: DriveVLM and DriveVLM-Dual model pipelines. From the [DriveVLM: The C
 | Architecture | VLM plus hierarchical planning | Uses language to decompose complex scenes. |
 | Hybrid variant | DriveVLM-Dual | Combines VLM semantics with conventional driving modules. |
 | Evidence | nuScenes, SUP-AD, vehicle deployment | Tests both public and production-style settings. |
+
+## Decision Lens
+
+DriveVLM informs which decisions benefit from explicit language reasoning and which must remain in a fast geometric pipeline. The model decomposes planning into scene description, object analysis, and hierarchical trajectory reasoning, then fuses that output with a conventional planner for real-time control.
+
+The hybrid design acknowledges that semantic breadth and control latency have different requirements, but it obscures whether the VLM adds causal driving information or merely an ensemble prior. The missing closed-loop ablation removes each reasoning stage and the traditional branch at matched latency. At 10× traffic density, token generation and stale object narratives dominate. The VLM branch would fail its purpose if the conventional planner alone matched safety and progress on the scenarios where language reasoning is supposed to help.
 
 **Context:** DriveVLM captures the field's tension clearly: VLMs are useful for understanding and explanation, but driving still needs precise geometry and real-time behavior.
 

--- a/src/content/posts/driving-with-llms-fusing-object-level-vector-modality.md
+++ b/src/content/posts/driving-with-llms-fusing-object-level-vector-modality.md
@@ -6,7 +6,7 @@ postSlug: driving-with-llms-fusing-object-level-vector-modality
 legacyPath: /paper shorts/2023/10/01/driving-with-llms-fusing-object-level-vector-modality.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: Driving with LLMs fed object-level vector scene state into language models to make driving decisions more explainable.
 ---
 ## 2023 - Driving with LLMs
@@ -38,6 +38,12 @@ _Source figure from the [Driving with LLMs paper](https://arxiv.org/abs/2310.019
 | Input | Object vectors | Structured state reduces visual ambiguity. |
 | Task | Driving QA and action generation | Tests scene interpretation and decisions. |
 | Tradeoff | Depends on upstream perception | Bad object state still misleads the LLM. |
+
+## Decision Lens
+
+Driving with LLMs informs whether an LLM should consume raw visual tokens or a compact object-level vector description of the scene. Its atomic input is an agent or map vector serialized into the language interface; the representation preserves metric relations while the language model supplies reasoning and explanation.
+
+Vectorization buys interpretability and shorter context but makes upstream detection the information bottleneck. The missing comparison matches token budget across object vectors, BEV features, image tokens, and oracle objects while measuring both explanation faithfulness and planning. At 10× agents, serialization order and context length dominate. The claim would fail if a non-language vector planner matched decisions and explanations derived from post-hoc state summaries at lower latency.
 
 **Context:** The paper made object-centric driving language models a serious baseline. It also clarified a recurring theme in autonomy: sometimes the right multimodal interface is not raw pixels, but structured state.
 

--- a/src/content/posts/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.md
+++ b/src/content/posts/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.md
@@ -6,7 +6,7 @@ postSlug: eagle-2-post-training-data-strategies-for-frontier-vision-language-mod
 legacyPath: /paper shorts/2025/01/01/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: Eagle 2 made the post-training data recipe the main contribution, showing how curation can move frontier VLM performance.
 ---
 ## 2025 - Eagle 2
@@ -38,6 +38,12 @@ _Figure 1: Overview of Eagle2-9B’s result across different multimodal benchmar
 | Main lever | Post-training data mixture | Turns a general VLM into a benchmark-strong assistant. |
 | Transparency | Recipe-focused release | Documents data strategy instead of only final weights. |
 | Scale signal | Eagle2-9B competitive with larger models | Suggests curation can buy efficiency. |
+
+## Decision Lens
+
+Eagle 2 informs a post-training allocation decision: whether another model-scale increase is worth more than improving the composition, filtering, and ordering of multimodal instruction data. The fundamental unit is the supervised image–instruction–response example, and the curriculum controls which capabilities are introduced and reinforced across stages. The shared model is conventional; the paper's real mechanism is distribution design across OCR, grounding, reasoning, and instruction following.
+
+The ablation trail shows that curation can make a 9B model competitive with larger systems, but benchmark gains do not by themselves establish that the recipe generalizes beyond the evaluation distribution. The missing test is a contamination-audited, held-out capability suite combined with a cost-matched comparison to simply adding parameters or raw examples. At ten times the data scale, quality filters may select increasingly homogeneous synthetic patterns and amplify benchmark style. The claim is falsified if the carefully staged mixture loses its advantage on fresh tasks after controlling for data provenance and total annotation cost.
 
 **Context:** Eagle 2 is valuable because it makes the data engineering visible. That helps turn VLM building from folklore into something closer to an inspectable recipe.
 

--- a/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
+++ b/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2020/04/01/efficientdet-scalable-and-efficient-object-detection.html
 tags:
   - Other
-field: Computer Vision
+field: 'Vision Foundations'
 summary: EfficientDet paired BiFPN feature fusion with compound scaling to make detector accuracy and latency easier to trade off.
 ---
 ## 2020 – EfficientDet: Scalable and Efficient Object Detection
@@ -46,5 +46,13 @@ Compared with its contemporaries, D0 matches YOLOv3 accuracy with 28× fewer FLO
 †Latency measured on Titan V GPU and single-thread Xeon CPU in the paper's ablation study.
 
 **Critiques & limitations:** EfficientDet's strength is its AP-per-FLOP story. BiFPN removes a lot of manual feature-fusion guesswork, and compound scaling gives practitioners a ready-made detector suite for different devices. The pipeline is still anchor-based and more complex than many modern anchor-free detectors. It also depends heavily on EfficientNet backbones, and transformer-based detectors now surpass its top-end accuracy at very large budgets.
+
+## Decision Lens
+
+EfficientDet informs how to allocate a detector's latency budget across backbone size, feature fusion, input resolution, and prediction heads. The operative units are multiscale feature-map locations and anchors, not isolated image patches.
+
+BiFPN compresses a pyramid of backbone features through repeated, learned weighted fusion, while compound scaling grows the full detector rather than one component. The reported model family establishes a favorable accuracy-efficiency frontier across several budgets; it does not prove that the same scaling coefficients remain optimal on different hardware or anchor-free heads.
+
+The key missing study is a latency-matched factorial ablation of BiFPN topology, fusion weights, resolution, backbone depth/width, and head capacity. At 10× resolution, activation memory and pyramid fusion dominate cost. Compound scaling would be falsified as the useful design rule if a single-axis or hardware-aware scaling policy consistently matched AP at lower measured latency and energy.
 
 **Takeaway:** EfficientDet showed that scaling every part of the detector matters as much as making it big. Thoughtful feature fusion and end-to-end scaling unlocked large gains in speed and accuracy and continue to influence modern detection pipelines.

--- a/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
+++ b/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2019/05/01/efficientnet-rethinking-model-scaling-for-convnets.html
 tags:
   - Other
-field: Computer Vision
+field: 'Vision Foundations'
 summary: EfficientNet made CNN scaling more systematic by growing depth, width, and resolution together under a compute budget.
 ---
 ## 2019 – EfficientNet — Rethinking Model Scaling for ConvNets
@@ -31,6 +31,12 @@ _Figure 2 from the [EfficientNet paper](https://arxiv.org/abs/1905.11946), via a
 **Summary:** EfficientNet argues that model scaling should be balanced, not improvised one axis at a time. Standard CNNs often grow by becoming deeper, wider, or by consuming higher-resolution images. Tan and Le show that scaling only one dimension leaves accuracy and efficiency on the table.
 
 Their recipe starts with a mobile-sized architecture found by neural architecture search, EfficientNet-B0. From there, a single compound factor $\phi$ scales depth $\alpha^\phi$, width $\beta^\phi$, and resolution $\gamma^\phi$ together. That rule turns one searched micro-architecture into the B1-B7 family while keeping the accuracy-to-compute tradeoff unusually strong.
+
+## Decision Lens
+
+EfficientNet informs how to spend additional CNN compute across depth, width, and input resolution instead of scaling one axis by habit. The training unit remains an image, but compound scaling changes the capacity and spatial detail available to every block under a common FLOP multiplier.
+
+The measured family shows that balanced scaling gives a better ImageNet accuracy-efficiency frontier around the searched B0 baseline; it does not prove universal coefficients across tasks or hardware. The missing experiment re-optimizes the coefficients for detection, segmentation, and memory-bound accelerators under measured latency rather than FLOPs. At 10× resolution, activation memory and data movement dominate. Compound scaling would fail as a general rule if hardware-aware single-axis or neural-architecture scaling consistently won at matched latency and energy.
 
 **Context:** EfficientNet made scaling feel like a design problem rather than a brute-force contest. B1 roughly matched ResNet-152 with 27x fewer FLOPs, while B7 topped ImageNet with a fraction of the parameters used by earlier NAS-heavy models.
 

--- a/src/content/posts/emma-end-to-end-multimodal-model-for-autonomous-driving.md
+++ b/src/content/posts/emma-end-to-end-multimodal-model-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: emma-end-to-end-multimodal-model-for-autonomous-driving
 legacyPath: /paper shorts/2024/10/01/emma-end-to-end-multimodal-model-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: EMMA represented driving inputs and outputs as language tokens so one multimodal model could handle planning, perception, and road structure tasks.
 ---
 ## 2024 - EMMA
@@ -38,6 +38,12 @@ _Figure 1: EMMA overview diagram. From the [EMMA: End-to-End Multimodal Model fo
 | Model role | Generalist driving model | One multimodal model handles several driving outputs. |
 | Output format | Text-encoded trajectories and objects | Lets prompts select task-specific outputs. |
 | Caveat | Limited temporal and 3D sensing | Promising architecture, not a complete AV stack. |
+
+## Decision Lens
+
+EMMA informs whether driving perception, road-structure understanding, and planning can be represented through one language-token interface. Its atomic unit is an autoregressive token conditioned on camera observations and a task prompt; shared parameters produce textual structures and future trajectories in a common format.
+
+The unified vocabulary simplifies task transfer but quantizes geometry and ties control latency to sequence generation. The missing ablation compares tokenized trajectories with a continuous head while keeping the visual-language backbone and multitask data fixed. At 10× horizon or agent count, output length and compounding decoding errors dominate. EMMA's interface would fail if a shared backbone with specialized continuous heads matched transfer and improved closed-loop accuracy and latency.
 
 **Context:** EMMA is a strong example of the generalist-model thesis entering autonomous driving: one model, many outputs, shared representations.
 

--- a/src/content/posts/fast-efficient-action-tokenization-for-vision-language-action-models.md
+++ b/src/content/posts/fast-efficient-action-tokenization-for-vision-language-action-models.md
@@ -6,7 +6,7 @@ postSlug: fast-efficient-action-tokenization-for-vision-language-action-models
 legacyPath: /paper shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html
 tags:
   - Other
-field: Robotics
+field: 'Vision-Language-Action & Robotics'
 summary: FAST compressed robot action trajectories into tokens so autoregressive VLA models could learn dexterous control more efficiently.
 ---
 ## 2025 - FAST
@@ -36,6 +36,12 @@ _Figure 1: We propose FAST, a simple yet effective approach for tokenization of 
 | Problem | High-frequency continuous actions | Naive tokenization makes sequences too long. |
 | Method | Time-series compression | Creates compact action tokens. |
 | Signal | Faster VLA training | Makes autoregressive robot policies more practical. |
+
+## Decision Lens
+
+FAST informs a representation decision that quietly controls the economics of autoregressive robot policies: how much of a continuous action trajectory deserves its own token. Instead of quantizing every timestep and control dimension independently, it transforms action chunks into frequency coefficients and discretizes the compressed representation. The model predicts a shorter sequence while retaining the smooth temporal structure that dexterous control needs.
+
+The paper shows that action-aware compression can improve training efficiency and behavior, but average task success does not reveal which high-frequency corrections are lost. A missing stress test should stratify tasks by control bandwidth and compare FAST with learned tokenizers at equal bitrate and decoding latency. At ten times the horizon, small reconstruction errors can accumulate and rare abrupt motions may be suppressed by the frequency prior. The claim is falsified if compact tokens help offline likelihood but fail to improve—or reduce—closed-loop robustness under perturbations.
 
 **Context:** Action representation is one of the hidden make-or-break details in robot foundation models. If actions are tokenized poorly, the model wastes capacity on formatting instead of behavior.
 

--- a/src/content/posts/fourier-features-let-networks-learn-high-frequency-functions-in-low-dimensional-domains.md
+++ b/src/content/posts/fourier-features-let-networks-learn-high-frequency-functions-in-low-dimensional-domains.md
@@ -6,7 +6,7 @@ postSlug: fourier-features-let-networks-learn-high-frequency-functions-in-low-di
 legacyPath: /paper shorts/2020/06/18/fourier-features-let-networks-learn-high-frequency-functions-in-low-dimensional-domains.html
 tags:
   - Other
-field: BEV
+field: 'Vision Foundations'
 summary: Fourier features turn low-dimensional coordinates into sinusoidal embeddings so MLPs can fit high-frequency geometry, images, and scene signals.
 ---
 ## 2020 - Fourier Features
@@ -49,6 +49,12 @@ _Figure 2 shows why the input mapping matters: Fourier features reshape the effe
 | ------------- | --------------------- | ------------ |
 | No mapping | 19.32 | 0.864 |
 | Gaussian Fourier features | 25.57 | 0.973 |
+
+## Decision Lens
+
+Fourier features inform whether an MLP should learn geometry directly from raw coordinates or receive a fixed sinusoidal basis that exposes high spatial frequencies. The atomic unit is a coordinate-value pair; a bandwidth-controlled projection maps the coordinate into periodic features before the shared MLP.
+
+The experiments show that the embedding changes the effective kernel and overcomes spectral bias on images and 3D signals. They do not prescribe one bandwidth for noisy, multiscale driving geometry. The missing test jointly sweeps bandwidth, learned encodings, and coordinate noise at matched parameters. At 10× spatial extent or resolution, aliasing and basis size become limiting. The claim would weaken if a learned positional encoding matched high-frequency reconstruction while adapting more robustly across scales.
 
 **Context:** Fourier features became one of the standard ways to make coordinate networks useful for detailed spatial signals.
 

--- a/src/content/posts/generative-adversarial-networks.md
+++ b/src/content/posts/generative-adversarial-networks.md
@@ -6,7 +6,7 @@ postSlug: generative-adversarial-networks
 legacyPath: /paper shorts/2014/06/01/generative-adversarial-networks.html
 tags:
   - Other
-field: Generative Models
+field: 'Generative Modeling'
 summary: GANs framed generation as a two-player game between a generator and discriminator, producing sharp samples without explicit likelihoods.
 ---
 ## 2014 – Generative Adversarial Networks
@@ -29,6 +29,12 @@ _Figure 1 from the [GAN paper](https://arxiv.org/abs/1406.2661), via arXiv HTML.
 **Summary:** GANs turn generative modelling into a contest. A generator $G$ maps random noise into synthetic samples, while a discriminator $D$ learns to tell real data from generated data. Training alternates between making $D$ better at the classification problem and making $G$ better at fooling $D$.
 
 The paper's central promise is elegant: with enough capacity and ideal optimization, the generator recovers the true data distribution and the discriminator becomes maximally uncertain, outputting 0.5 everywhere. That framing recasts density estimation as a differentiable game rather than an explicit likelihood problem. It also gives the generator direct feedback in pixel space, which helped avoid some of the blurry samples associated with early likelihood-based models.
+
+## Decision Lens
+
+GANs inform whether a generator should learn through an adversarial density-ratio signal instead of an explicit likelihood. Each update couples a minibatch of real examples with generated samples; the discriminator and generator optimize opposing objectives but share no parameters.
+
+The original experiments established that the game can produce sharp samples, not that it covers the data distribution or converges reliably. The missing decisive evidence is a seed-rich comparison of likelihood coverage, sample quality, and mode recovery against explicit-density models at matched compute. At 10× scale, discriminator overfitting, mode collapse, and oscillatory optimization intensify. The adversarial premise would fail if a non-adversarial model matched perceptual quality while covering rare modes and training more reliably.
 
 **Context:** The first experiments were small, mostly multilayer perceptrons on MNIST-like data, but the idea opened a much larger path. GANs made high-quality sample generation feel less like approximate density estimation and more like learned counterfeiting.
 

--- a/src/content/posts/genie-generative-interactive-environments.md
+++ b/src/content/posts/genie-generative-interactive-environments.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: genie-generative-interactive-environments
 legacyPath: /paper shorts/2024/02/23/genie-generative-interactive-environments.html
 tags: [World Models]
-field: Omni-Models
+field: 'Video & Interactive World Models'
 summary: '2024 – Genie: a latent-action generative environment learned from unlabeled Internet video.'
 ---
 
@@ -27,7 +27,12 @@ Genie is valuable because it makes latent actions a trainable interface rather t
 | Dynamics model | Predicts the next latent state. |
 | Latent-action model | Supplies an action-conditioned control interface without action labels. |
 
+## Decision Lens
+
+Genie informs whether controllable world models require action-labeled trajectories or can infer a useful control interface from ordinary video. Its pipeline separates a video tokenizer, a dynamics model over compressed observations, and a latent-action model that discovers transitions capable of conditioning future frames. The learned latent action—not a human command label—is the crucial training unit that turns passive footage into an interactive environment.
+
+The paper establishes that latent controls can reproduce and recombine behaviors in the studied visual domains, but visual controllability is weaker evidence than semantic or physical correctness. The missing test aligns discovered actions with known controls in an environment where both are available, then measures identifiability, long-horizon consistency, and intervention response. At ten times the rollout length or environment diversity, latent actions may drift, collapse, or encode camera artifacts. The central claim fails if the controls cannot predictably reproduce the same intervention across scenes.
+
 **Limits:** Interactive plausibility in generated environments is not evidence of metric accuracy, safety, or causal fidelity in a physical robot or vehicle setting.
 
 **Takeaway:** A world model needs action-conditioned consequences; realistic video alone is not enough.
-

--- a/src/content/posts/gpt-driver-learning-to-drive-with-gpt.md
+++ b/src/content/posts/gpt-driver-learning-to-drive-with-gpt.md
@@ -6,7 +6,7 @@ postSlug: gpt-driver-learning-to-drive-with-gpt
 legacyPath: /paper shorts/2023/10/01/gpt-driver-learning-to-drive-with-gpt.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: GPT-Driver reframed motion planning as language modeling over scene tokens and future waypoints.
 ---
 ## 2023 - GPT-Driver
@@ -38,6 +38,12 @@ _Figure 1: Overview of GPT-Driver. From the [GPT-Driver: Learning to Drive with 
 | Input | Structured scene tokens | Makes the driving problem legible to GPT-style models. |
 | Output | Future waypoints plus rationale | Adds interpretability to motion planning. |
 | Caveat | Open-loop and LLM latency | Needs closed-loop validation before real deployment. |
+
+## Decision Lens
+
+GPT-Driver informs whether motion planning can be reframed as conditional language modeling over structured scene tokens and waypoint outputs. The atomic prediction is a discretized coordinate or waypoint token, with textual scene context and chain-of-thought-style supervision preceding the trajectory.
+
+The formulation gains access to pretrained sequence modeling, but coordinate serialization, numerical precision, and rationale faithfulness become hidden design choices. The missing test matches data and backbone across tokenized waypoints, continuous regression, and a non-language autoregressive decoder. At 10× horizon, exposure error and token latency accumulate. The language-modeling claim would fail if the continuous decoder matched planning diversity and safety while using fewer steps and showing better metric precision.
 
 **Context:** It opened a line of work where language is not just for explanation after the fact. It becomes an intermediate representation for planning.
 

--- a/src/content/posts/how-much-do-language-models-memorize.md
+++ b/src/content/posts/how-much-do-language-models-memorize.md
@@ -6,7 +6,7 @@ postSlug: how-much-do-language-models-memorize
 legacyPath: /paper shorts/2025/05/30/how-much-do-language-models-memorize.html
 tags:
   - Other
-field: Natural Language Processing
+field: 'Language Models'
 summary: This paper separates memorization from generalization and estimates GPT-style language-model capacity at about 3.6 bits per parameter.
 ---
 ## 2025 - How Much Do Language Models Memorize?
@@ -56,6 +56,12 @@ _Figure 1 isolates capacity with uniform random data: because there is no reusab
 | Model size sweep | Capacity is roughly linear in parameter count | GPT-style transformers store a stable number of bits per parameter. |
 | Text data | Unintended memorization decreases after capacity fills | The model starts spending training signal on generalization. |
 | Membership inference | F1 approaches random guessing as datasets get very large | Average samples become hard to distinguish from held-out text. |
+
+## Decision Lens
+
+This paper informs how much parameter budget should be interpreted as storage rather than transferable computation. The unit of analysis is a training token whose recoverability is measured against held-out generalization, producing an estimated memorization capacity of roughly 3.6 bits per parameter for the studied GPT-style models.
+
+That estimate is conditional on the data distribution, model family, extraction method, and definition of memorization; it is not a hardware-independent constant. The crucial missing study varies duplication, deduplication, tokenizer, and architecture while holding tokens and optimization fixed. At 10× scale, rare-string extraction, privacy exposure, and benchmark leakage become more important than the average capacity estimate. The claim would fail if an independent extraction protocol produced a substantially different bits-per-parameter slope on held-out model families.
 
 **Context:** The paper gives a cleaner measurement vocabulary for a fuzzy debate. Instead of asking only whether a string can be extracted, it asks how many bits of sample-specific information the weights contain and how that budget scales.
 

--- a/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2021/06/01/improved-denoising-diffusion-probabilistic-models.html
 tags:
   - Other
-field: Generative Models
+field: 'Generative Modeling'
 summary: Improved DDPM tightened diffusion likelihoods and made sampling faster by learning reverse-process variance.
 ---
 ## 2021 – Improved Denoising Diffusion Probabilistic Models (ID DPM)
@@ -59,5 +59,11 @@ def iddpm_loss(model, x0, timesteps, betas, logvar_schedule):
 Switching to the cosine $\beta_t$ schedule from the appendix further sharpens FID at low step counts.
 
 **Critiques:** The upgrades are attractive because they are almost drop-in: learn variance, adjust the objective, improve the schedule. They became part of the practical diffusion toolbox used by later systems. Sampling still needs dozens of UNet passes, large models remain memory-heavy, and classifier guidance can introduce bias, which later classifier-free methods address more cleanly.
+
+## Decision Lens
+
+Improved DDPM informs where to spend diffusion complexity: on the noise-prediction loss, learned reverse variance, schedule, or additional sampling steps. Its atomic unit remains a noisy image-timestep pair, but the hybrid objective adds likelihood pressure while the learned variance permits aggressive step reduction.
+
+The results show better likelihood and useful samples with far fewer reverse steps in the tested image regimes; they do not isolate whether those gains persist with modern solvers and latent diffusion. A matched wall-clock factorial ablation of variance learning, cosine schedule, objective, and sampler is the missing decision table. At 10× scale, repeated high-resolution evaluations remain dominant. The recipe would be falsified if a fixed-variance model with a stronger solver matched NLL and FID at lower total compute.
 
 **Takeaway:** ID DPM turned diffusion from a slow curiosity into a practical generator, paving the way for fast samplers and classifier-free guidance.

--- a/src/content/posts/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.md
+++ b/src/content/posts/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.md
@@ -6,7 +6,7 @@ postSlug: internvl-2-5-expanding-performance-boundaries-of-open-source-multimoda
 legacyPath: /paper shorts/2024/12/01/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: InternVL 2.5 scaled open multimodal models with better data, training strategy, and test-time reasoning.
 ---
 ## 2024 - InternVL 2.5
@@ -38,6 +38,12 @@ _Figure 1: Performance of various MLLMs on the OpenCompass leaderboard. From the
 | Scale | 1B to 78B family | Studies where open VLM scaling pays off. |
 | Training | Data quality and balancing | Reduces failures that pure scale does not fix. |
 | Evaluation | MMMU and hallucination-style tests | Looks beyond simple captioning/VQA. |
+
+## Decision Lens
+
+InternVL 2.5 informs how to scale an open multimodal system when model size, visual resolution, data balance, and test-time reasoning all consume the same budget. Its training unit remains an interleaved visual-token and text-token sequence, but the effective curriculum spans image, document, video, multilingual, grounding, and hallucination-oriented data. The paper's broad family from 1B to 78B is most useful as evidence that these levers interact rather than as proof that parameter count alone drives progress.
+
+The reported frontier comparisons establish strong coverage, not a clean causal scaling law. A more revealing study would hold training compute and test-time token budget fixed while independently sweeping model size, data quality, and inference strategy. At ten times the scale, duplicated supervision, evaluation leakage, and test-time latency are likelier bottlenecks than raw capacity. The paper's scaling narrative would fail if smaller models trained on the same curated distribution and given the same inference budget closed the gap on hallucination-resistant, out-of-distribution tests.
 
 **Context:** InternVL 2.5 showed that open models could compete with leading closed systems on difficult multimodal benchmarks while exposing more of the training recipe.
 

--- a/src/content/posts/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.md
+++ b/src/content/posts/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation
 legacyPath: /paper shorts/2024/10/17/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.html
 tags: [Multimodal AI]
-field: Omni-Models
+field: 'Omni-Model Architectures'
 summary: '2024 – Janus: separate visual routes for understanding and generation around one transformer.'
 ---
 
@@ -26,7 +26,12 @@ Understanding needs semantic, task-relevant features; generation needs fine visu
 | What is specialized? | Visual encoders for understanding and generation. |
 | What decision does it inform? | Whether one visual tokenizer must serve every capability. |
 
+## Decision Lens
+
+Janus informs whether a unified multimodal model must also impose a unified visual representation. It keeps a shared transformer for cross-modal reasoning but gives understanding and generation distinct visual encoders, acknowledging that semantic invariance and pixel-level fidelity demand different compression. The architecture shares the expensive sequence model while specializing the interfaces where representational conflict is strongest.
+
+Its results support decoupling as a practical compromise, but the paper needs a tighter capacity-matched comparison against one stronger tokenizer and against fully separate models. Without that, gains could come from extra parameters rather than reduced interference. At ten times the modality or resolution scale, the number of specialized interfaces may proliferate and the shared transformer can still suffer gradient conflict. The thesis would be falsified if a single dual-purpose tokenizer matches both understanding and generation under equal compute, or if separate transformers outperform despite losing sharing.
+
 **Limits:** Separate routes add components and do not remove the need to measure interference in the shared transformer.
 
 **Takeaway:** Share reasoning capacity when it transfers; specialize visual representations when their information requirements differ.
-

--- a/src/content/posts/lanegcn-learning-lane-graph-representations-for-motion-forecasting.md
+++ b/src/content/posts/lanegcn-learning-lane-graph-representations-for-motion-forecasting.md
@@ -6,7 +6,7 @@ postSlug: lanegcn-learning-lane-graph-representations-for-motion-forecasting
 legacyPath: /paper shorts/2020/07/27/lanegcn-learning-lane-graph-representations-for-motion-forecasting.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: LaneGCN made lane topology and actor-map interaction explicit by building a graph from raw map lanes and fusing actor-to-lane, lane-to-lane, lane-to-actor, and actor-to-actor messages.
 ---
 ## 2020 - LaneGCN
@@ -41,6 +41,12 @@ _Figure 1 shows the full LaneGCN pipeline: a lane graph and actor trajectories a
 | Actor encoder | ActorNet over observed trajectories | Encodes dynamic motion separately from static map geometry. |
 | Fusion | A2L, L2L, L2A, A2A interactions | Makes actor-map relations first-class. |
 | Benchmark | Argoverse motion forecasting | Tests the value of explicit lane structure in a public driving setting. |
+
+## Decision Lens
+
+LaneGCN informs whether road topology should be rasterized into pixels or preserved as an explicit directed lane graph for forecasting. Its atomic units are actor histories and lane-segment nodes; typed lane-to-lane, actor-to-lane, lane-to-actor, and actor-to-actor messages control which interactions are represented.
+
+The graph supplies topology efficiently, but map quality and graph radius become hidden dependencies. The missing factorial ablation holds the trajectory decoder fixed while replacing the lane graph with raster and polyline encoders at equal latency. At 10× agents or map extent, interaction edges and neighborhood expansion dominate. LaneGCN's representation claim would fail if a simpler polyline attention model matched forecasting accuracy and map generalization with fewer graph-specific operations.
 
 **Context:** LaneGCN set up a clean actor-map relational template that later forecasting and planning models kept reusing in denser Transformer forms.
 

--- a/src/content/posts/language-models-are-few-shot-learners.md
+++ b/src/content/posts/language-models-are-few-shot-learners.md
@@ -6,7 +6,7 @@ postSlug: language-models-are-few-shot-learners
 legacyPath: /paper shorts/2020/05/01/language-models-are-few-shot-learners.html
 tags:
   - Other
-field: Natural Language Processing
+field: 'Language Models'
 summary: GPT-3 showed that scale can turn language models into few-shot learners, but also exposed the limits of prompting alone.
 ---
 ## 2020 – Language Models are Few-Shot Learners (GPT-3)
@@ -42,6 +42,12 @@ The paper's central claim is that no-fine-tune performance improves smoothly wit
 Inference speed at a 2048-token context is about 0.4 seconds on an A100-80&nbsp;GB GPU. Memory footprint is roughly 350&nbsp;GB, necessitating model-parallel serving.
 
 **Critiques & discussion:** The minimalist recipe is the point: scale a standard decoder stack and new behaviors appear. Few-shot prompting changed how people interact with language models and helped launch the API-first LLM ecosystem. The costs are just as central. Training required enormous compute, replication was limited to megascale labs, bias and toxicity remained visible, multi-step reasoning was brittle, and closed weights made full scientific scrutiny difficult.
+
+## Decision Lens
+
+GPT-3 informs whether additional pre-training scale can replace task-specific gradient updates with in-context examples. Its atomic unit is the next token in a mixed web, book, and code sequence; the same decoder parameters absorb both stored knowledge and the procedure implied by a prompt.
+
+The reported curves show broad few-shot improvement across the tested model sizes, not that prompting reliably substitutes for training on every task. The missing control is a matched-compute comparison between a larger frozen model, a smaller fine-tuned model, and retrieval-augmented inference. At 10× scale, data quality, memorization, inference cost, and evaluation contamination would dominate parameter count. The scaling thesis would fail if those alternatives delivered equal accuracy and calibration at lower total training-plus-serving cost.
 
 **Takeaway:** GPT-3 shifted the field from task-specific models toward general models steered by prompts. Its breadth came from scale, and its limitations showed what scale alone could not yet solve.
 

--- a/src/content/posts/learning-transferable-visual-models-from-natural-language-supervision.md
+++ b/src/content/posts/learning-transferable-visual-models-from-natural-language-supervision.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2021/02/28/learning-transferable-visual-models-from-natural-language-supervision.html
 tags:
   - Other
-field: Computer Vision
+field: 'Vision-Language Models'
 summary: CLIP used image-text contrastive training to make visual representations transfer through natural-language prompts.
 ---
 ## 2021 – Learning Transferable Visual Models From Natural Language Supervision (CLIP)
@@ -67,5 +67,11 @@ print("Predicted class:", pred)
 ```
 
 **Critiques:** CLIP is one of the cleanest bridges between vision and language: one embedding space, many tasks, no dataset-specific classifier head. The weaknesses follow from the same design. Training depends on heavy compute and a proprietary web-scale dataset, zero-shot accuracy can be sensitive to prompt wording, and fairness problems mirror the data scraped from the web.
+
+## Decision Lens
+
+CLIP informs the decision to buy visual transfer with image-text supervision rather than a closed-set label vocabulary. The training unit is an image-caption pair; separate visual and text encoders meet in a shared embedding space, and the contrastive batch defines the negative set.
+
+The central tradeoff is breadth versus control: web captions expand semantic coverage but import bias, noise, and prompt sensitivity. A decisive ablation would match data volume and compute across curated class labels, raw captions, and filtered captions while evaluating both zero-shot transfer and calibration. At 10× scale, duplicate pairs and low-information captions dilute the negative set. CLIP's recipe would lose its advantage if a smaller curated or generative objective matched transfer across unseen datasets at lower data and batch-communication cost.
 
 **Takeaway:** CLIP showed that natural-language supervision can give vision models rich, transferable semantics. It helped turn multimodal learning from a niche setup into a default way to build open-vocabulary systems.

--- a/src/content/posts/lmt-net-lane-model-transformer-network-for-automated-hd-mapping-from-sparse-vehicle-observations.md
+++ b/src/content/posts/lmt-net-lane-model-transformer-network-for-automated-hd-mapping-from-sparse-vehicle-observations.md
@@ -6,7 +6,7 @@ postSlug: lmt-net-lane-model-transformer-network-for-automated-hd-mapping-from-s
 legacyPath: /paper shorts/2024/09/19/lmt-net-lane-model-transformer-network-for-automated-hd-mapping-from-sparse-vehicle-observations.html
 tags:
   - Other
-field: BEV
+field: 'BEV Perception & Mapping'
 summary: LMT-Net predicts lane pairs and lane connectivity from sparse vehicle observations, turning aggregated lane-boundary traces into a lane graph.
 ---
 ## 2024 - LMT-Net
@@ -38,6 +38,12 @@ _Figure 1 shows the full LMT-Net path from sparse observed polylines to lane-pai
 | Input | Aggregated sparse lane-boundary observations | Reduces dependence on dense remapping passes. |
 | Output | Lane pairs plus connectivity | Produces a map-like graph rather than only local detections. |
 | Evaluation | Internal highway and non-highway ODD data | Promising, but harder to compare against public methods. |
+
+## Decision Lens
+
+LMT-Net informs how to turn sparse, aggregated vehicle traces into a topologically valid lane graph rather than a set of disconnected boundary points. The operative units are paired lane-boundary observations and lane queries; the Transformer predicts both lane geometry and connectivity.
+
+The approach is attractive when fleet traces are cheaper than dense mapping surveys, but sparsity, localization error, and observation bias are coupled. The missing control varies trace density and pose noise while comparing pair-based prediction with sequential vectorization under equal map priors. At 10× geographic coverage, inconsistent local frames and topology stitching dominate. The claim would fail if a geometry-first baseline recovered equal lane connectivity with less dependence on repeated observations.
 
 **Context:** LMT-Net is a reminder that online HD mapping is not only a camera-to-vector problem; fleet traces and sparse observations can also drive map upkeep.
 

--- a/src/content/posts/locca-visual-pretraining-with-location-aware-captioners.md
+++ b/src/content/posts/locca-visual-pretraining-with-location-aware-captioners.md
@@ -6,7 +6,7 @@ postSlug: locca-visual-pretraining-with-location-aware-captioners
 legacyPath: /paper shorts/2024/03/28/locca-visual-pretraining-with-location-aware-captioners.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: LocCa adds location-aware captioning tasks to visual pretraining, improving region grounding while preserving broad VLM transfer.
 ---
 ## 2024 - LocCa
@@ -48,6 +48,12 @@ _Figure 1 shows the LocCa task interface: normal captioning, automatic referring
 | Better frozen encoder | LocCa's vision encoder substantially outperforms CapPa and SigLIP-style baselines on localization transfer. |
 | Clean evaluation | The authors remove overlapping validation/test images from the combined RefCOCO training set. |
 | VLM transfer | A PaLI-3 model using the LocCa encoder improves over strong SigLIP encoder baselines, especially on object-sensitive tasks. |
+
+## Decision Lens
+
+LocCa informs whether localization should be added as a separate detector-style subsystem or learned inside caption pretraining. Caption, automatic referring expression, and grounded-caption examples all use the same encoder–decoder and generative loss; coordinates become part of the output vocabulary, so the training interface forces the visual representation to bind language to regions without a specialized detection head.
+
+The transfer results show that location-aware proxy tasks can improve grounding without sacrificing broad visual tasks, and the authors' RefCOCO de-duplication makes that evidence more credible. The important missing ablation is an annotation- and compute-matched comparison against ordinary captioning plus later grounding supervision. At ten times the mixture size, coordinate-heavy examples could crowd out global semantics or teach dataset-specific box conventions. The central claim would be falsified if the gains disappear on leakage-free, differently formatted localization datasets while an equally funded late-grounding baseline transfers cleanly.
 
 **Context:** LocCa is a neat counterexample to the idea that grounding needs a separate detection-heavy architecture. A captioner can become location-aware if the pretraining interface makes coordinates part of the language game.
 

--- a/src/content/posts/maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-construction.md
+++ b/src/content/posts/maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-construction.md
@@ -6,7 +6,7 @@ postSlug: maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-co
 legacyPath: /paper shorts/2022/08/30/maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-construction.html
 tags:
   - Other
-field: BEV
+field: 'BEV Perception & Mapping'
 summary: MapTR models HD map elements as permutation-equivalent point sets, making online vectorized map construction trainable with a structured Transformer.
 ---
 ## 2022 - MapTR
@@ -49,6 +49,12 @@ _Figure 4 shows the structured MapTR pipeline: sensor inputs become BEV features
 | VectorMapNet | Camera | R50 | 40.9 | 2.9 |
 | MapTR-nano | Camera | R18 | 45.9 | 25.1 |
 | MapTR-tiny | Camera | R50 | 50.3 | 11.2 |
+
+## Decision Lens
+
+MapTR informs whether online map elements should be decoded as ordered polylines with one canonical point sequence or as permutation-equivalent point sets. The atomic unit is a map-element query whose point queries represent geometry; hierarchical bipartite matching handles element identity and equivalent point orderings.
+
+The structured set view reduces arbitrary ordering penalties, but matching cost and fixed point count shape the result. A decisive ablation compares canonical ordering, permutation-equivalent matching, and curve-parameter decoders with the same image backbone and query budget. At 10× map extent, query count and Hungarian matching become bottlenecks. MapTR's formulation would fail if a simpler ordered decoder matched topology and geometry at lower latency and with fewer assignment ambiguities.
 
 **Context:** MapTR gave the field a practical transformer baseline for vector maps and made permutation ambiguity a first-class modeling issue.
 

--- a/src/content/posts/maptrv2-an-end-to-end-framework-for-online-vectorized-hd-map-construction.md
+++ b/src/content/posts/maptrv2-an-end-to-end-framework-for-online-vectorized-hd-map-construction.md
@@ -6,7 +6,7 @@ postSlug: maptrv2-an-end-to-end-framework-for-online-vectorized-hd-map-construct
 legacyPath: /paper shorts/2023/08/10/maptrv2-an-end-to-end-framework-for-online-vectorized-hd-map-construction.html
 tags:
   - Other
-field: BEV
+field: 'BEV Perception & Mapping'
 summary: MapTRv2 strengthens MapTR with auxiliary one-to-many matching and dense supervision, improving convergence and accuracy on nuScenes and Argoverse2.
 ---
 ## 2023 - MapTRv2
@@ -40,6 +40,12 @@ _Figure 4 shows how MapTRv2 keeps the vector-map decoder structured while adding
 | Datasets | nuScenes and Argoverse2 | Tests whether the MapTR idea transfers across map benchmarks. |
 | Training recipe | One-to-many matching plus dense supervision | Improves convergence and final accuracy. |
 | Output | Real-time vector HD map construction | Keeps the planner-friendly vector representation. |
+
+## Decision Lens
+
+MapTRv2 informs whether sparse one-to-one supervision is sufficient for vector-map queries or should be supplemented with one-to-many assignments and dense auxiliary targets. The training unit remains a map-element query and its point sequence, but extra matches expose more positive supervision during early optimization.
+
+The gains support supervision density as an optimization lever, not a change in the final map representation. The missing ablation matches the number of positive gradients across one-to-many matching, denoising queries, and dense segmentation auxiliaries. At 10× classes or map elements, duplicate assignments and auxiliary-loss balance become unstable. The claim would fail if longer training or a simpler query-denoising scheme matched convergence and map quality without the extra matching path.
 
 **Context:** MapTRv2 turned MapTR from a strong baseline into a more robust framework that later online-map papers could compare against.
 

--- a/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
+++ b/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
@@ -6,7 +6,7 @@ postSlug: mastering-atari-go-chess-shogi-muzero
 legacyPath: /paper shorts/2019/11/01/mastering-atari-go-chess-shogi-muzero.html
 tags:
   - Other
-field: Reinforcement Learning
+field: 'Reinforcement Learning'
 summary: MuZero learned just enough model dynamics to plan with MCTS, without reconstructing full environment observations.
 ---
 ## 2019 – Mastering Atari, Go, Chess & Shogi by Planning with a Learned Model (MuZero)
@@ -39,5 +39,11 @@ The important design choice is what MuZero chooses not to model. It predicts onl
 | Chess / Shogi | Matches AlphaZero with fewer training games | Tests whether the same model-based planning recipe transfers across rule systems. |
 
 **Critiques & limitations:** MuZero is elegant because it preserves the strength of search without requiring explicit rules. The cost is large. Training used enormous compute, inference requires MCTS, and the learned dynamics remain hard to interpret: the model plans well, but it is not obvious what environment structure it has actually learned.
+
+## Decision Lens
+
+MuZero informs how much of an environment model must be learned for planning. Its atomic unit is a trajectory segment: representation, dynamics, and prediction networks are trained from observations, actions, rewards, value targets, and MCTS-derived policies, while the latent state is shared between model learning and search.
+
+The evidence shows that predicting decision-relevant rewards and values can outperform reconstructing pixels, but search compute and target generation are part of the result. The missing control compares MuZero with a reconstruction-based world model and a model-free agent under equal environment, training, and planning FLOPs. At 10× horizon, compounding latent error and search branching dominate. The central claim would fail if reconstruction or model-free learning matched return and sample efficiency at lower total compute.
 
 **Takeaway:** MuZero showed that learned latent models can support serious planning across very different domains. It replaced hand-coded rules with learned prediction, but it paid for that generality with compute and search latency.

--- a/src/content/posts/mgmap-mask-guided-learning-for-online-vectorized-hd-map-construction.md
+++ b/src/content/posts/mgmap-mask-guided-learning-for-online-vectorized-hd-map-construction.md
@@ -6,7 +6,7 @@ postSlug: mgmap-mask-guided-learning-for-online-vectorized-hd-map-construction
 legacyPath: /paper shorts/2024/04/01/mgmap-mask-guided-learning-for-online-vectorized-hd-map-construction.html
 tags:
   - Other
-field: BEV
+field: 'BEV Perception & Mapping'
 summary: MGMap adds learned masks to online vector-map construction so instance queries and point refinement focus on the relevant BEV regions.
 ---
 ## 2024 - MGMap
@@ -48,6 +48,12 @@ _The MGMap overview shows where the mask guidance enters the vector-map pipeline
 | Camera | R50 | 61.4 | 11.6 |
 | LiDAR | SECOND | 67.9 | 5.5 |
 | Camera + LiDAR | R50 + SECOND | 71.7 | 4.8 |
+
+## Decision Lens
+
+MGMap informs whether vector-map queries need an explicit spatial mask to focus feature sampling and point refinement. Its atomic unit is a map-instance query coupled to a learned BEV relevance mask; the mask constrains where the decoder looks before producing vector points.
+
+The mask supplies dense localization guidance to an otherwise sparse vector objective, but it may encode the same answer through an auxiliary raster task. The missing control equalizes auxiliary supervision and compares learned masks with deformable attention or uncertainty-guided sampling. At 10× scene extent, mask resolution and foreground imbalance dominate. MGMap's claim would fail if sparse attention learned equivalent regions and map quality without mask labels or raster overhead.
 
 **Context:** MGMap pushed vector-map models toward richer query support instead of treating each polyline point as a thin detection target.
 

--- a/src/content/posts/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.md
+++ b/src/content/posts/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training
 legacyPath: /paper shorts/2024/03/14/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.html
 tags: [Multimodal AI]
-field: Omni-Models
+field: 'Omni-Model Architectures'
 summary: '2024 – MM1: a controlled study of multimodal pre-training choices.'
 ---
 
@@ -26,7 +26,12 @@ The central result is a prioritization rule: image encoder quality, image resolu
 | Data mixture | Mixed image-caption, interleaved, and text-only data is important | Capability is shaped by the training distribution. |
 | Connector | Smaller effect in the reported ablations | Avoid spending the whole budget on connector variants. |
 
+## Decision Lens
+
+MM1 informs experiment allocation during multimodal pretraining. Its controlled studies indicate that image-encoder quality, resolution, visual-token count, and the mix of caption, interleaved image–text, and text-only data matter more than elaborate connector design. The fundamental unit is the mixed training sequence, but its value depends heavily on how much visual evidence survives encoding and which sequence types shape the shared language model.
+
+The paper establishes a prioritization order within its tested regime, not a timeless ranking of components. The missing evidence is whether connector importance reappears when encoders, token budgets, or downstream tasks change, especially under equal end-to-end compute. At ten times the scale, data provenance and mixture interference may swamp gains from resolution. MM1's practical conclusion would be falsified if a connector sweep on stronger frozen encoders produces larger, more transferable gains than equivalent investment in data or visual tokens.
+
 **Limits:** The conclusions come from MM1's model family and data pipeline; they are a strong experimental prior, not a universal ranking for every architecture.
 
 **Takeaway:** In multimodal pre-training, spend early runs on the visual representation and mixture before polishing the connector.
-

--- a/src/content/posts/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.md
+++ b/src/content/posts/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.md
@@ -6,7 +6,7 @@ postSlug: molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision
 legacyPath: /paper shorts/2024/09/01/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: Molmo argued that high-quality open multimodal data can matter more than sheer data volume.
 ---
 ## 2024 - Molmo and PixMo
@@ -38,6 +38,12 @@ _Figure 1: Datasets in PixMo (left) and the capabilities they enable in Molmo (r
 | Data | PixMo collection | Rich captions and pointing supervision improve grounding. |
 | Openness | Open weights and data | Makes the training story inspectable. |
 | Signal | Small models compete strongly | Suggests annotation quality can substitute for some scale. |
+
+## Decision Lens
+
+Molmo and PixMo inform whether an open VLM program should buy more weakly labeled scale or fewer, richer human annotations. PixMo's dense descriptions and pointing data make the image–text example more informative by supervising both what is present and where it is; Molmo then turns that data into generated language and point-based outputs through a shared multimodal model. The openness of weights and data makes the causal story unusually auditable.
+
+The strong results from relatively small models support data quality as a substitute for some parameter scale, but the paper does not fully normalize for the cost of collecting and validating that quality. A useful missing curve would plot downstream capability against total human and compute dollars for PixMo, web-scale weak data, and synthetic captions. At ten times the collection scale, annotator consistency and coverage of rare visual concepts may become the limiting factors. The claim weakens if a cost-matched weak-data baseline matches grounding and description quality on fresh images rather than familiar benchmark styles.
 
 **Context:** The paper strengthened the case that VLM progress is not just architecture scale. Annotation style, spatial grounding, and openness can move the frontier too.
 

--- a/src/content/posts/motionlm-multi-agent-motion-forecasting-as-language-modeling.md
+++ b/src/content/posts/motionlm-multi-agent-motion-forecasting-as-language-modeling.md
@@ -6,7 +6,7 @@ postSlug: motionlm-multi-agent-motion-forecasting-as-language-modeling
 legacyPath: /paper shorts/2023/09/28/motionlm-multi-agent-motion-forecasting-as-language-modeling.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: MotionLM discretizes continuous trajectories into motion tokens and forecasts interacting road agents with an autoregressive language-model objective.
 ---
 ## 2023 - MotionLM
@@ -46,6 +46,12 @@ _Figure 2 shows the language-model analogy concretely: scene features condition 
 | MTR | 0.9181 | 0.4411 | 0.2037 |
 | JFP | 0.8817 | 0.4233 | 0.2050 |
 | MotionLM | 0.8911 | 0.4115 | 0.2178 |
+
+## Decision Lens
+
+MotionLM informs whether continuous multi-agent futures should be generated jointly as discrete motion tokens. The atomic unit is a quantized displacement token for a particular agent and timestep; autoregressive ordering lets each predicted move condition on the emerging joint future.
+
+Tokenization makes interaction modeling compatible with language-model training, but quantization error, sequence ordering, and exposure bias become part of the planner. The missing study holds backbone and sampling budget fixed across tokenized autoregression and continuous joint decoders. At 10× agents or horizon, sequence length and sampling latency grow linearly while joint combinations grow much faster. The claim would fail if a continuous decoder matched joint metrics and controllable diversity with lower latency and no quantization artifacts.
 
 **Context:** MotionLM made the language-model analogy concrete for autonomous-driving behavior prediction.
 

--- a/src/content/posts/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.md
+++ b/src/content/posts/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2026/03/23/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.html
 tags:
   - Other
-field: Alignment
+field: 'Alignment & Post-Training'
 summary: mSFT adapts multitask fine-tuning mixtures by tracking which datasets overfit at different rates.
 ---
 ## 2026 – mSFT: Addressing Dataset Mixtures Overfitting Heterogeneously in Multi-task SFT
@@ -39,6 +39,12 @@ The proposed algorithm makes the mixture overfitting-aware. It trains on the act
 - Figure 2 is the premise: benchmark sub-datasets peak at materially different epochs, so one global stopping point creates both overfitting and under-training.
 - Figure 3 is the reason the naive single-rollout fix is unstable: once one dataset is removed, the remaining tasks' optimal stopping points move.
 - Figure 6 is the practical claim: under a low compute budget, dataset exclusion can improve accuracy while reducing net FLOPs.
+
+## Decision Lens
+
+mSFT informs whether multitask fine-tuning should keep a static dataset mixture when tasks overfit at different rates. Its atomic unit is a supervised example tagged by dataset; validation behavior feeds back into the probability of sampling that dataset, turning the mixture into a training-control variable.
+
+The method's value depends on whether per-dataset validation loss is a reliable early signal for downstream utility. The missing comparison holds total examples and optimizer steps fixed against static, temperature-based, and loss-proportional mixtures, including tasks whose validation loss is poorly correlated with quality. At 10× tasks, noisy validation signals and scheduler instability can cause oscillating or starved datasets. The claim would fail if a static mixture matched average and worst-task performance under the same compute.
 
 **Context:** Data mixture tuning is usually treated as a static weighting problem. mSFT reframes it as a training-dynamics problem: the right mixture can change over time because tasks saturate at different rates. That is especially relevant for post-training, where datasets often differ in size, difficulty, quality, and target behavior.
 

--- a/src/content/posts/opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-language-action-model.md
+++ b/src/content/posts/opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-language-action-model.md
@@ -6,7 +6,7 @@ postSlug: opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-l
 legacyPath: /paper shorts/2025/03/30/opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-language-action-model.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: OpenDriveVLA adapts open VLMs for end-to-end driving by aligning 2D and 3D structured visual tokens with language and autoregressively modeling agent-environment-ego interactions.
 ---
 ## 2025 - OpenDriveVLA
@@ -43,6 +43,12 @@ _Figure 2 shows OpenDriveVLA's staged training pipeline, from hierarchical featu
 | Training | Hierarchical alignment plus instruction and planning tuning | Bridges perception, language, and action. |
 | Interaction | Agent-environment-ego autoregressive modeling | Makes other actors and ego state part of the action context. |
 | Evaluation | nuScenes planning and driving QA | Tests both action quality and language-grounded understanding. |
+
+## Decision Lens
+
+OpenDriveVLA informs how an open VLM should be adapted to produce structured driving actions rather than only commentary. The training curriculum moves from vision-centric alignment to driving instruction tuning, agent-environment interaction modeling, and trajectory planning; 2D and 3D visual tokens share the language backbone before action decoding.
+
+The staged recipe makes curriculum order and token balance central, but it is unclear which stage creates planning gains. A matched-token factorial ablation should remove, reorder, or replace each stage and compare 2D-only, 3D-only, and fused tokens. At 10× visual context, token budget and modality interference dominate. The VLA design would fail if a frozen VLM plus a compact geometric planner matched closed-loop performance with lower training and inference cost.
 
 **Context:** OpenDriveVLA made the spatial-token design problem explicit for autonomous-driving VLA systems.
 

--- a/src/content/posts/openvla-open-source-vision-language-action-model.md
+++ b/src/content/posts/openvla-open-source-vision-language-action-model.md
@@ -6,7 +6,7 @@ postSlug: openvla-open-source-vision-language-action-model
 legacyPath: /paper shorts/2024/06/01/openvla-open-source-vision-language-action-model.html
 tags:
   - Other
-field: Robotics
+field: 'Vision-Language-Action & Robotics'
 summary: OpenVLA released a 7B open robot policy trained on 970k real robot demonstrations.
 ---
 ## 2024 - OpenVLA
@@ -38,6 +38,12 @@ _Figure 1: OpenVLA model architecture. From the [OpenVLA: An Open-Source Vision-
 | Scale | 7B VLA | Large enough to reuse language-model priors. |
 | Data | 970k robot demonstrations | Gives the model cross-embodiment behavior. |
 | Artifact | Open code/checkpoints | Makes generalist robot policies inspectable. |
+
+## Decision Lens
+
+OpenVLA informs whether an inspectable 7B vision-language backbone trained across many robot datasets is a useful default policy before building a proprietary architecture. The policy fuses SigLIP's semantic features with DINOv2's spatial features, then autoregressively emits discretized actions from language-conditioned observations. Open X-Embodiment's 970,000 demonstrations supply the cross-robot curriculum, making data interoperability as central as model scale.
+
+The release establishes a strong open baseline and shows broad transfer, but it does not separate the contribution of internet-scale VLM priors from robot-data scale and dual visual encoders. A compute-matched policy trained from scratch and a single-encoder ablation across unseen embodiments would answer that. At ten times the embodiments, inconsistent action spaces and dataset imbalance could overwhelm shared tokens. The foundation-policy thesis would fail if per-robot specialists initialized from the same encoders adapt faster and achieve higher closed-loop reliability with equal demonstrations.
 
 **Context:** OpenVLA made the VLA recipe concrete and public. It also showed that Internet-scale vision-language pretraining can combine with robot demonstration data to produce transferable manipulation policies.
 

--- a/src/content/posts/paligemma-a-versatile-3b-vlm-for-transfer.md
+++ b/src/content/posts/paligemma-a-versatile-3b-vlm-for-transfer.md
@@ -6,7 +6,7 @@ postSlug: paligemma-a-versatile-3b-vlm-for-transfer
 legacyPath: /paper shorts/2024/07/10/paligemma-a-versatile-3b-vlm-for-transfer.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: PaliGemma combines SigLIP and Gemma into a compact open VLM meant for fine-tuning across many vision-language tasks.
 ---
 ## 2024 - PaliGemma
@@ -49,6 +49,12 @@ _Figure 1 shows PaliGemma's core architecture: a SigLIP image encoder feeds a Ge
 | Low-data usability | Most tasks reach within 10% of full-data performance with 4k examples and within 20% with 256 examples. |
 | MMVP | PaliGemma-224 reaches 47.3% paired accuracy, compared with 38.7% for GPT-4V and 40.7% for Gemini in the paper's comparison. |
 | Practical training | A final Stage1 run takes just under 3 days on TPUv5e-256; Stage2 resolution increases take about 15 hours each. |
+
+## Decision Lens
+
+PaliGemma informs whether teams need a large chat-oriented VLM or a compact base model designed for task transfer. SigLIP patch features are linearly projected into Gemma's token space, and captions, answers, boxes, and masks are all emitted autoregressively under task prefixes. Resolution upcycling from 224 to 448 and 896 pixels is the paper's practical compression tradeoff: spend more visual tokens only for tasks whose fine detail warrants them.
+
+The nearly forty-task transfer suite establishes versatility, not that one checkpoint or resolution is universally optimal. The missing decision table is a compute-matched comparison of resolution, visual-token count, and task-specific fine-tuning data across OCR, localization, and semantic tasks. At ten times the image resolution or task count, autoregressive coordinate strings and context length become fragile bottlenecks. The transferable-base thesis would be falsified if specialized models with the same adaptation budget consistently dominate while a single instruction-tuned checkpoint transfers just as well.
 
 **Context:** PaliGemma made the "small open VLM as a transferable base model" story concrete. It is useful because it is inspectable, fine-tunable, and broad enough to cover more than chat.
 

--- a/src/content/posts/perceiver-io-a-general-architecture-for-structured-inputs-and-outputs.md
+++ b/src/content/posts/perceiver-io-a-general-architecture-for-structured-inputs-and-outputs.md
@@ -6,7 +6,7 @@ postSlug: perceiver-io-a-general-architecture-for-structured-inputs-and-outputs
 legacyPath: /paper shorts/2021/07/30/perceiver-io-a-general-architecture-for-structured-inputs-and-outputs.html
 tags:
   - Other
-field: BEV
+field: 'Omni-Model Architectures'
 summary: Perceiver IO uses latent bottleneck cross-attention plus output queries to process arbitrary inputs and produce structured outputs without task-specific heads.
 ---
 ## 2021 - Perceiver IO
@@ -48,6 +48,12 @@ _Figure 2 shows the Perceiver IO template: arbitrary inputs enter a latent works
 | GLUE average | BERT Base at 81.1 | 81.2 with Perceiver IO Base | Comparable language performance with the general architecture. |
 | Sintel clean optical flow | RAFT at 1.95 EPE | 1.81 EPE | Strong dense prediction without hand-built multiscale matching. |
 | Sintel final optical flow | RAFT at 2.57 EPE | 2.42 EPE | General output queries still handle dense visual output. |
+
+## Decision Lens
+
+Perceiver IO informs whether compute should scale with raw input size or with a fixed latent bottleneck and a chosen set of output queries. The atomic operations are input-to-latent cross-attention, latent self-attention, and output-query cross-attention; task structure enters through the queries rather than a bespoke head.
+
+The architecture demonstrates broad modality and output flexibility, but the fixed latent array can discard fine detail before the task reveals what matters. The missing ablation sweeps latent count and output-query density against full attention at matched FLOPs across tasks with different information bottlenecks. At 10× input size, cross-attention remains manageable, but latent capacity becomes the failure point. The claim would fail if task-specific sparse attention preserved accuracy with equal efficiency and less latent tuning.
 
 **Context:** Perceiver IO gave researchers a reusable pattern for multimodal models whose inputs and outputs do not fit one simple grid or sequence.
 

--- a/src/content/posts/pi0-vision-language-action-flow-model-for-general-robot-control.md
+++ b/src/content/posts/pi0-vision-language-action-flow-model-for-general-robot-control.md
@@ -6,7 +6,7 @@ postSlug: pi0-vision-language-action-flow-model-for-general-robot-control
 legacyPath: /paper shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html
 tags:
   - Other
-field: Robotics
+field: 'Vision-Language-Action & Robotics'
 summary: Pi0 used a VLM backbone and flow matching to turn visual-language context into continuous robot actions.
 ---
 ## 2024 - Pi0
@@ -38,6 +38,12 @@ _Figure 2 from the [pi0 paper](https://arxiv.org/abs/2410.24164), via arXiv HTML
 | Input | Images plus language goals | Uses VLM semantics for robot context. |
 | Output | Continuous actions | Requires smooth control, not text. |
 | Mechanism | Flow matching | Models action trajectories for dexterous behavior. |
+
+## Decision Lens
+
+Pi0 informs whether semantic reasoning and precise continuous control should share a backbone but use different output mathematics. Images and language are processed by a pretrained VLM, while flow matching generates continuous action chunks rather than forcing motor commands into text-like tokens. Training across single-arm, dual-arm, and mobile manipulation makes the trajectory—not the individual scalar command—the meaningful control unit.
+
+The dexterous and language-conditioned results support this hybrid interface, but they do not isolate flow matching from the size, diversity, and quality of the private robot corpus. The missing ablation is a matched-data comparison against diffusion, regression, and autoregressive token heads under identical control frequency and latency. At ten times the horizon or embodiment variety, action distributions may become too multimodal for one shared head and sampling error may compound. The approach is falsified if simpler heads match closed-loop recovery and cross-embodiment adaptation at the same inference budget.
 
 **Context:** Pi0 is part of the shift from models that understand scenes to models that act in them. It treats robot control as a foundation-model problem rather than a collection of isolated policies.
 

--- a/src/content/posts/playing-atari-with-dqn.md
+++ b/src/content/posts/playing-atari-with-dqn.md
@@ -6,7 +6,7 @@ postSlug: playing-atari-with-dqn
 legacyPath: /paper shorts/2013/12/01/playing-atari-with-dqn.html
 tags:
   - Other
-field: Reinforcement Learning
+field: 'Reinforcement Learning'
 summary: DQN combined Q-learning, replay, and target networks to make pixel-based Atari control work with deep networks.
 ---
 ## 2013 – Playing Atari with Deep Reinforcement Learning
@@ -32,6 +32,12 @@ _Figure 1 provides sample screenshots from five of the games used for training. 
 2. **Target network:** hold a slowly updated copy of the Q-network to compute stable learning targets.
 
 With those pieces in place, the authors trained one CNN architecture across seven Atari games using the same weights and hyperparameters. That result mattered because it moved deep RL away from game-specific feature engineering and toward end-to-end pixel-to-action learning. Replay memory and target networks also became durable building blocks for value-based deep RL, while the paper's limitations helped motivate later variants such as Double DQN, prioritized replay, and distributional RL.
+
+## Decision Lens
+
+DQN informs whether a single convolutional Q-network can replace game-specific features and controllers while learning directly from pixels. The learning unit is a replayed transition $(s,a,r,s')$; replay breaks short-term correlation and a lagged target network stabilizes the bootstrapped label.
+
+The Atari results establish sample reuse and target lag as a workable combination, not a generally stable recipe for every observation or reward distribution. The missing ablation is a seed-rich factorial study of replay, target updates, reward clipping, frame stacking, and optimizer under equal environment steps. At 10× task diversity, replay imbalance and interference would dominate. The claim would fail if an on-policy or model-based baseline matched median human-normalized score with the same frames and less tuning.
 
 **Context:** DQN showed that a relatively simple network, three convolutional layers followed by two fully connected layers, could handle high-dimensional visual state in a reinforcement learning loop. The important contribution was not just the score table. It was the recipe: pair Q-learning with enough neural capacity, then add just enough machinery to make the targets less volatile.
 

--- a/src/content/posts/proximal-policy-optimization-ppo.mdx
+++ b/src/content/posts/proximal-policy-optimization-ppo.mdx
@@ -6,7 +6,7 @@ postSlug: proximal-policy-optimization-ppo
 legacyPath: /paper shorts/2017/07/01/proximal-policy-optimization-ppo.html
 tags:
   - Other
-field: Reinforcement Learning
+field: 'Reinforcement Learning'
 summary: PPO kept policy updates stable with a clipped objective that is much simpler to implement than TRPO.
 ---
 import PythonPlayground from '../../components/PythonPlayground';
@@ -67,3 +67,9 @@ Run several epochs of Adam on batches of rollout data, add a small value-functio
 The important part to internalize is not the `torch` syntax; it is the update size PPO refuses to trust. This tiny terminal lets you vary the log-probabilities, advantage, and clipping threshold while the walkthrough shows exactly when the unclipped objective gets cut back.
 
 <PythonPlayground client:visible {...ppoPlayground} />
+
+## Decision Lens
+
+PPO informs whether policy updates need an explicit trust-region solver or can be stabilized with a clipped surrogate. The atomic unit is an on-policy rollout transition carrying an advantage estimate; several minibatch epochs reuse that rollout while clipping discourages large probability-ratio changes.
+
+The paper establishes a favorable simplicity-performance tradeoff across its benchmark suite, not that clipping enforces a true trust region or removes sensitivity to batch, advantage, and entropy choices. A matched-sample comparison of clipping, adaptive KL penalties, and TRPO across seeds is the missing control. At 10× policy size, rollout freshness and distributed inference dominate optimizer cost. PPO's advantage would disappear if a simpler policy-gradient or KL-regularized method matched return and stability with less hyperparameter sensitivity.

--- a/src/content/posts/qwen-vla-unifying-vision-language-action-modeling-across-tasks-environments-and-robot-embodiments.md
+++ b/src/content/posts/qwen-vla-unifying-vision-language-action-modeling-across-tasks-environments-and-robot-embodiments.md
@@ -6,7 +6,7 @@ postSlug: qwen-vla-unifying-vision-language-action-modeling-across-tasks-environ
 legacyPath: /paper shorts/2026/05/28/qwen-vla-unifying-vision-language-action-modeling-across-tasks-environments-and-robot-embodiments.html
 tags:
   - Other
-field: Robotics
+field: 'Vision-Language-Action & Robotics'
 summary: Qwen-VLA extends the Qwen vision-language stack with a DiT action decoder so one model can handle manipulation, navigation, and trajectory prediction across embodiments.
 ---
 ## 2026 - Qwen-VLA
@@ -49,6 +49,12 @@ _The Qwen-VLA overview shows the shared vision-language backbone feeding a DiT a
 | Navigation | 69.0 R2R OS, 57.5 R2R SR, 59.6 RxR SR | Extends the same policy idea beyond tabletop manipulation. |
 | OOD dynamics | 32.0 SimplerEnv-OOD SR, 26.6 DOMINO SR, 39.5 DOMINO MS | Tests generalization to unseen spatial/visual tasks and dynamic objects. |
 | Real-world ALOHA | 83.6 in-domain average and 76.9 OOD average with pretraining | Shows the pretraining recipe matters outside simulation. |
+
+## Decision Lens
+
+Qwen-VLA informs whether manipulation, navigation, and trajectory prediction can be treated as one embodied modeling problem rather than separate product stacks. A Qwen vision-language backbone shares perception and instruction semantics, while a DiT flow-matching decoder produces continuous actions. Embodiment-aware prompts define robot-specific conventions, and the mixture spans robot trajectories, egocentric video, simulation, navigation, trajectory supervision, and auxiliary vision-language data.
+
+The breadth of results establishes that one interface can cover unusually different tasks, but it does not show how much positive transfer occurs between them. The missing evidence is a mixture matrix that removes each data family and measures gains and interference per embodiment at fixed compute. At ten times the mixture size, high-volume domains may dominate gradients while prompt conditioning fails to reconcile incompatible dynamics. The unification claim would be falsified if domain-specific policies trained on their own slices consistently outperform the shared model without losing sample efficiency.
 
 **Context:** Qwen-VLA pushes VLA models toward a single embodied interface across robot types and task families. It is less "a VLM that can call a robot head" and more "a VLM backbone trained to speak continuous action."
 

--- a/src/content/posts/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.md
+++ b/src/content/posts/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.md
@@ -6,7 +6,7 @@ postSlug: qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-an
 legacyPath: /paper shorts/2024/09/01/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: Qwen2-VL made resolution and video length more flexible by letting visual token count scale with the input.
 ---
 ## 2024 - Qwen2-VL
@@ -38,6 +38,12 @@ _Figure 1: Qwen2-VL capabilities: Multilingual image text understanding, code/ma
 | Resolution | Dynamic visual tokens | Preserves small text and high-resolution detail. |
 | Modalities | Image plus video | One model handles static and temporal inputs. |
 | Artifact | Qwen2-VL docs/project | Useful for OCR-heavy and multilingual multimodal tasks. |
+
+## Decision Lens
+
+Qwen2-VL informs whether visual detail should be normalized away at ingestion or represented through a variable token budget. Naive Dynamic Resolution lets patch count track the source image, while multimodal rotary position encoding supplies a common spatial and temporal coordinate system for text, images, and video. Compression is therefore adaptive rather than fixed: documents and dense scenes pay for more tokens, and simpler inputs remain cheaper.
+
+The OCR, document, and video results demonstrate the value of retaining detail, but they confound resolution, token count, and training distribution. A decisive ablation would compare fixed and dynamic schemes under identical average and tail latency, with separate results for small text, ordinary photographs, and long video. At ten times the input size, context occupation and attention cost can turn adaptive fidelity into unpredictable service behavior. The claim is operationally falsified if a fixed-token resampler matches accuracy and preserves more throughput under the same memory envelope.
 
 **Context:** Resolution is not cosmetic. If a model cannot preserve the evidence, the language model hallucinates around it. Qwen2-VL showed that flexible tokenization can make generalist VLMs much more usable.
 

--- a/src/content/posts/rtmap-real-time-recursive-mapping-with-change-detection-and-localization.md
+++ b/src/content/posts/rtmap-real-time-recursive-mapping-with-change-detection-and-localization.md
@@ -6,7 +6,7 @@ postSlug: rtmap-real-time-recursive-mapping-with-change-detection-and-localizati
 legacyPath: /paper shorts/2025/07/01/rtmap-real-time-recursive-mapping-with-change-detection-and-localization.html
 tags:
   - Other
-field: BEV
+field: 'BEV Perception & Mapping'
 summary: RTMap treats online HD mapping as a recursive system that localizes against a prior map, detects structural changes, and updates the crowdsourced map over time.
 ---
 ## 2025 - RTMap
@@ -50,6 +50,12 @@ _Figure 2 shows RTMap's loop: encode sensors and the crowdsourced HD map, match 
 | Change detection | RTMap is especially sensitive to the changed category and improves overall accuracy over the TbV baseline. | High recall is valuable for mining possible map-update events. |
 | Localization | Optimization-based pose estimation outperforms the end-to-end pose head in the nuScenes ablation. | Classical state estimation still helps inside learned mapping systems. |
 | System coupling | Change detection improves localization by rejecting mismatched prior-map elements. | Freshness and localization are linked problems. |
+
+## Decision Lens
+
+RTMap informs whether online mapping should rebuild each frame independently or recursively localize against, compare with, and update a prior map. The atomic unit is a local map observation aligned to a persistent vector map; change detection decides which prior elements survive, move, appear, or disappear.
+
+Recursion buys temporal consistency and fleet accumulation, but localization error can masquerade as map change and then contaminate the prior. The missing experiment independently perturbs pose, prior freshness, and change frequency while comparing recursive and stateless mapping. At 10× deployment duration, error accumulation, conflicting updates, and versioning dominate inference. The recursive claim would fail if periodic stateless remapping produced equal change recall and map stability at lower operational complexity.
 
 **Context:** RTMap moves online vector mapping from "predict the local map once" to "maintain a map that can remember, align, and revise itself."
 

--- a/src/content/posts/scaling-laws-for-generative-mixed-modal-language-models.md
+++ b/src/content/posts/scaling-laws-for-generative-mixed-modal-language-models.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: scaling-laws-for-generative-mixed-modal-language-models
 legacyPath: /paper shorts/2023/01/10/scaling-laws-for-generative-mixed-modal-language-models.html
 tags: [Scaling Laws]
-field: Omni-Models
+field: 'Multimodal Scaling & Data Mixtures'
 summary: '2023 – Mixed-modal scaling laws that model both modality contributions and interactions.'
 ---
 
@@ -26,7 +26,12 @@ The useful shift is from asking whether a mixture is good to estimating how each
 | Interaction term | Represents synergy or competition between modalities. |
 | Proxy experiments | Estimate a mixture before the expensive run. |
 
+## Decision Lens
+
+This paper informs how to choose a modality mixture before committing to an expensive mixed-modal run. It extends unimodal loss scaling with an interaction term that represents synergy or competition between modalities, then estimates the curve from proxy experiments. The 30B speech–text validation matters because it tests whether small-run mixture behavior extrapolates beyond the fitting regime.
+
+The curve establishes predictability for the studied modalities and budgets, not a universal law of beneficial mixing. The most important missing test is transfer across architectures, tokenizers, and data-quality regimes without refitting the interaction from scratch. At ten times the scale, changing data entropy and curriculum order can make a fixed interaction term nonstationary. The framework is falsified if mixtures selected by proxy fits consistently lose to simple baselines such as temperature sampling when evaluated at the target scale and full training cost.
+
 **Limits:** Scaling fits describe the studied training regime; interactions can change with model family, tokenization, and evaluation target.
 
 **Takeaway:** Data mixture is an optimization variable with interactions, not a fixed recipe to inherit.
-

--- a/src/content/posts/scaling-laws-for-native-multimodal-models.md
+++ b/src/content/posts/scaling-laws-for-native-multimodal-models.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: scaling-laws-for-native-multimodal-models
 legacyPath: /paper shorts/2025/04/10/scaling-laws-for-native-multimodal-models.html
 tags: [Multimodal AI]
-field: Omni-Models
+field: 'Multimodal Scaling & Data Mixtures'
 summary: '2025 – Scaling laws comparing native early-fusion and late-fusion multimodal models.'
 ---
 
@@ -26,7 +26,12 @@ The authors find no inherent late-fusion advantage in their study. Early-fusion 
 | Small-model efficiency | Early fusion is stronger at lower parameter counts. |
 | Specialization | MoE modality-specific weights improve the native model. |
 
+## Decision Lens
+
+This study informs the architectural choice between early fusion and late fusion for native multimodal training. In the reported regime, a shared early-fusion stream is simpler and more efficient at smaller parameter counts, while modality-aware mixture-of-experts weights recover specialization without duplicating the whole model. The result argues that modality-specific capacity can live inside a unified transformer rather than behind separate towers.
+
+The evidence rejects an inherent late-fusion advantage only for the tested modalities, tokenization, and compute range. A decisive missing comparison would equalize active parameters, communication cost, context length, and modality-specific preprocessing across both designs. At ten times the number of modalities or sequence length, shared attention and routing contention may reverse the result. The claim would be falsified if late fusion becomes more sample- or compute-efficient once high-bandwidth modalities and matched systems costs are included.
+
 **Limits:** Scaling-law conclusions are conditional on the architectures, modalities, objectives, and mixtures studied; they should guide a proxy-run plan, not replace one.
 
 **Takeaway:** Treat early fusion plus learned specialization as a serious baseline rather than assuming a pretrained visual tower is necessary.
-

--- a/src/content/posts/scaling-laws-for-optimal-data-mixtures.md
+++ b/src/content/posts/scaling-laws-for-optimal-data-mixtures.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: scaling-laws-for-optimal-data-mixtures
 legacyPath: /paper shorts/2025/07/12/scaling-laws-for-optimal-data-mixtures.html
 tags: [Scaling Laws]
-field: Omni-Models
+field: 'Multimodal Scaling & Data Mixtures'
 summary: '2025 – Estimating compute-aware data mixtures from small training runs.'
 ---
 
@@ -26,7 +26,12 @@ The authors validate the prediction framework across LLM, native multimodal, and
 | Domain weights $h$ | Defines the candidate mixture. |
 | Target-domain loss | Defines what “optimal” means. |
 
+## Decision Lens
+
+This paper informs how to allocate a finite pretraining budget across domains when the target metric is known. Small proxy runs fit loss as a function of model size, total data, and mixture weights; optimization then chooses a compute-aware mixture for the target domain. The important conceptual move is that “optimal data” is conditional on the evaluation target, not an intrinsic property of a dataset.
+
+Validation across language, native multimodal, and vision settings supports the fitting procedure, but it leaves distribution drift and data quality largely outside the law. The missing experiment chooses a mixture once, then carries it across a substantial scale jump and a changed model family without retuning. At ten times the corpus size, duplication and domain quality may change faster than mixture weights capture. The method is falsified if its predicted optimum repeatedly underperforms robust heuristic mixtures after including the proxy-search cost.
+
 **Limits:** An extrapolated optimum is only as trustworthy as the small-run fit and the stability of rankings outside the observed regime.
 
 **Takeaway:** Allocate data with an uncertainty-aware fitted model, then update the allocation as new evidence arrives.
-

--- a/src/content/posts/scaling-laws-of-motion-forecasting-and-planning.md
+++ b/src/content/posts/scaling-laws-of-motion-forecasting-and-planning.md
@@ -6,7 +6,7 @@ postSlug: scaling-laws-of-motion-forecasting-and-planning
 legacyPath: /paper shorts/2025/06/09/scaling-laws-of-motion-forecasting-and-planning.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: This Waymo technical report studies how autoregressive motion forecasting and planning transformers improve with training compute, data, model size, and inference-time sampling.
 ---
 ## 2025 - Scaling Laws of Motion Forecasting and Planning
@@ -48,6 +48,12 @@ _Figure 2 is the core scaling-law evidence: training loss improves predictably a
 | Driving data | 447 thousand hours and 5.6 million miles | Shows the curves come from fleet-scale data. |
 | Training examples | 541 million | Gives the scaling study enough examples to vary data budgets. |
 | Compute-optimal trend | Model size grows 1.5x as fast as dataset size | Bigger compute budgets should not be spent on data and parameters equally. |
+
+## Decision Lens
+
+This study informs how an autonomy program should split additional compute among model parameters, logged driving data, and inference-time trajectory sampling. Its atomic example is an autoregressive scene sequence drawn from fleet-scale logs; the reported curves connect training loss to open-loop and closed-loop forecasting/planning metrics.
+
+The evidence supports predictable improvement within the measured model, data, and sampling ranges, including a compute-optimal trend in which model size grows faster than dataset size. It does not prove that the same exponents survive a new architecture, geography, or safety distribution. A held-out large run with fixed evaluation and confidence intervals is the decisive test. The law would fail operationally if closed-loop ranking reversed even while training loss followed the fitted curve.
 
 **Context:** The paper moved motion forecasting and planning into the scaling-laws conversation with evidence that closed-loop behavior can improve predictably.
 

--- a/src/content/posts/scaling-motion-forecasting-models-with-ensemble-distillation.md
+++ b/src/content/posts/scaling-motion-forecasting-models-with-ensemble-distillation.md
@@ -6,7 +6,7 @@ postSlug: scaling-motion-forecasting-models-with-ensemble-distillation
 legacyPath: /paper shorts/2024/04/05/scaling-motion-forecasting-models-with-ensemble-distillation.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: This paper uses large motion-forecasting ensembles as teachers and distills their gains into smaller student models that fit onboard compute budgets.
 ---
 ## 2024 - Ensemble Distillation
@@ -40,6 +40,12 @@ _Figure 4 shows the deployment tradeoff: larger ensembles improve metrics with m
 | Teacher | Large ensemble of optimized forecasters | Raises the accuracy ceiling. |
 | Student | Distilled smaller model | Brings ensemble gains closer to deployment cost. |
 | Benchmarks | WOMD and Argoverse leaderboards | Covers widely used motion-forecasting evaluations. |
+
+## Decision Lens
+
+This paper informs whether serving constraints should cap teacher quality or whether a costly forecasting ensemble can be used only during training and distilled into one onboard model. The unit is a scene with multiple teacher trajectory distributions; the student learns both logged futures and the ensemble's softened multimodal predictions.
+
+The result establishes a train-serve asymmetry: ensemble diversity can improve a student that cannot afford ensemble inference. The missing comparison matches total teacher-training compute against a single larger teacher and tests which teacher diversity actually transfers. At 10× ensemble size, teacher storage, inference for label generation, and correlated errors dominate. Distillation would fail as the allocation strategy if a directly trained student or single teacher matched leaderboard and calibration metrics at lower end-to-end cost.
 
 **Context:** It showed a practical way to use scaling and ensembles even when the production model must stay small.
 

--- a/src/content/posts/scene-reconstruction-as-mapping-priors-for-3d-detection.md
+++ b/src/content/posts/scene-reconstruction-as-mapping-priors-for-3d-detection.md
@@ -6,7 +6,7 @@ postSlug: scene-reconstruction-as-mapping-priors-for-3d-detection
 legacyPath: /paper shorts/2026/05/21/scene-reconstruction-as-mapping-priors-for-3d-detection.html
 tags:
   - Other
-field: BEV
+field: 'BEV Perception & Mapping'
 summary: MPA3D uses automatically reconstructed surfel and 3D Gaussian maps as dense static priors for 3D object detection.
 ---
 ## 2026 - Scene Reconstruction as Mapping Priors for 3D Detection
@@ -48,6 +48,12 @@ _Figure 2 shows MPA3D: camera BEV features, LiDAR, surfels, and 3D Gaussian prio
 | MPA3D vs MAD temporal fusion | +0.2/+0.4 L2 AP/APH on validation and +0.9/+1.2 on testing | Comparable or better than using up to 99 previous frames. |
 | Gated fusion ablation | 83.3 overall L2 AP, +2.9 over the next-best concat baseline | The fusion mechanism is a real contributor, not just more inputs. |
 | Runtime caveat | Adding both priors increases latency from 245 ms to 452 ms in the reported setup | The accuracy gain comes with deployment cost. |
+
+## Decision Lens
+
+MPA3D informs whether static scene reconstruction can serve as a reusable prior for 3D detection instead of forcing each frame to relearn background geometry. The atomic prior is a surfel or 3D Gaussian map element aligned with current sensor features; dynamic-object prediction is conditioned on that persistent static representation.
+
+The method can turn repeated fleet observations into dense supervision, but localization quality and stale geometry determine whether the prior helps. The missing factorial study separates map density, reconstruction type, pose error, and detector capacity under equal current-frame inputs. At 10× territory and map age, storage, retrieval, and change management dominate. The mapping-prior claim would fail if a temporal detector matched 3D accuracy under pose noise without maintaining an external reconstructed map.
 
 **Context:** MPA3D reframes mapping as perception memory. The map does not need to be a manually labeled semantic product; a reconstructed static scene can still be a powerful prior for finding what changed.
 

--- a/src/content/posts/scene-transformer-a-unified-architecture-for-predicting-multiple-agent-trajectories.md
+++ b/src/content/posts/scene-transformer-a-unified-architecture-for-predicting-multiple-agent-trajectories.md
@@ -6,7 +6,7 @@ postSlug: scene-transformer-a-unified-architecture-for-predicting-multiple-agent
 legacyPath: /paper shorts/2021/06/15/scene-transformer-a-unified-architecture-for-predicting-multiple-agent-trajectories.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: Scene Transformer uses one scene-centric attention architecture for marginal, joint, conditional, and goal-conditioned multi-agent forecasting.
 ---
 ## 2021 - Scene Transformer
@@ -41,6 +41,12 @@ _Figure 2 shows the two key ideas: prediction tasks become mask patterns, and on
 | Masked tasks | MP, CMP, and GCP as visibility patterns | Turns a family of tasks into one model interface. |
 | Attention axes | Time, agents, and road graph | Lets heterogeneous scene information interact. |
 | Evidence | Waymo Open Motion Dataset and Argoverse | Tests both large-scale scene prediction and public map-rich forecasting. |
+
+## Decision Lens
+
+Scene Transformer informs whether marginal, joint, conditional, and goal-conditioned forecasting require separate architectures. The atomic unit is an agent-time state token; masks and conditioning inputs alter the forecasting query while the same scene-centric attention stack models interactions.
+
+Unification reduces task-specific machinery, but dense attention over agents and time makes missing-state handling and scene size part of the compute budget. The missing control compares one universal model with specialized models at matched total parameters and training examples, not merely shared implementation. At 10× agents or horizon, the interaction tensor dominates memory. The unification claim would fail if specialized decoders consistently improved joint calibration or rare conditional queries at equal aggregate cost.
 
 **Context:** Scene Transformer pushed the field toward unified heterogeneous scene attention, where the model reasons over agents, time, and map context together.
 

--- a/src/content/posts/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.md
+++ b/src/content/posts/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: senna-bridging-large-vision-language-models-and-end-to-end-autonomous-
 legacyPath: /paper shorts/2024/10/01/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: SENNA split driving into high-level language planning and low-level trajectory control.
 ---
 ## 2024 - SENNA
@@ -36,6 +36,12 @@ _Figure 1: Previous methods plan trajectories without a decision-making step, ma
 | Decomposition | Language plan plus control module | Separates semantic intent from numeric control. |
 | Training | Planning-oriented QA and curriculum | Tunes the VLM for traffic decisions. |
 | Caveat | Language plan is not a guarantee | Control still needs safety validation. |
+
+## Decision Lens
+
+SENNA informs whether a driving stack should separate high-level semantic commands from low-level continuous trajectory control. The VLM predicts a compact driving intention from images and language context; a fast planner conditions on that intention to generate the trajectory.
+
+The hierarchy reduces language-generation latency in the control loop, but the command vocabulary can become an information bottleneck. The missing test varies command granularity and compares oracle, learned, and absent high-level guidance under matched planner capacity. At 10× scenario complexity, ambiguous commands and recovery from a wrong high-level decision dominate. The separation would fail if direct end-to-end planning matched safety and generalization without the semantic intermediate.
 
 **Context:** SENNA captures a useful decomposition for safety-critical systems: use language for semantic planning, but keep numeric control in a component designed for precision.
 

--- a/src/content/posts/sequence-to-sequence-learning-with-neural-networks.md
+++ b/src/content/posts/sequence-to-sequence-learning-with-neural-networks.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2014/09/01/sequence-to-sequence-learning-with-neural-networks.html
 tags:
   - Other
-field: Natural Language Processing
+field: 'Language Models'
 summary: Seq2seq made encoder-decoder neural translation practical before attention became the default alignment mechanism.
 ---
 ## 2014 – Sequence to Sequence Learning with Neural Networks
@@ -43,5 +43,11 @@ The paper also contains one of those oddly practical details that becomes famous
 | Decoding | Beam = 12 | – | ~0.11 s / sentence on CPU |
 
 **Critiques & limitations:** The architecture was clean because it removed hand-built alignments, but the fixed-length vector became an obvious bottleneck for long sentences. Large vocabularies also made training expensive, and the lack of an official implementation left early adopters guessing about details. Attention mechanisms would soon address the bottleneck directly.
+
+## Decision Lens
+
+Seq2seq informs the decision to learn translation as one conditional sequence model rather than assemble a phrase table, language model, and hand-built decoder. The atomic example is a parallel source-target sentence pair: an encoder compresses the source into a fixed vector, and a decoder predicts target tokens autoregressively.
+
+The result established that end-to-end neural translation could beat a strong phrase-based system, but the fixed-vector bottleneck entangles sentence length with representation quality. A length-stratified comparison against an attention-equipped encoder-decoder is the missing decisive ablation. Scaling to much longer documents would fail through information compression and autoregressive exposure bias. The central claim would weaken if a modular or retrieval-based system matched BLEU and generalization under the same parallel-data and compute budget.
 
 **Takeaway:** The encoder-decoder LSTM showed that a general neural network could outperform traditional translation systems. It did not solve sequence modelling by itself, but it gave the field the scaffold that attention and Transformers later expanded.

--- a/src/content/posts/sigmoid-loss-for-language-image-pre-training-siglip.md
+++ b/src/content/posts/sigmoid-loss-for-language-image-pre-training-siglip.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2023/10/01/sigmoid-loss-for-language-image-pre-training-siglip.html
 tags:
   - Other
-field: Computer Vision
+field: 'Vision-Language Models'
 summary: SigLIP replaced softmax contrastive normalization with independent sigmoid losses, simplifying large-batch image-text training.
 ---
 ## 2023 – Sigmoid Loss for Language-Image Pre-Training (SigLIP)
@@ -50,5 +50,11 @@ def siglip_loss(img_emb, txt_emb, temperature=0.07):
 ```
 
 **Critiques:** SigLIP is compelling because the intervention is so small: swap the loss, get better scaling behavior. It is easier to reproduce at smaller batch sizes than CLIP-style training. The main caveat is the data. The strongest results use the private WebLI dataset, public alternatives lag slightly, and web-scale bias remains part of the model.
+
+## Decision Lens
+
+SigLIP informs whether image-text pre-training needs a globally normalized softmax over the batch. Its atomic unit is one image-text pair with an independent sigmoid classification target, which removes the requirement that every accelerator participate in one shared denominator.
+
+The paper establishes that simpler pairwise normalization can match or improve contrastive transfer while easing large-batch communication. The missing systems ablation is a wall-clock and accuracy comparison across batch sizes and cluster topologies with identical encoders and data. At 10× scale, negative-pair imbalance and web-data noise may replace all-gather as the bottleneck. The claim would fail if a carefully tuned softmax objective reached the same transfer at equal end-to-end throughput or if sigmoid training degraded calibration on hard negatives.
 
 **Takeaway:** SigLIP shows that language-image contrastive learning does not require a softmax over huge batches. A sigmoid BCE loss can deliver better accuracy with much less training infrastructure.

--- a/src/content/posts/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.md
+++ b/src/content/posts/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.md
@@ -6,7 +6,7 @@ postSlug: sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representat
 legacyPath: /paper shorts/2024/05/30/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.html
 tags:
   - Other
-field: BEV
+field: 'Autonomous Driving: VLA & Planning'
 summary: SparseDrive replaces expensive dense BEV planning features with sparse scene instances, symmetric sparse perception, parallel motion planning, and collision-aware rescoring.
 ---
 ## 2024 - SparseDrive
@@ -41,6 +41,12 @@ _Figure 3 shows SparseDrive's architecture: image features become sparse scene r
 | Perception | Detection, tracking, and mapping in a symmetric sparse module | Keeps dynamic and static scene structure aligned. |
 | Planning | Parallel motion planner | Lets agent prediction and ego planning interact earlier. |
 | Safety | Collision-aware rescoring | Makes trajectory selection sensitive to physical conflicts. |
+
+## Decision Lens
+
+SparseDrive informs whether end-to-end planning needs a dense BEV feature map or can operate on a compact set of detected agents and map instances. Its atomic units are sparse scene queries shared by perception, motion prediction, and planning; collision-aware rescoring links predicted futures back to ego selection.
+
+The sparse interface buys latency by discarding most spatial locations, but missed or poorly localized instances become irreversible planner blind spots. The missing test equalizes backbone and latency across sparse queries, dense BEV, and a hybrid occupancy path under occlusion and long-tail clutter. At 10× actors, query competition and pairwise interaction cost dominate. The claim would fail if a compressed dense representation matched planning safety with better recall at the same runtime.
 
 **Context:** SparseDrive sharpened the argument that sparse/vectorized planning can be both faster and more planner-aligned than dense BEV stacks.
 

--- a/src/content/posts/talk2bev-language-enhanced-birds-eye-view-maps-for-autonomous-driving.md
+++ b/src/content/posts/talk2bev-language-enhanced-birds-eye-view-maps-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: talk2bev-language-enhanced-birds-eye-view-maps-for-autonomous-driving
 legacyPath: /paper shorts/2023/10/03/talk2bev-language-enhanced-birds-eye-view-maps-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: Talk2BEV grounds language queries in BEV maps by augmenting objects with image-language features, enabling open-ended scene, spatial, intent, and decision questions.
 ---
 ## 2023 - Talk2BEV
@@ -43,6 +43,12 @@ _Figure 2 shows how Talk2BEV turns generated BEV maps into language-enhanced map
 | Dataset | 1,000 BEV scenarios | Gives the paper a human-annotated evaluation set. |
 | QA volume | More than 20,000 questions and responses | Covers varied scene, object, intent, and decision queries. |
 | Source data | nuScenes | Keeps the benchmark tied to a standard driving dataset. |
+
+## Decision Lens
+
+Talk2BEV informs whether open-vocabulary driving questions should be answered from camera tokens directly or from a metric BEV map augmented with language-aligned object features. The atomic representation is a BEV object with geometry, identity, and an image-language embedding; spatial and intent queries operate over that grounded map.
+
+The design preserves metric relations while importing open-vocabulary semantics, but errors from detection, BEV projection, and captioning compound. The missing ablation compares oracle objects, learned BEV objects, and direct image prompting with equal language-model context. At 10× scene density, object selection and relation enumeration dominate. The BEV grounding claim would fail if direct visual prompting matched spatial accuracy and explanation faithfulness without the structured map.
 
 **Context:** Talk2BEV is an early clean example of language-grounded scene reasoning over BEV rather than only camera images.
 

--- a/src/content/posts/tnt-target-driven-trajectory-prediction.md
+++ b/src/content/posts/tnt-target-driven-trajectory-prediction.md
@@ -6,7 +6,7 @@ postSlug: tnt-target-driven-trajectory-prediction
 legacyPath: /paper shorts/2020/08/19/tnt-target-driven-trajectory-prediction.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: TNT makes multimodal motion forecasting explicit by predicting likely target states, rolling out target-conditioned trajectories, and scoring a compact diverse set.
 ---
 ## 2020 - TNT: Target-driveN Trajectory Prediction
@@ -53,6 +53,12 @@ _Figure 2 shows the three-stage TNT pipeline: encode the scene, score candidate 
 | INTERACTION validation | MultiPath: 0.99 minFDE, 0.30 minADE | 0.67 minFDE, 0.21 minADE |
 | PAID pedestrians | MultiPath: 0.43 minFDE, 0.23 minADE | 0.32 minFDE, 0.18 minADE |
 | Stanford Drone | PECNet: 25.98 minFDE, 12.79 minADE | 21.16 minFDE, 12.23 minADE |
+
+## Decision Lens
+
+TNT informs whether multimodal forecasting should first choose a destination and then generate the path, rather than regress complete trajectories in one step. The atomic hierarchy is an actor history, a candidate target state, and a target-conditioned trajectory; a final scorer selects a compact diverse set.
+
+The factorization gives modes a semantic endpoint, but target discretization and candidate pruning can exclude valid futures before decoding. The missing ablation holds total proposals fixed while comparing endpoint-first, anchor-trajectory, and direct set prediction across map-rich and map-free datasets. At 10× candidate density, target scoring dominates and duplicates crowd out rare modes. TNT's claim would fail if direct trajectory-set prediction matched miss rate and diversity without a target bottleneck.
 
 **Context:** TNT made goal-conditioned motion forecasting feel practical for autonomous driving. It kept the multimodal structure visible and showed that endpoint candidates can be a cleaner intent representation than opaque latent samples.
 

--- a/src/content/posts/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.md
+++ b/src/content/posts/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.md
@@ -6,7 +6,7 @@ postSlug: tod3cap-towards-3d-dense-captioning-in-outdoor-scenes
 legacyPath: /paper shorts/2024/03/01/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: TOD3Cap asked driving models to detect outdoor 3D objects and caption them with rich language.
 ---
 ## 2024 - TOD3Cap
@@ -36,6 +36,12 @@ _Figure 1: We introduce the task of 3D dense captioning in outdoor scenes (right
 | Dataset | 850 scenes / 64.3k objects / 2.3M captions | Large outdoor dense-captioning setup. |
 | Task | 3D object captioning | Requires boxes plus descriptions. |
 | Use case | Scene explanation and planner context | Turns perception into grounded language. |
+
+## Decision Lens
+
+TOD3Cap informs whether outdoor perception should stop at 3D boxes or attach language descriptions that expose object attributes and relations. The atomic output is a detected 3D instance paired with a caption, so localization and language quality are jointly constrained by the same scene.
+
+Dense captions can support open-ended reasoning, but caption metrics may reward generic descriptions and ignore metric grounding. The missing study conditions on oracle versus predicted boxes and evaluates whether captions improve a downstream driving decision, not only language similarity. At 10× objects, proposal-caption pairing and annotation consistency dominate. The task formulation would fail if richer detection attributes delivered the same downstream utility with less free-form language ambiguity.
 
 **Context:** Dense captioning is a bridge between perception and explanation. A driving system that can say what every relevant object is doing has a better interface to planners, annotators, and safety reviewers.
 

--- a/src/content/posts/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.md
+++ b/src/content/posts/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation
 legacyPath: /paper shorts/2024/12/04/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.html
 tags: [Multimodal AI]
-field: Omni-Models
+field: 'Omni-Model Architectures'
 summary: '2024 – TokenFlow: a dual-codebook tokenizer for visual semantics and reconstruction detail.'
 ---
 
@@ -27,7 +27,12 @@ The key mechanism is dual codebooks connected through a shared mapping, so share
 | Reconstruction | FID 0.63 at 384×384 | Tests fine visual detail. |
 | Generation | GenEval 0.55 at 256×256 | Tests the generation side of the tokenizer. |
 
+## Decision Lens
+
+TokenFlow informs whether one discrete image interface can support both semantic understanding and high-fidelity generation. Its dual codebooks preserve semantic and fine-grained signals, while a shared index mapping lets a transformer consume a unified token stream. The image token is therefore not forced to choose between invariance and reconstruction detail; the mapping couples two specialized representations at each position.
+
+The reported understanding, reconstruction, and generation results show that the compromise is viable, but they do not isolate the cost of the larger codebook machinery or test severe compression uniformly. A bitrate- and parameter-matched comparison with single codebooks across resolutions is the missing ablation. At ten times the image complexity or sequence length, index alignment may become brittle and discrete sequences expensive. The unification claim fails if separate tokenizers deliver a better Pareto frontier once tokenizer compute and downstream context cost are counted.
+
 **Limits:** The design adds tokenizer complexity; results depend on the selected comparisons and resolutions.
 
 **Takeaway:** The tokenizer is an architectural decision: semantic and reconstruction features can be aligned without being identical.
-

--- a/src/content/posts/toponet-graph-based-topology-reasoning-for-driving-scenes.md
+++ b/src/content/posts/toponet-graph-based-topology-reasoning-for-driving-scenes.md
@@ -6,7 +6,7 @@ postSlug: toponet-graph-based-topology-reasoning-for-driving-scenes
 legacyPath: /paper shorts/2023/04/11/toponet-graph-based-topology-reasoning-for-driving-scenes.html
 tags:
   - Other
-field: BEV
+field: 'BEV Perception & Mapping'
 summary: TopoNet reasons over lane connectivity and traffic-element-to-lane assignment with a scene graph neural network and a scene knowledge graph.
 ---
 ## 2023 - TopoNet
@@ -47,6 +47,12 @@ _Figure 2 shows how TopoNet routes traffic elements and centerlines through deco
 | ------------------------------ | -------------- | ------------------ | --------------------- | --- |
 | MapTR* | 17.7 | 1.1 | 10.4 | 26.0 |
 | TopoNet | 28.5 | 4.1 | 20.8 | 35.6 |
+
+## Decision Lens
+
+TopoNet informs whether lane geometry and traffic-element association should be predicted independently or reasoned over as one scene graph. Its atomic units are lane and traffic-element queries; graph edges represent lane-to-lane connectivity and traffic-element-to-lane assignment.
+
+Joint reasoning can enforce coherent topology, but errors in node detection and edge classification compound. The missing control holds node features fixed while comparing independent edge heads, message passing, and explicit structural constraints. At 10× lane density, candidate edges grow quadratically and class imbalance worsens. The graph claim would fail if a sparse rule-constrained matcher achieved equal topology metrics and downstream route validity with fewer learned pairwise evaluations.
 
 **Context:** TopoNet made road topology a first-class perception output, not a post-processing afterthought.
 

--- a/src/content/posts/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.md
+++ b/src/content/posts/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training
 legacyPath: /paper shorts/2024/10/09/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.html
 tags: [ML Systems]
-field: Omni-Models
+field: 'Training Systems & Reliability'
 summary: '2024 – TorchTitan: composable parallelism, checkpointing, and debugging for large-scale PyTorch pre-training.'
 ---
 
@@ -27,7 +27,12 @@ The contribution is operational composability: compare and combine parallelism s
 | Checkpointing and logging | Recoverability and diagnosis belong in the training design. |
 | Modular recipes | Enables controlled comparisons instead of one-off system configurations. |
 
+## Decision Lens
+
+TorchTitan informs a systems decision: whether large-model training should be assembled from bespoke frameworks or expressed as composable, PyTorch-native recipes. The effective unit is the recoverable distributed training step, because tensor, pipeline, and data parallelism, checkpointing, logging, and compilation must operate as one system. Results from 8B through 405B models show incremental throughput gains as parallelism becomes multidimensional.
+
+Those measurements establish that the stack can scale on the tested H100 configurations, not that a single recipe is optimal across clusters and failure modes. The missing evaluation combines throughput with utilization, restart cost, checkpoint stalls, and engineer time against mature alternatives. At ten times the device count, network topology, stragglers, and coordinated recovery dominate kernel efficiency. The production-readiness claim is falsified if nominal speedups disappear under realistic failures or require model-specific code that breaks the promised composability.
+
 **Limits:** The reported recipes are LLM-focused. Multimodal runs add long-sequence, data-pipeline, and modality-health failure modes that still need explicit monitoring.
 
 **Takeaway:** A production training stack is part of the research method because it determines what experiments can be run, compared, and recovered.
-

--- a/src/content/posts/training-language-models-to-follow-instructions-with-human-feedback.md
+++ b/src/content/posts/training-language-models-to-follow-instructions-with-human-feedback.md
@@ -8,7 +8,7 @@ legacyPath: >-
   shorts/2022/02/28/training-language-models-to-follow-instructions-with-human-feedback.html
 tags:
   - Other
-field: Alignment
+field: 'Alignment & Post-Training'
 summary: InstructGPT showed that human preference data can make smaller language models follow instructions better than larger base models.
 ---
 ## 2022 – Training Language Models to Follow Instructions with Human Feedback (InstructGPT)
@@ -73,3 +73,9 @@ A reference policy (the frozen supervised model) keeps the RL step from drifting
 
 **Why it matters**
 RLHF transformed large language models from clever autocomplete systems into instruction-following assistants, laying the groundwork for ChatGPT, GPT-4, and beyond.
+
+## Decision Lens
+
+InstructGPT informs whether scarce human preference data is better spent on supervised demonstrations alone or on a reward model followed by policy optimization. Its training pipeline moves from prompt-response demonstrations to ranked completion pairs and finally to PPO rollouts constrained by a KL penalty to the supervised policy.
+
+The smaller aligned model beating a much larger base model establishes that behavioral supervision can dominate parameter count on instruction-following judgments. It does not isolate the value of PPO from demonstration quality, reward-model capacity, and sampling policy. At 10× scale, annotation consistency, reward hacking, and rollout cost dominate. The RLHF stack would be falsified as necessary if a matched supervised or direct-preference method reproduced helpfulness and safety without the online RL stage.

--- a/src/content/posts/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.md
+++ b/src/content/posts/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model
 legacyPath: /paper shorts/2024/08/20/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.html
 tags: [Multimodal AI]
-field: Omni-Models
+field: 'Omni-Model Architectures'
 summary: '2024 – Transfusion: one transformer, next-token language modeling, and image diffusion.'
 ---
 
@@ -26,7 +26,12 @@ The paper separates the question of a shared transformer from the question of a 
 | Shared transformer | Preserves cross-modal interaction. |
 | Modality-specific I/O | Lets each modality use a suitable representation. |
 
+## Decision Lens
+
+Transfusion informs whether modality unification requires forcing images into next-token prediction. It shares a transformer across text and images but keeps losses appropriate to each representation: autoregressive cross-entropy for text and diffusion denoising for continuous image patches. Modality-specific input and output layers permit aggressive image compression while the shared trunk learns cross-modal dependencies.
+
+The scaling results support hybrid objectives over discrete image-token generation in the studied setting, but loss normalization becomes the hidden control knob because token prediction and denoising have different magnitudes and sample structures. A missing ablation should sweep loss weights and image patch counts at fixed compute, including a stronger discrete tokenizer. At ten times the resolution, diffusion patches can dominate training and attention despite compression. The core claim fails if its advantage vanishes after matching tokenizer quality, effective image compute, and per-modality loss contribution.
+
 **Limits:** Hybrid objectives make loss weighting, training diagnostics, and serving more complicated than one next-token objective.
 
 **Takeaway:** A unified model does not require a unified loss; use the objective that matches the modality.
-

--- a/src/content/posts/uniad-planning-oriented-autonomous-driving.md
+++ b/src/content/posts/uniad-planning-oriented-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: uniad-planning-oriented-autonomous-driving
 legacyPath: /paper shorts/2022/12/20/uniad-planning-oriented-autonomous-driving.html
 tags:
   - Other
-field: BEV
+field: 'Autonomous Driving: VLA & Planning'
 summary: UniAD connects perception, prediction, occupancy, and planning in one planning-oriented driving stack, using task queries as interfaces between modules.
 ---
 ## 2022 - UniAD
@@ -42,6 +42,12 @@ _Figure 2 shows UniAD's pipeline: BEV features feed tracking and mapping, those 
 | MotionFormer | Forecasts multi-agent futures | Models how other actors may move. |
 | OccFormer | Predicts occupancy | Adds a dense safety-oriented future signal. |
 | Planner | Predicts ego waypoints | Makes the stack optimize toward driving behavior. |
+
+## Decision Lens
+
+UniAD informs whether perception, tracking, mapping, motion, occupancy, and planning should be optimized as separate products or as one planning-oriented query pipeline. The atomic interfaces are task queries: agent, map, motion, occupancy, and ego queries carry a shared scene state between modules while losses remain task-specific.
+
+Joint training makes upstream representations accountable to planning, but it also obscures which task and loss weight creates the gain. The missing factorial ablation freezes or removes each query interface under matched backbone, data, and latency, then measures closed-loop rather than only open-loop metrics. At 10× task or scene complexity, gradient conflict and query bandwidth dominate. UniAD's claim would fail if a modular pipeline matched closed-loop safety and progress while allowing better independent calibration and recovery.
 
 **Context:** UniAD set the dense BEV end-to-end driving baseline that later vectorized and VLA systems compare themselves against.
 

--- a/src/content/posts/unidrivevla-unifying-understanding-perception-and-action-planning-for-autonomous-driving.md
+++ b/src/content/posts/unidrivevla-unifying-understanding-perception-and-action-planning-for-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: unidrivevla-unifying-understanding-perception-and-action-planning-for-
 legacyPath: /paper shorts/2026/04/02/unidrivevla-unifying-understanding-perception-and-action-planning-for-autonomous-driving.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: UniDriveVLA decouples semantic understanding, spatial perception, and action planning into specialized Transformer experts coordinated by masked joint attention.
 ---
 ## 2026 - UniDriveVLA
@@ -43,6 +43,12 @@ _Figure 3 shows UniDriveVLA's Mixture-of-Transformers architecture, where specia
 | Coordination | Masked joint attention | Shares information without collapsing every token into one stream. |
 | Training | Three-stage progressive recipe | Stabilizes VLA optimization for driving. |
 | Evaluation | nuScenes and Bench2Drive | Covers open-loop public data and closed-loop simulation. |
+
+## Decision Lens
+
+UniDriveVLA informs whether one fully shared Transformer should handle driving semantics, spatial perception, and action planning or whether those functions need specialized experts. Its atomic tokens enter expert-specific paths coordinated by masked joint attention, which controls information exchange without forcing every parameter to serve every objective.
+
+Specialization can reduce gradient conflict, but expert boundaries and joint-attention masks may encode the answer manually. The missing factorial ablation matches total parameters across fully shared, expert-only, and partially shared designs while measuring transfer and per-task gradients. At 10× modalities or tasks, routing imbalance and interface bandwidth dominate. The expert claim would fail if a dense shared model matched worst-task and closed-loop performance under equal training and inference FLOPs.
 
 **Context:** UniDriveVLA makes expert decoupling a central design pattern for driving VLAs.
 

--- a/src/content/posts/vad-vectorized-scene-representation-for-efficient-autonomous-driving.md
+++ b/src/content/posts/vad-vectorized-scene-representation-for-efficient-autonomous-driving.md
@@ -6,7 +6,7 @@ postSlug: vad-vectorized-scene-representation-for-efficient-autonomous-driving
 legacyPath: /paper shorts/2023/03/21/vad-vectorized-scene-representation-for-efficient-autonomous-driving.html
 tags:
   - Other
-field: BEV
+field: 'Autonomous Driving: VLA & Planning'
 summary: VAD replaces dense rasterized planning inputs with vectorized agents and map elements, improving end-to-end planning efficiency and safety constraints.
 ---
 ## 2023 - VAD
@@ -48,6 +48,12 @@ _Figure 1 shows the representational shift: VAD keeps agents, maps, and ego plan
 | UniAD | 1.03 | 0.31 | 555.6 | 1.8 |
 | VAD-Tiny | 0.78 | 0.38 | 59.5 | 16.8 |
 | VAD-Base | 0.72 | 0.22 | 224.3 | 4.5 |
+
+## Decision Lens
+
+VAD informs whether an ego planner needs a dense raster feature map or can reason over vectorized agents and map elements. Its atomic units are agent vectors, map vectors, and ego trajectory points; vector attention exposes interaction while explicit safety costs rescore plans.
+
+The representation reduces dense BEV compute, but planning quality becomes bounded by vector extraction recall and uncertainty. The missing comparison matches latency and backbone across vector-only, raster-only, and hybrid planners under missed detections and map errors. At 10× actors, pairwise interaction and vector selection dominate. VAD's claim would fail if a low-resolution raster or occupancy interface matched collision and progress metrics while degrading more gracefully when upstream instances are missing.
 
 **Context:** VAD connected vectorized scene understanding to end-to-end planning, not just map construction.
 

--- a/src/content/posts/vectornet-encoding-hd-maps-and-agent-dynamics-from-vectorized-representation.md
+++ b/src/content/posts/vectornet-encoding-hd-maps-and-agent-dynamics-from-vectorized-representation.md
@@ -6,7 +6,7 @@ postSlug: vectornet-encoding-hd-maps-and-agent-dynamics-from-vectorized-represen
 legacyPath: /paper shorts/2020/05/08/vectornet-encoding-hd-maps-and-agent-dynamics-from-vectorized-representation.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: VectorNet encoded HD maps and agent histories as polylines, using local polyline aggregation and a global interaction graph instead of rasterized BEV images.
 ---
 ## 2020 - VectorNet
@@ -39,6 +39,12 @@ _Figure 2 shows the core hierarchy: vectors become polyline features, polyline f
 | Architecture | Local polyline subgraphs plus global graph | Matches the natural hierarchy of driving scenes. |
 | Auxiliary task | Masked entity completion | Forces the global graph to use scene context. |
 | Evidence | Internal benchmark and Argoverse | Shows vectorized encoding can compete with rendered BEV baselines. |
+
+## Decision Lens
+
+VectorNet informs whether HD maps and trajectories should be rasterized or preserved as polylines with explicit geometric identity. The atomic unit is a point feature grouped into a polyline; local aggregation creates polyline embeddings and a global graph models interactions among agents and map elements.
+
+Vectorization preserves topology and avoids empty pixels, but preprocessing choices determine segment length, coordinate frame, and missing-map behavior. The missing ablation matches encoder capacity and latency against raster and raw-point attention across map quality levels. At 10× map extent, global polyline attention and retrieval dominate. The claim would fail if a compact raster encoder matched forecasting accuracy and cross-city generalization without vector-specific preprocessing.
 
 **Context:** VectorNet made vectorized map and agent encoding feel like a primary representation, not a preprocessing trick.
 

--- a/src/content/posts/videollama-3-frontier-multimodal-foundation-models.md
+++ b/src/content/posts/videollama-3-frontier-multimodal-foundation-models.md
@@ -6,7 +6,7 @@ postSlug: videollama-3-frontier-multimodal-foundation-models
 legacyPath: /paper shorts/2025/01/01/videollama-3-frontier-multimodal-foundation-models.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Video & Interactive World Models'
 summary: VideoLLaMA 3 showed that strong image understanding can be the foundation for efficient video understanding.
 ---
 ## 2025 - VideoLLaMA 3
@@ -38,6 +38,12 @@ _Figure 1: Performance Comparison of VideoLLaMA3 with the previous advanced imag
 | Training stages | Image alignment then video tuning | Uses image semantics before temporal specialization. |
 | Efficiency | Dynamic token merging | Compresses redundant visual tokens across frames. |
 | Evidence | Image and video benchmarks | Checks whether video gains preserve image understanding. |
+
+## Decision Lens
+
+VideoLLaMA 3 informs whether video understanding should begin with a separate temporal model or with a strong image-language representation followed by temporal specialization. Its curriculum first establishes image–text alignment, then adds video data; variable-resolution encoding preserves spatial detail, while dynamic token merging compresses redundant evidence across frames before the language model consumes it.
+
+The joint image and video benchmarks show that this route can add temporal capability without discarding image competence, but they do not isolate whether token merging preserves the events that matter rather than merely benchmark-level appearance. The missing study varies motion density and event duration at equal token budgets. At ten times the video length, rare actions may be merged away while context and decoding costs still grow. The thesis would fail if a temporally explicit model with the same compute consistently wins on long-horizon causal and event-order tests.
 
 **Context:** It connects the image VLM and video VLM stories. If static visual grounding is strong, video becomes a temporal extension rather than a separate world.
 

--- a/src/content/posts/vision-language-action-models-for-autonomous-driving-past-present-and-future.md
+++ b/src/content/posts/vision-language-action-models-for-autonomous-driving-past-present-and-future.md
@@ -6,7 +6,7 @@ postSlug: vision-language-action-models-for-autonomous-driving-past-present-and-
 legacyPath: /paper shorts/2025/12/18/vision-language-action-models-for-autonomous-driving-past-present-and-future.html
 tags:
   - Other
-field: Autonomous Driving
+field: 'Autonomous Driving: VLA & Planning'
 summary: This survey traces autonomous-driving VLA work from vision-action models to end-to-end and dual-system VLA paradigms, with attention to action generators and guidance styles.
 ---
 ## 2025 - Vision-Language-Action Models for Autonomous Driving
@@ -41,6 +41,12 @@ _Figure 2 summarizes representative VA and VLA models across end-to-end, world-m
 | Action generator | Textual action, numerical trajectory, or control signal | Determines how directly the model can drive. |
 | Guidance style | Explicit or implicit | Separates prompt-like supervision from representation-level conditioning. |
 | Historical line | VA, world model, VLA | Connects new VLA papers to older driving policy and dynamics work. |
+
+## Decision Lens
+
+This survey informs how to compare vision-action, end-to-end VLA, and dual-system driving models without collapsing them into one label. Its key units are system boundaries: where language enters, how action is represented, whether a world model is present, and whether evaluation is open or closed loop.
+
+The historical taxonomy is useful if it predicts engineering tradeoffs rather than merely ordering papers. A common benchmark that fixes sensors, data, action horizon, and latency across the three paradigms is the missing test. As the field scales, proprietary data and inconsistent closed-loop protocols make architectural claims hard to compare. The taxonomy would fail if data scale and evaluator choice explained outcomes better than the proposed model evolution.
 
 **Context:** This survey gives a cleaner vocabulary for comparing monolithic driving VLAs against hybrid systems such as DriveVLM-Dual-style designs.
 

--- a/src/content/posts/visual-instruction-tuning-llava.md
+++ b/src/content/posts/visual-instruction-tuning-llava.md
@@ -6,7 +6,7 @@ postSlug: visual-instruction-tuning-llava
 legacyPath: /paper shorts/2023/04/01/visual-instruction-tuning-llava.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Vision-Language Models'
 summary: LLaVA showed that a frozen vision encoder, an LLM, and synthetic instruction data could produce a useful open multimodal assistant.
 ---
 ## 2023 - Visual Instruction Tuning (LLaVA)
@@ -38,6 +38,12 @@ _Figure 1: LLaVA network architecture. From the [Visual Instruction Tuning (LLaV
 | Interface | Image-to-chat assistant | Turns visual representations into dialogue. |
 | Training signal | Visual instruction tuning | Synthetic QA data teaches the model how to answer about images. |
 | Artifact | Project page and code | The LLaVA recipe became a common open baseline. |
+
+## Decision Lens
+
+LLaVA informs whether a pretrained visual representation needs architectural reinvention or primarily an instruction-following interface. CLIP patch features pass through a learned projector into the language model, and a two-stage curriculum first aligns that interface and then trains image-grounded dialogue. The expensive asset is not a new encoder but synthetic visual instruction data generated from captions and image context.
+
+The paper establishes that text-style instruction tuning transfers surprisingly well to a visual assistant, but it does not prove that the model's answers are grounded rather than polished expressions of language priors. The key missing ablation pairs equivalent conversations with counterfactual or withheld visual evidence and compares human, synthetic, and caption-only supervision. At ten times the synthetic-data scale, teacher bias and templated reasoning could harden into confident hallucination. The central claim is falsified if performance survives image corruption or swapping, because then the instruction interface has improved conversation without improving perception.
 
 **Context:** LLaVA made the VLM stack modular: vision encoder, projector, LLM, instruction data. That template became the default starting point for many open multimodal assistants.
 

--- a/src/content/posts/vlm-ad-end-to-end-autonomous-driving-through-vision-language-model-supervision.md
+++ b/src/content/posts/vlm-ad-end-to-end-autonomous-driving-through-vision-language-model-supervision.md
@@ -6,7 +6,7 @@ postSlug: vlm-ad-end-to-end-autonomous-driving-through-vision-language-model-sup
 legacyPath: /paper shorts/2024/12/19/vlm-ad-end-to-end-autonomous-driving-through-vision-language-model-supervision.html
 tags:
   - Other
-field: Vision-Language Models
+field: 'Autonomous Driving: VLMs & Evaluation'
 summary: VLM-AD uses a VLM as a training-time teacher, distilling driving reasoning and structured action labels into an end-to-end driving model without using the VLM at inference time.
 ---
 ## 2024 - VLM-AD
@@ -50,6 +50,14 @@ _Figure 2 shows the training-time teacher setup: the VLM produces freeform reaso
 | UniAD on nuScenes | 1.03 avg L2, 0.31 avg collision | 0.88 avg L2, 0.19 avg collision | Lower planning error and fewer collisions. |
 | VAD-Base on CARLA Town05 Short | 64.29 DS, 87.26 RC | 67.78 DS, 88.56 RC | Better closed-loop score and route completion. |
 | VAD-Base on CARLA Town05 Long | 30.31 DS, 75.20 RC | 35.25 DS, 84.14 RC | Larger gain on the longer interactive route. |
+
+## Decision Lens
+
+The expensive decision is where semantic reasoning belongs in a real-time driving stack and what can safely remain end to end. Its fundamental training unit is a text token plus a visual patch or compressed visual token. Each modality keeps a separate input encoder before sharing a connector/backbone or common token-processing stack.
+
+The VLM watches driving scenes during dataset construction, produces freeform reasoning and structured action annotations, and those annotations become auxiliary supervision for a smaller driving model. The note does not give full mixture proportions or a reproducible curriculum schedule. Cameras and scene state are compressed into BEV features, object/map vectors, queries, or language tokens.
+
+The most important missing comparison is a closed-loop, matched-latency ablation that isolates semantic reasoning from perception and planner capacity. At 10× scale, sensor-token count, scene density, temporal context, and closed-loop latency would grow faster than the headline offline metric. The central claim would fail under this test: Run matched-latency closed-loop evaluation with and without the proposed reasoning or representation; reject it if safety and progress do not improve.
 
 **Context:** VLM-AD is a clean example of the "language model as teacher" pattern for physical systems. The VLM improves training signal, but the deployed system still respects latency and control constraints.
 

--- a/src/content/posts/wan-open-and-advanced-large-scale-video-generative-models.md
+++ b/src/content/posts/wan-open-and-advanced-large-scale-video-generative-models.md
@@ -5,7 +5,7 @@ section: paper-shorts
 postSlug: wan-open-and-advanced-large-scale-video-generative-models
 legacyPath: /paper shorts/2025/03/26/wan-open-and-advanced-large-scale-video-generative-models.html
 tags: [Video Generation]
-field: Omni-Models
+field: 'Video & Interactive World Models'
 summary: '2025 – Wan: an open video-generation suite built around diffusion transformers, a VAE, and large-scale curation.'
 ---
 
@@ -27,7 +27,12 @@ Wan supplies a systems-oriented video reference rather than only a generative-mo
 | Data pipeline | Caption quality, motion filtering, and curation affect the usable training signal. |
 | Model family | How to trade quality against a consumer-scale deployment target. |
 
+## Decision Lens
+
+Wan informs how to divide a video-generation budget among latent compression, transformer scale, data curation, and deployability. A video VAE compresses spatial and temporal structure before the generative model operates, while the released 1.3B and 14B variants expose a concrete quality–resource tradeoff; the smaller model's reported 8.19 GB requirement makes consumer hardware an explicit design target.
+
+The broad task support shows that the stack is reusable, but it does not reveal whether model scale, VAE quality, captions, or motion filtering produces the largest marginal gain. A compute- and data-matched component ablation with temporal-fidelity metrics is the missing decision evidence. At ten times the duration or resolution, VAE artifacts and temporal drift can compound faster than model quality improves. The scaling story would be falsified if a smaller transformer with better data or weaker compression matches the 14B model on motion consistency and prompt adherence at much lower cost.
+
 **Limits:** Video quality does not establish action-conditioned dynamics, causal control, or long-horizon world consistency.
 
 **Takeaway:** Treat the video autoencoder and data pipeline as first-class architecture choices, not preprocessing details.
-

--- a/src/content/posts/wayformer-motion-forecasting-via-simple-and-efficient-attention-networks.md
+++ b/src/content/posts/wayformer-motion-forecasting-via-simple-and-efficient-attention-networks.md
@@ -6,7 +6,7 @@ postSlug: wayformer-motion-forecasting-via-simple-and-efficient-attention-networ
 legacyPath: /paper shorts/2022/07/12/wayformer-motion-forecasting-via-simple-and-efficient-attention-networks.html
 tags:
   - Other
-field: BEV
+field: 'Motion Forecasting & Planning'
 summary: Wayformer shows that a simpler attention stack can fuse heterogeneous road, agent, and traffic-light inputs for motion forecasting when the fusion strategy is chosen carefully.
 ---
 ## 2022 - Wayformer
@@ -39,6 +39,12 @@ _Figure 1 shows Wayformer as an encoder-decoder attention network over heterogen
 | Efficiency | Factorized and latent-query attention | Makes large scene attention more practical. |
 | Inputs | Road geometry, traffic lights, agent history | Covers the messy inputs forecasting systems actually use. |
 | Benchmarks | Waymo Open Motion Dataset and Argoverse | Compares across major public motion forecasting settings. |
+
+## Decision Lens
+
+Wayformer informs how much forecasting quality comes from a specialized interaction graph versus a carefully chosen attention fusion strategy. Its atomic tokens represent agents, road elements, and traffic lights over time; early, late, or hierarchical fusion determines when those modalities can interact.
+
+The results favor early fusion in the tested regimes, but fusion choice is entangled with token count and attention approximation. The missing factorial study matches FLOPs while varying fusion point, latent bottleneck, and full versus factorized attention across scene densities. At 10× actors and map tokens, early fusion's quadratic interaction cost becomes decisive. The simplicity claim would fail if hierarchical fusion matched accuracy and calibration with a materially better latency curve.
 
 **Context:** Wayformer helped normalize unified attention over heterogeneous driving scenes while keeping the architecture relatively simple.
 


### PR DESCRIPTION
## Summary
- add an individualized prose Decision Lens to all 90 paper notes
- replace broad catch-all fields with 15 decision-oriented paper categories
- separate BEV mapping, motion forecasting, driving VLM evaluation, and driving VLA planning

## Validation
- npm run ci
- 90 paper notes, 90 Decision Lens sections, 15 rendered categories
- git diff --check