### PR TITLE
Add zero-to-hero guides for multimodal pretraining and VLA post-training

### DIFF
--- a/public/assets/images/omni-pretraining-decision-stack.svg
+++ b/public/assets/images/omni-pretraining-decision-stack.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="820" viewBox="0 0 1400 820" role="img" aria-labelledby="title desc">
+  <title id="title">Omni-model pretraining decision stack</title>
+  <desc id="desc">A stack of coupled decisions from representations and objectives through data mixtures, scaling experiments, systems, and capability evaluation.</desc>
+  <defs>
+    <linearGradient id="bg2" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fbff"/>
+      <stop offset="1" stop-color="#f3eefb"/>
+    </linearGradient>
+    <filter id="shadow2" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="9" flood-color="#26324a" flood-opacity="0.12"/>
+    </filter>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 Z" fill="#5d5f9e"/></marker>
+  </defs>
+  <rect width="1400" height="820" rx="28" fill="url(#bg2)"/>
+  <text x="700" y="58" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="700" fill="#26324a">Omni-model pretraining is a coupled allocation problem</text>
+  <text x="700" y="94" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="18" fill="#596780">A model family is credible only when its representation, data, compute, and evaluation assumptions agree.</text>
+
+  <g font-family="Inter, Arial, sans-serif" filter="url(#shadow2)">
+    <g><rect x="120" y="145" width="900" height="85" rx="18" fill="#e7f0ff"/><text x="165" y="180" font-size="21" font-weight="700" fill="#234b7a">1 · Representation</text><text x="165" y="207" font-size="16" fill="#405b78">text tokens · image patches/latents · video clips · action chunks</text></g>
+    <g><rect x="120" y="250" width="900" height="85" rx="18" fill="#e9f7f0"/><text x="165" y="285" font-size="21" font-weight="700" fill="#245f45">2 · Sharing and objectives</text><text x="165" y="312" font-size="16" fill="#416b58">shared trunk vs experts · autoregression vs diffusion/flow · loss normalization</text></g>
+    <g><rect x="120" y="355" width="900" height="85" rx="18" fill="#fff5df"/><text x="165" y="390" font-size="21" font-weight="700" fill="#7b540b">3 · Data mixture and curriculum</text><text x="165" y="417" font-size="16" fill="#755f32">text · image-text · generation · video · action · quality · repetition</text></g>
+    <g><rect x="120" y="460" width="900" height="85" rx="18" fill="#f3eefe"/><text x="165" y="495" font-size="21" font-weight="700" fill="#5b4284">4 · Proxy scaling experiments</text><text x="165" y="522" font-size="16" fill="#6d5a85">model size · token budget · compression · context · confidence intervals</text></g>
+    <g><rect x="120" y="565" width="900" height="85" rx="18" fill="#eaf4f8"/><text x="165" y="600" font-size="21" font-weight="700" fill="#285f72">5 · Systems and run health</text><text x="165" y="627" font-size="16" fill="#4b707d">parallelism · throughput · checkpoints · data health · rollback</text></g>
+    <g><rect x="120" y="670" width="900" height="85" rx="18" fill="#fdecec"/><text x="165" y="705" font-size="21" font-weight="700" fill="#844040">6 · Capability evidence</text><text x="165" y="732" font-size="16" fill="#7b5555">per-modality transfer · interference · generation · grounding · action</text></g>
+  </g>
+
+  <g fill="none" stroke="#5d5f9e" stroke-width="4" marker-end="url(#arrow2)">
+    <path d="M1055 188 H1160 V292 H1045"/>
+    <path d="M1055 397 H1160 V502 H1045"/>
+    <path d="M1055 607 H1160 V712 H1045"/>
+  </g>
+  <rect x="1090" y="310" width="240" height="245" rx="20" fill="#26324a"/>
+  <text x="1210" y="356" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="21" font-weight="700" fill="#ffffff">Kill criteria</text>
+  <text x="1210" y="397" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="15" fill="#d9e0ef">Does sharing help?</text>
+  <text x="1210" y="429" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="15" fill="#d9e0ef">Does the mixture transfer?</text>
+  <text x="1210" y="461" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="15" fill="#d9e0ef">Do proxy ranks persist?</text>
+  <text x="1210" y="493" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="15" fill="#d9e0ef">Can the run recover?</text>
+  <text x="1210" y="525" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="15" fill="#d9e0ef">Does capability justify cost?</text>
+</svg>

--- a/public/assets/images/vla-post-training-closed-loop.svg
+++ b/public/assets/images/vla-post-training-closed-loop.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="760" viewBox="0 0 1400 760" role="img" aria-labelledby="title desc">
+  <title id="title">Closed-loop VLA post-training system</title>
+  <desc id="desc">A loop from base VLA through supervised fine-tuning, deployment rollouts, failure mining, feedback, policy optimization, evaluation, and redeployment.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f7fafc"/>
+      <stop offset="1" stop-color="#e9f2ff"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#0f2745" flood-opacity="0.12"/>
+    </filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#3567a8"/>
+    </marker>
+  </defs>
+  <rect width="1400" height="760" rx="28" fill="url(#bg)"/>
+  <text x="700" y="60" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="700" fill="#102a43">VLA post-training is a measurement loop</text>
+  <text x="700" y="96" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="18" fill="#486581">Every update is only as good as the failures, feedback, and evaluation that produced it.</text>
+
+  <g fill="none" stroke="#3567a8" stroke-width="4" marker-end="url(#arrow)">
+    <path d="M270 225 H360"/>
+    <path d="M590 225 H680"/>
+    <path d="M910 225 H1000"/>
+    <path d="M1115 295 V390"/>
+    <path d="M1000 470 H910"/>
+    <path d="M680 470 H590"/>
+    <path d="M360 470 H270"/>
+    <path d="M155 390 V295"/>
+  </g>
+
+  <g filter="url(#shadow)" font-family="Inter, Arial, sans-serif">
+    <g><rect x="40" y="155" width="230" height="140" rx="20" fill="#ffffff"/><text x="155" y="210" text-anchor="middle" font-size="23" font-weight="700" fill="#173f5f">Base VLA</text><text x="155" y="244" text-anchor="middle" font-size="16" fill="#526d82">semantic + motor priors</text></g>
+    <g><rect x="360" y="155" width="230" height="140" rx="20" fill="#ffffff"/><text x="475" y="210" text-anchor="middle" font-size="23" font-weight="700" fill="#173f5f">Task SFT</text><text x="475" y="244" text-anchor="middle" font-size="16" fill="#526d82">adapt action interface</text></g>
+    <g><rect x="680" y="155" width="230" height="140" rx="20" fill="#ffffff"/><text x="795" y="210" text-anchor="middle" font-size="23" font-weight="700" fill="#173f5f">Rollouts</text><text x="795" y="244" text-anchor="middle" font-size="16" fill="#526d82">visit policy-induced states</text></g>
+    <g><rect x="1000" y="155" width="230" height="140" rx="20" fill="#ffffff"/><text x="1115" y="210" text-anchor="middle" font-size="23" font-weight="700" fill="#173f5f">Failure mining</text><text x="1115" y="244" text-anchor="middle" font-size="16" fill="#526d82">segment cause, not symptom</text></g>
+    <g><rect x="1000" y="390" width="230" height="160" rx="20" fill="#fff7e6"/><text x="1115" y="440" text-anchor="middle" font-size="23" font-weight="700" fill="#7a4b00">Feedback</text><text x="1115" y="475" text-anchor="middle" font-size="15" fill="#765d31">success · correction · preference</text><text x="1115" y="502" text-anchor="middle" font-size="15" fill="#765d31">progress · safety · uncertainty</text></g>
+    <g><rect x="680" y="390" width="230" height="160" rx="20" fill="#edf9f0"/><text x="795" y="440" text-anchor="middle" font-size="23" font-weight="700" fill="#22633b">Optimize</text><text x="795" y="475" text-anchor="middle" font-size="15" fill="#426b50">correction SFT · KTO/APO</text><text x="795" y="502" text-anchor="middle" font-size="15" fill="#426b50">PPO/RL · distillation</text></g>
+    <g><rect x="360" y="390" width="230" height="160" rx="20" fill="#f2effb"/><text x="475" y="440" text-anchor="middle" font-size="23" font-weight="700" fill="#563d7c">Evaluation</text><text x="475" y="475" text-anchor="middle" font-size="15" fill="#66567d">offline → sim → real</text><text x="475" y="502" text-anchor="middle" font-size="15" fill="#66567d">held-out shifts + CIs</text></g>
+    <g><rect x="40" y="390" width="230" height="160" rx="20" fill="#eaf5ff"/><text x="155" y="440" text-anchor="middle" font-size="23" font-weight="700" fill="#0b568f">Redeploy</text><text x="155" y="475" text-anchor="middle" font-size="15" fill="#476a85">versioned policy + rollback</text><text x="155" y="502" text-anchor="middle" font-size="15" fill="#476a85">repeat under new failures</text></g>
+  </g>
+
+  <rect x="280" y="620" width="840" height="82" rx="18" fill="#102a43"/>
+  <text x="700" y="654" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700" fill="#ffffff">North-star metric</text>
+  <text x="700" y="682" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="18" fill="#d7e7f5">reliable policy improvement per robot-hour, human-hour, annotation-hour, and unit of compute</text>
+</svg>

--- a/src/content/posts/action-chunking-with-transformers-act.md
+++ b/src/content/posts/action-chunking-with-transformers-act.md
@@ -1,0 +1,44 @@
+---
+title: 'Learning Fine-Grained Bimanual Manipulation with Low-Cost Hardware (ACT)'
+date: '2023-04-23T09:00:00.000Z'
+section: paper-shorts
+postSlug: action-chunking-with-transformers-act
+legacyPath: /paper shorts/2023/04/23/action-chunking-with-transformers-act.html
+tags:
+  - Robotics
+  - Imitation Learning
+field: 'Vision-Language-Action & Robotics'
+summary: 2023 – ACT predicts temporally coherent action chunks for precise bimanual manipulation.
+---
+
+## 2023 – Learning Fine-Grained Bimanual Manipulation with Low-Cost Hardware
+
+**arXiv:** [2304.13705](https://arxiv.org/abs/2304.13705)
+
+**Project:** [ALOHA](https://tonyzhaozh.github.io/aloha/)
+
+ACT pairs a low-cost bimanual teleoperation platform with a conditional variational autoencoder that predicts action sequences. The policy does not choose one motor command in isolation; it proposes a chunk, while temporal ensembling blends overlapping predictions during execution.
+
+## Paper Insights
+
+Action chunking reduces the effective decision horizon and captures coordinated motion that per-step regression tends to fragment. A latent variable models variation across human demonstrations, while a transformer consumes multi-view images and joint state to generate the chunk. Temporal ensembling smooths successive predictions without committing to an entire open-loop plan.
+
+The paper reports 80–90% success on six precise real-world tasks using roughly ten minutes of demonstrations per task. That result ties model design to a data-collection system: cheap, expressive teleoperation produces the demonstrations that make the sequence model useful.
+
+| Lever | Benefit | Tradeoff |
+| --- | --- | --- |
+| Longer chunks | Shorter effective horizon and smoother behavior | Slower response to unexpected state changes |
+| Temporal ensembling | Blends overlapping action predictions | Adds a weighting and latency choice |
+| Latent action style | Represents multimodal demonstrations | Can absorb inconsistency rather than task structure |
+
+## Decision Lens
+
+ACT informs the chunk-length and execution-interface decision for imitation-trained robot policies. Its training unit is an observation paired with a future action trajectory. Visual and proprioceptive inputs share a transformer representation, while the CVAE compresses demonstration variation into a latent style variable.
+
+The results establish that chunks are effective for the studied precise bimanual tasks, not that longer is always better. A missing ablation would sweep chunk length under controlled perturbation frequency and inference latency. At ten times the task duration, open-loop commitment and latent-style ambiguity can compound. The method's core advantage disappears if a matched recurrent single-step policy recovers faster from disturbances while retaining the same smoothness and success.
+
+**Context:** ACT made action chunks a default design axis for modern VLA adaptation recipes.
+
+**Limits:** The policy still learns from demonstrations and inherits their state coverage.
+
+**Takeaway:** Chunking buys temporal coherence by spending responsiveness; choose the horizon from the disturbance timescale, not convention.

--- a/src/content/posts/action-preference-optimization-for-robotic-policy-refinement.md
+++ b/src/content/posts/action-preference-optimization-for-robotic-policy-refinement.md
@@ -1,0 +1,44 @@
+---
+title: 'Human-Assisted Robotic Policy Refinement via Action Preference Optimization'
+date: '2025-06-08T09:00:00.000Z'
+section: paper-shorts
+postSlug: action-preference-optimization-for-robotic-policy-refinement
+legacyPath: /paper shorts/2025/06/08/action-preference-optimization-for-robotic-policy-refinement.html
+tags:
+  - Robotics
+  - Preference Optimization
+field: 'Robot Post-Training & Evaluation'
+summary: 2025 – APO converts human interventions into binary action desirability for VLA refinement.
+---
+
+## 2025 – Human-Assisted Robotic Policy Refinement via Action Preference Optimization
+
+**arXiv:** [2506.07127](https://arxiv.org/abs/2506.07127)
+
+**Project:** [Action Preference Optimization](https://gewu-lab.github.io/action_preference_optimization/)
+
+Action Preference Optimization (APO) learns from a deployment pattern that ordinary DPO handles poorly: a robot starts to fail, a human takes over, and the corrected trajectory continues from a different state. The method labels actions as desirable or undesirable rather than pretending the intervention supplies a matched chosen–rejected pair.
+
+## Paper Insights
+
+The data loop combines autonomous execution, human takeover, and trajectory logging. APO uses a prospect-theoretic binary objective related to KTO, then adaptively reweights token-level gradients according to decoded continuous-action error. That second step addresses a VLA-specific mismatch: two nearby action tokens may have very different physical effects, while token probability alone does not encode control distance.
+
+The paper evaluates simulation and real manipulation, reporting better generalization and robustness than the compared supervised and preference baselines. The important contribution is the preference unit: intervention data says which local action was failure-prone, but it does not construct a counterfactual episode from the same state.
+
+| Deployment event | Training signal |
+| --- | --- |
+| Autonomous action before failure | Undesirable action evidence |
+| Human corrective action | Desirable action evidence |
+| Continuous action error | Adaptive weight on token-level optimization |
+
+## Decision Lens
+
+APO informs whether human time should produce full demonstrations or targeted interventions on policy failures. Its atomic unit is an action labeled by desirability within an interaction trajectory. Irreversibility prevents exact pairing, and adaptive weighting maps physical action discrepancy back into an autoregressive token loss.
+
+The results show that binary action feedback can exploit failures more directly than preferred-sample SFT. A missing ablation compares intervention timing, action-window length, and matched-state resets. At ten times the deployment volume, operator latency and inconsistent takeover thresholds will bias the data. The approach fails if action-level gains do not improve episode-level safety or if the policy learns to rely on states reachable only after human rescue.
+
+**Context:** APO is the practical bridge from KTO-style binary feedback to irreversible physical interaction.
+
+**Limits:** An intervention identifies a bad local choice more reliably than it identifies the earliest causal error.
+
+**Takeaway:** Do not force physical corrections into language-style pairs; preserve what the intervention actually tells you.

--- a/src/content/posts/constitutional-ai-harmlessness-from-ai-feedback.md
+++ b/src/content/posts/constitutional-ai-harmlessness-from-ai-feedback.md
@@ -1,0 +1,42 @@
+---
+title: 'Constitutional AI: Harmlessness from AI Feedback'
+date: '2022-12-15T09:00:00.000Z'
+section: paper-shorts
+postSlug: constitutional-ai-harmlessness-from-ai-feedback
+legacyPath: /paper shorts/2022/12/15/constitutional-ai-harmlessness-from-ai-feedback.html
+tags:
+  - Alignment
+  - AI Feedback
+field: 'Alignment & Post-Training'
+summary: 2022 – Constitutional AI turns explicit principles into self-revision data and AI-generated preferences.
+---
+
+## 2022 – Constitutional AI: Harmlessness from AI Feedback
+
+**arXiv:** [2212.08073](https://arxiv.org/abs/2212.08073)
+
+Constitutional AI replaces most harmfulness labels with an explicit list of principles and two model-mediated stages. The supervised stage produces critiques and revisions of harmful responses. The reinforcement stage asks a model to choose between responses under a sampled principle, trains a preference model, and optimizes the assistant against that model.
+
+## Paper Insights
+
+The constitution is both specification and data generator. It makes behavioral constraints inspectable, but every generated critique, revision, and preference still passes through a model whose interpretation can be incomplete. The supervised stage also gives the RL policy a safer starting distribution, reducing the exploration burden in the reinforcement phase.
+
+The paper reports a less harmful, less evasive assistant with far fewer direct human harmfulness labels. For embodied systems, the transferable idea is not “let a VLM decide safety.” It is to encode constraints explicitly, generate adversarial and corrective supervision from those constraints, and preserve human evaluation as the external authority.
+
+| Stage | Generated supervision | Function |
+| --- | --- | --- |
+| Constitutional SFT | Critique and revised response | Moves the policy into a better initial region. |
+| RLAIF | AI preference under a principle | Scales comparisons without one human label per pair. |
+| Human evaluation | Independent behavior judgment | Tests whether the constitution and judge produced the intended behavior. |
+
+## Decision Lens
+
+Constitutional AI informs whether scarce human attention should label every example or define rules and audit the supervision that models generate from them. The fundamental units are a critique–revision example and a preference pair. The policy and preference model are separate, and errors in the AI judge can be amplified by RL.
+
+In robotics, a constitution could encode forbidden contacts, workspace boundaries, uncertainty-triggered stops, and recovery priorities. The missing experiment is causal: compare rule-generated feedback with hand-labeled physical violations under matched human time, then evaluate novel hazards. At ten times the task diversity, principle conflicts and unmodeled geometry will dominate. The approach fails if the critic can verbalize the right rule while rewarding trajectories that violate it physically.
+
+**Context:** Constitutional AI is a blueprint for scalable supervision, not proof that automated oversight is self-validating.
+
+**Limits:** The work studies dialogue harmlessness; physical safety constraints require grounded state and calibrated uncertainty.
+
+**Takeaway:** A constitution lowers labeling cost only when independent evaluation can detect how the judge misread it.

--- a/src/content/posts/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.md
+++ b/src/content/posts/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.md
@@ -1,0 +1,44 @@
+---
+title: 'DAgger: A Reduction of Imitation Learning to No-Regret Online Learning'
+date: '2011-04-11T09:00:00.000Z'
+section: paper-shorts
+postSlug: dagger-reduction-of-imitation-learning-to-no-regret-online-learning
+legacyPath: /paper shorts/2011/04/11/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.html
+tags:
+  - Imitation Learning
+  - Robotics
+field: 'Vision-Language-Action & Robotics'
+summary: 2011 – DAgger trains on states induced by the learner rather than only states visited by an expert.
+---
+
+## 2011 – DAgger: A Reduction of Imitation Learning to No-Regret Online Learning
+
+**Paper:** [PMLR 15:627–635](https://proceedings.mlr.press/v15/ross11a.html)
+
+**Conference:** AISTATS 2011
+
+DAgger explains why a policy with low supervised error can still fail catastrophically in closed loop. The learner's actions change its next observation. Once it leaves the expert distribution, small errors expose unfamiliar states and compound across the horizon.
+
+## Paper Insights
+
+The algorithm repeatedly runs a mixture of the current learner and expert, asks the expert for the correct action on visited states, aggregates those state–action labels, and retrains a stationary policy. The dataset therefore follows the learner as it improves. Under the paper's assumptions, no-regret online learning yields performance that scales linearly with horizon rather than the quadratic worst case of naive behavioral cloning.
+
+DAgger's lasting contribution is a data-collection rule: label the states your policy causes, not only the states an expert prefers. Modern intervention logs, corrective action chunks, and failure mining are variations on that principle. The difficult part is that querying an expert online can be expensive or unsafe.
+
+| Behavioral cloning | DAgger |
+| --- | --- |
+| Learns from the expert state distribution | Learns from the learner-induced state distribution |
+| Errors compound after the first deviation | New deviations become labeled training states |
+| Data can be collected once | Data collection and policy training alternate |
+
+## Decision Lens
+
+DAgger informs whether the next annotation budget should fund more clean demonstrations or corrections on states the deployed policy actually reaches. Its atomic unit is a visited state paired with an expert action. The environment closes the loop, so data distribution is part of the algorithm rather than a fixed input.
+
+The theory establishes why interactive aggregation can control compounding error under an available expert. It does not resolve delayed feedback, irreversible actions, or human reaction latency. At ten times the rollout volume, expert queries become the bottleneck and policy versions can make aggregated data stale. The central claim is falsified operationally if failure-targeted corrections do not beat an equal number of fresh expert demonstrations on held-out closed-loop disturbances.
+
+**Context:** DAgger is the conceptual ancestor of failure-driven VLA post-training.
+
+**Limits:** Expert intervention can alter the trajectory, and a corrective label may arrive after the state that caused the failure.
+
+**Takeaway:** Deployment changes the state distribution; a serious improvement loop must train on that changed distribution.

--- a/src/content/posts/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.md
+++ b/src/content/posts/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.md
@@ -1,0 +1,44 @@
+---
+title: 'Diffusion Policy: Visuomotor Policy Learning via Action Diffusion'
+date: '2023-03-07T09:00:00.000Z'
+section: paper-shorts
+postSlug: diffusion-policy-visuomotor-policy-learning-via-action-diffusion
+legacyPath: /paper shorts/2023/03/07/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.html
+tags:
+  - Robotics
+  - Diffusion
+field: 'Vision-Language-Action & Robotics'
+summary: 2023 – Diffusion Policy models multimodal continuous action sequences through iterative denoising.
+---
+
+## 2023 – Diffusion Policy: Visuomotor Policy Learning via Action Diffusion
+
+**arXiv:** [2303.04137](https://arxiv.org/abs/2303.04137)
+
+**Project:** [diffusion-policy.cs.columbia.edu](https://diffusion-policy.cs.columbia.edu/)
+
+Diffusion Policy represents a visuomotor policy as a conditional denoising process over action trajectories. Instead of regressing toward the average of several valid behaviors, it learns the score of a multimodal action distribution and samples a coherent sequence at inference time.
+
+## Paper Insights
+
+The policy conditions a diffusion model on observations, starts from noisy action sequences, and refines them across denoising steps. Receding-horizon control executes only the near part of each sampled trajectory before observing again. This combination gives diffusion enough horizon to coordinate motion while retaining closed-loop replanning.
+
+Across 15 tasks from four manipulation benchmarks, the paper reports an average 46.9% improvement over the compared state of the art. The important mechanism is distributional expressivity: high-dimensional action sequences and multiple valid strategies are represented without an explicit mixture model. The cost is iterative sampling and a likelihood interface that is less convenient for policy-gradient or preference optimization.
+
+| Representation | Strength | Post-training complication |
+| --- | --- | --- |
+| Per-step regression | Cheap and explicit | Averages incompatible actions |
+| Autoregressive tokens | Native likelihood | Quantization and sequential latency |
+| Diffusion trajectory | Multimodal continuous behavior | Iterative inference and denoising-step credit assignment |
+
+## Decision Lens
+
+Diffusion Policy informs whether action multimodality is important enough to justify iterative decoding. Its atomic unit is an action trajectory corrupted at a diffusion timestep; the loss predicts denoising information conditioned on visual state. Temporal compression comes from predicting a sequence and executing it receding-horizon.
+
+The benchmark establishes a strong imitation-learning Pareto point, not that diffusion remains optimal under strict latency or online RL. A missing experiment matches end-to-end control frequency and compute against flow, autoregressive, and parallel regression heads. At ten times the horizon, denoising cost and model error across the unused tail grow. The representation claim fails if a simpler continuous chunk policy matches robustness and multimodality at the same closed-loop rate.
+
+**Context:** Diffusion Policy made the policy distribution—not only the backbone—a central robot-learning decision.
+
+**Limits:** Strong offline imitation results do not automatically provide tractable action log-probabilities for RL.
+
+**Takeaway:** Diffusion is valuable when the action distribution has several precise modes; its sampling interface must still fit the control and post-training loop.

--- a/src/content/posts/dppo-diffusion-policy-policy-optimization.md
+++ b/src/content/posts/dppo-diffusion-policy-policy-optimization.md
@@ -1,0 +1,44 @@
+---
+title: 'DPPO: Diffusion Policy Policy Optimization'
+date: '2024-09-01T09:00:00.000Z'
+section: paper-shorts
+postSlug: dppo-diffusion-policy-policy-optimization
+legacyPath: /paper shorts/2024/09/01/dppo-diffusion-policy-policy-optimization.html
+tags:
+  - Robotics
+  - Reinforcement Learning
+field: 'Robot Post-Training & Evaluation'
+summary: 2024 – DPPO applies policy gradients to pretrained diffusion policies through the denoising process.
+---
+
+## 2024 – DPPO: Diffusion Policy Policy Optimization
+
+**arXiv:** [2409.00588](https://arxiv.org/abs/2409.00588)
+
+**Project:** [diffusion-ppo.github.io](https://diffusion-ppo.github.io/)
+
+DPPO addresses a representation mismatch in robot RL: a diffusion policy does not expose one simple action density in the same way as a Gaussian policy. The method treats denoising as an augmented Markov process and applies policy-gradient updates across denoising transitions.
+
+## Paper Insights
+
+Starting from an imitation-trained diffusion policy, DPPO fine-tunes with PPO-style machinery and a set of stability choices. The paper finds that the diffusion parameterization encourages structured, on-manifold exploration and stable updates, outperforming the compared RL methods for diffusion policies and several other policy classes. It also demonstrates zero-shot deployment of a simulation-trained policy on hardware for a long-horizon task.
+
+The critical distinction is between environment time and denoising time. Credit must be assigned to a physical action sequence, while log-probabilities arise from the stochastic denoising path that produced it. Changing sampler steps can therefore change the optimization geometry without changing the executed action space.
+
+| Time scale | Meaning |
+| --- | --- |
+| Environment step | Robot state transition and reward |
+| Action horizon | Sequence generated for receding-horizon execution |
+| Denoising step | Internal stochastic policy transition used for likelihood ratios |
+
+## Decision Lens
+
+DPPO informs whether a strong diffusion imitation policy can be improved directly with RL or should first be distilled into a simpler actor. Its atomic optimization unit is a denoising transition nested inside an action trajectory. The method keeps continuous multimodality but pays for multiple stochastic steps and more complex likelihood accounting.
+
+The experiments establish that policy gradients can work well with diffusion policies under the proposed recipe. A missing comparison equalizes wall-clock control rate and total denoising compute against flow and Gaussian actors. At ten times the action dimension or horizon, variance across denoising steps can dominate. The claim would fail if the same pretrained policy distilled to a simpler distribution reaches equal robustness with fewer interactions and lower latency.
+
+**Context:** DPPO is the technical reference for asking what “policy likelihood” means when actions come from a diffusion process.
+
+**Limits:** Simulator rewards and an augmented denoising MDP do not remove real-world reward and safety constraints.
+
+**Takeaway:** Apply RL to the distribution the policy actually samples from, not to an imagined Gaussian action head.

--- a/src/content/posts/kto-model-alignment-as-prospect-theoretic-optimization.md
+++ b/src/content/posts/kto-model-alignment-as-prospect-theoretic-optimization.md
@@ -1,0 +1,46 @@
+---
+title: 'KTO: Model Alignment as Prospect Theoretic Optimization'
+date: '2024-02-02T09:00:00.000Z'
+section: paper-shorts
+postSlug: kto-model-alignment-as-prospect-theoretic-optimization
+legacyPath: /paper shorts/2024/02/02/kto-model-alignment-as-prospect-theoretic-optimization.html
+tags:
+  - Alignment
+  - Preference Optimization
+field: 'Alignment & Post-Training'
+summary: 2024 – KTO learns from desirable and undesirable outputs without requiring paired preferences.
+---
+
+## 2024 – KTO: Model Alignment as Prospect Theoretic Optimization
+
+**arXiv:** [2402.01306](https://arxiv.org/abs/2402.01306)
+
+**GitHub:** [ContextualAI/HALOs](https://github.com/ContextualAI/HALOs)
+
+**Conference:** ICML 2024
+
+KTO asks whether alignment data must arrive as a chosen–rejected pair. It derives a human-aware loss from prospect theory and trains directly on binary judgments: an output was desirable or undesirable. That interface matters when feedback occurs naturally as approval, a safety flag, or a deployment failure rather than as two completions from the same prompt.
+
+## Paper Insights
+
+KTO measures each completion relative to a reference point estimated from the policy and reference model. Desirable examples receive a gain-shaped objective; undesirable examples receive a loss-shaped objective. The asymmetry encodes loss aversion, while a KL term keeps the policy from moving arbitrarily far from its reference.
+
+The paper places KTO, DPO, and PPO-style objectives inside a broader family called human-aware losses. Across 1B–30B language models, KTO matches or exceeds paired-preference methods in the reported comparisons despite using unpaired binary feedback. The result does not mean pairs are useless. It shows that a loss with the right inductive bias can extract value from a cheaper feedback interface.
+
+| Design choice | KTO's answer | Operational consequence |
+| --- | --- | --- |
+| Feedback unit | One prompt–response labeled desirable or undesirable | Logs and moderation outcomes can become training data without constructing pairs. |
+| Reference | Policy-relative utility with KL control | The reference distribution remains part of the method even without pairwise labels. |
+| Main comparison | Binary feedback versus preference pairs | Data interface and objective must be evaluated together. |
+
+## Decision Lens
+
+KTO informs whether a post-training program should pay to construct matched preference pairs or learn from independent positive and negative outcomes. Its atomic unit is a labeled completion, not a pair. For robotics, that maps naturally to successful and failed action chunks, but only if the label really reflects the action under the state in which it was taken.
+
+The experiments establish that binary feedback can be competitive in the studied language-model regime. They do not establish that KTO handles continuous actions, irreversible transitions, or highly imbalanced failure logs. A decisive robot-policy test would compare KTO-style binary optimization, correction SFT, and paired preferences under the same rollout and annotation budget. The claim would weaken if binary training improves logged desirability while closed-loop recovery and safety remain unchanged.
+
+**Context:** KTO is the clean bridge from paired language preferences to deployment signals that arrive one event at a time.
+
+**Limits:** The reference-point estimate, class balance, and mapping from token likelihood to physical action quality become new sources of error in VLA training.
+
+**Takeaway:** Use KTO when binary feedback is genuinely abundant; do not pretend that an unmatched failure and success form a counterfactual pair.

--- a/src/content/posts/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.md
+++ b/src/content/posts/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.md
@@ -1,0 +1,45 @@
+---
+title: 'LIBERO: Benchmarking Knowledge Transfer for Lifelong Robot Learning'
+date: '2023-06-05T09:00:00.000Z'
+section: paper-shorts
+postSlug: libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning
+legacyPath: /paper shorts/2023/06/05/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.html
+tags:
+  - Robotics
+  - Evaluation
+field: 'Robot Post-Training & Evaluation'
+summary: 2023 – LIBERO separates spatial, object, goal, and mixed knowledge transfer across 130 manipulation tasks.
+---
+
+## 2023 – LIBERO: Benchmarking Knowledge Transfer for Lifelong Robot Learning
+
+**arXiv:** [2306.03310](https://arxiv.org/abs/2306.03310)
+
+**Project:** [libero-project.github.io](https://libero-project.github.io/)
+
+LIBERO is a procedural benchmark for lifelong robot learning that distinguishes declarative knowledge—objects, layouts, goals—from procedural knowledge about how to act. It provides four suites and 130 language-conditioned manipulation tasks with teleoperated demonstrations.
+
+## Paper Insights
+
+LIBERO-Spatial, Object, and Goal each isolate a type of transfer across ten tasks; LIBERO-100 mixes them at larger scale. The benchmark also varies task order, policy architecture, lifelong-learning algorithm, and visual pretraining. Its initial experiments include counterintuitive results: sequential fine-tuning can beat specialized lifelong methods on forward transfer, and naive supervised pretraining can hurt later learning.
+
+The benchmark later became a common VLA scoreboard, which changes how its numbers should be read. High average success on fixed instructions and simulation states does not establish real-world robustness, paraphrase invariance, or recovery behavior.
+
+| Suite | Controlled transfer target |
+| --- | --- |
+| LIBERO-Spatial | Reuse of objects and skills across spatial relations |
+| LIBERO-Object | Behavior transfer across object identity |
+| LIBERO-Goal | Scene reuse under different goals |
+| LIBERO-100 | Entangled declarative and procedural variation |
+
+## Decision Lens
+
+LIBERO informs which knowledge transfer failures a post-training method fixes. Its atomic unit is a language-conditioned demonstration trajectory, but evaluation is closed-loop task success across controlled suite shifts. The procedural generator makes task families comparable while preserving repeatability.
+
+The benchmark establishes relative performance inside its simulator. At ten times the paper usage, saturation and tuning to the benchmark become larger risks than task difficulty. A missing test is cross-benchmark and real-robot rank correlation under unseen instruction phrasing. LIBERO ceases to be decision-useful if methods trade places under minor simulator, language, or controller changes.
+
+**Context:** LIBERO is the common substrate connecting OpenVLA-OFT, RIPT-VLA, and SimpleVLA-RL results.
+
+**Limits:** Fixed instruction templates and simulation physics leave major deployment shifts unmeasured.
+
+**Takeaway:** Treat LIBERO as a diagnostic suite of transfer types, not as a scalar definition of robot intelligence.

--- a/src/content/posts/libero-para-paraphrase-robustness-in-vla-models.md
+++ b/src/content/posts/libero-para-paraphrase-robustness-in-vla-models.md
@@ -1,0 +1,44 @@
+---
+title: 'LIBERO-Para: A Diagnostic Benchmark for Paraphrase Robustness in VLA Models'
+date: '2026-03-30T09:00:00.000Z'
+section: paper-shorts
+postSlug: libero-para-paraphrase-robustness-in-vla-models
+legacyPath: /paper shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html
+tags:
+  - Robotics
+  - Evaluation
+field: 'Robot Post-Training & Evaluation'
+summary: 2026 – LIBERO-Para exposes large VLA failures under controlled instruction paraphrases.
+---
+
+## 2026 – LIBERO-Para: A Diagnostic Benchmark for Paraphrase Robustness in VLA Models
+
+**arXiv:** [2603.28301](https://arxiv.org/abs/2603.28301)
+
+**GitHub:** [cau-hai-lab/LIBERO-Para](https://github.com/cau-hai-lab/LIBERO-Para)
+
+LIBERO-Para changes the instruction while holding the intended task fixed. It varies action expressions and object references independently, then measures whether a VLA's apparent language grounding survives phrasing that was absent from downstream fine-tuning.
+
+## Paper Insights
+
+Across seven VLA configurations from 0.6B to 7.5B parameters, the paper reports 22–52 percentage-point drops under paraphrasing. Object-level lexical substitutions drive much of the degradation, and 80–96% of failures arise from planning-level trajectory divergence rather than low-level execution. The policy often identifies the wrong task before motor control begins.
+
+The benchmark also introduces PRIDE, which models paraphrase difficulty using semantic and syntactic factors. That matters because average success can be dominated by easy rewordings and hide inconsistent grounding.
+
+| Variation | Diagnostic target |
+| --- | --- |
+| Action expression | Stable skill selection across “turn on,” “fire up,” and “activate” |
+| Object reference | Preservation of object identity under synonyms |
+| PRIDE difficulty | Success stability as linguistic distance grows |
+
+## Decision Lens
+
+LIBERO-Para informs whether a post-trained VLA learned task semantics or memorized the fine-tuning instruction surface. Its unit is a set of paraphrases mapped to one closed-loop task. Visual state and controller remain fixed so linguistic variation is the causal intervention.
+
+The results establish a large robustness gap in current configurations, but generated paraphrases may not match how real users speak. At ten times the language diversity, ambiguity and legitimate task reinterpretation complicate the oracle. The benchmark's claim would weaken if human-equivalent commands are not semantically interchangeable or if instruction augmentation closes LIBERO-Para without improving natural user interactions.
+
+**Context:** LIBERO-Para reveals a failure hidden by the original LIBERO protocol's identical train/eval instructions.
+
+**Limits:** Language robustness is only one axis; success can still hide visual or control shortcuts.
+
+**Takeaway:** A VLA has not grounded an instruction if a harmless paraphrase changes the plan.

--- a/src/content/posts/octo-an-open-source-generalist-robot-policy.md
+++ b/src/content/posts/octo-an-open-source-generalist-robot-policy.md
@@ -1,0 +1,44 @@
+---
+title: 'Octo: An Open-Source Generalist Robot Policy'
+date: '2024-05-20T09:00:00.000Z'
+section: paper-shorts
+postSlug: octo-an-open-source-generalist-robot-policy
+legacyPath: /paper shorts/2024/05/20/octo-an-open-source-generalist-robot-policy.html
+tags:
+  - Robotics
+  - Generalist Policies
+field: 'Vision-Language-Action & Robotics'
+summary: 2024 – Octo builds a modular open policy that adapts across observations, goals, and action spaces.
+---
+
+## 2024 – Octo: An Open-Source Generalist Robot Policy
+
+**arXiv:** [2405.12213](https://arxiv.org/abs/2405.12213)
+
+**Project:** [octo-models.github.io](https://octo-models.github.io/)
+
+Octo treats adaptation interfaces as part of the foundation-model design. A transformer policy pretrained on 800,000 Open X-Embodiment trajectories accepts language or goal-image tasks, supports flexible camera and proprioceptive inputs, and can be fine-tuned to new action spaces on consumer GPUs.
+
+## Paper Insights
+
+Octo uses tokenized observations and tasks but a diffusion action head, separating semantic/temporal representation from continuous action generation. Its modular tokenizers and readouts allow new sensors or controllers without rebuilding the backbone. Experiments across nine platforms study both out-of-the-box behavior and downstream adaptation.
+
+The model is an open research baseline rather than a claim of zero-shot universal control. The most useful contribution is inspectability: architecture, data, checkpoints, and adaptation code make it possible to test which priors transfer.
+
+| Interface | Octo design | Why it matters |
+| --- | --- | --- |
+| Task | Language or goal image | Supports semantic and visual goal conditioning. |
+| Observation | Modular camera/proprio tokens | New sensors can be added during adaptation. |
+| Action | Diffusion readout | Handles continuous multimodal trajectories. |
+
+## Decision Lens
+
+Octo informs whether a generalist policy should optimize for zero-shot breadth or for cheap, modular adaptation. Its atomic unit is a heterogeneous robot trajectory; shared transformer tokens carry task and observation context while the action readout remains control-specific.
+
+The experiments show that diverse pretraining can provide a useful initialization across nine platforms. A missing comparison would equalize pretraining compute and target demonstrations against per-robot policies and VLM-backed VLAs. At ten times the sensor/action interfaces, modularity may become a routing and configuration burden. The claim would fail if pretraining does not reduce target data or training time after controlling for architecture and optimizer.
+
+**Context:** Octo is the clean open baseline for studying what cross-embodiment pretraining buys during adaptation.
+
+**Limits:** A flexible interface cannot compensate for low-quality or incompatible pretraining trajectories.
+
+**Takeaway:** For robot foundation models, adaptation cost is a first-class metric—not an afterthought to zero-shot success.

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -1,80 +1,294 @@
 ---
-title: 'What Omni-Model Roles Are Really Testing'
+title: 'Omni-Model Pretraining: Zero to Hero'
 date: '2026-07-15T09:00:00.000Z'
 section: blog
 postSlug: omni-model-pretraining-decisions
 legacyPath: /blog/2026/07/15/omni-model-pretraining-decisions.html
 tags:
   - Multimodal AI
+  - Pretraining
   - Research Leadership
-summary: A preparation map for making architecture, data, systems, and action-model decisions in large multimodal training runs.
+summary: A paper-linked guide to representation, modality sharing, objectives, data mixtures, proxy scaling, video and action modeling, and reliable large-scale omni-model training.
 ---
 
-# What Omni-Model Roles Are Really Testing
+# Omni-Model Pretraining: Zero to Hero
 
-An omni-model role is not a memory test for multimodal papers. It is a test of whether you can make expensive technical decisions under uncertainty: what to share across modalities, which losses and datasets belong together, which small runs predict a large one, and how to keep a months-long training job healthy.
+An omni-model is easy to describe and expensive to specify. Put text, images, video, audio, and actions into one model; train at scale; expect transfer. Every clause hides a decision that can waste a major run.
 
-My background in vision-language-action systems, BEV representations, autonomous driving, and grounding points toward a useful thesis: preserve metric, temporally persistent entity representations for prediction and control, while letting a pretrained multimodal model provide open-vocabulary semantics and reasoning.
+Should an image be a sequence of discrete codes or a grid of continuous latents? Should understanding and generation share a tokenizer? Should video frames compete with text tokens in the same context window? Should actions use the language vocabulary, a frequency tokenizer, or a continuous expert? If a mixture works at 300M parameters, will it still work at 30B? If one modality's loss falls faster, is that positive transfer or gradient domination?
 
-## The architecture decision
+Pretraining leadership is the ability to reduce those questions to evidence before the full bill arrives.
 
-Four families cover most of the current design space.
+![Omni-model pretraining decision stack](/assets/images/omni-pretraining-decision-stack.svg)
+_The stack is coupled: representation changes sequence length, which changes systems cost, mixture economics, and the capabilities that can be measured._
 
-| Family | Representative papers | Core bet | Main risk |
+This guide follows the decisions in the order they should be made. Its companion, [Post-Training Vision-Language-Action Models: Zero to Hero](/blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html), starts where this one ends: a pretrained model enters deployment, produces failures, and must improve without losing its general capabilities.
+
+## 1. Define the capability contract before the architecture
+
+“Multimodal” is not a capability. A contrastive encoder, visual assistant, image generator, video predictor, and robot policy can all consume images and text while solving different problems.
+
+Write the contract as observable behavior:
+
+- retrieve and classify open-vocabulary concepts;
+- answer questions that require fine visual grounding;
+- generate images with controllable structure;
+- understand and generate temporally coherent video;
+- preserve state and action-conditioned consequences;
+- emit actions at a deployment control rate;
+- add a new modality without retraining every component.
+
+The contract determines what must be shared. [CLIP](/paper%20shorts/2021/02/28/learning-transferable-visual-models-from-natural-language-supervision.html) only needs image and text representations to meet in an embedding space. [LLaVA](/paper%20shorts/2023/04/01/visual-instruction-tuning-llava.html) needs visual tokens to enter a generative language model. [Chameleon](/paper%20shorts/2024/05/16/chameleon-mixed-modal-early-fusion-foundation-models.html) asks one autoregressive transformer to understand and generate mixed-modal sequences. [Transfusion](/paper%20shorts/2024/08/20/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.html) shares a transformer while giving text and images different objectives. [Pi0](/paper%20shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html) shares semantic context but gives continuous control a flow-based action expert.
+
+No architecture dominates those contracts for free.
+
+## 2. Representation is the first scaling law
+
+Before choosing transformer depth, decide what counts as one training unit.
+
+Text already arrives as compressed symbolic tokens. Images can be patches, contrastive features, discrete codes, or continuous latents. Video adds a temporal sampling policy on top of spatial compression. Actions can be per-dimension bins, chunks, frequency coefficients, diffusion trajectories, or flow samples.
+
+The unit determines sequence length:
+
+$$
+T_{total}
+=T_{text}+T_{image}+T_{video}+T_{audio}+T_{action}.
+$$
+
+Attention cost, context competition, batch composition, and loss weighting all inherit that choice.
+
+[ViT](/paper%20shorts/2020/10/01/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.html) made image patches look like tokens, but a 16×16 patch is not semantically equivalent to a wordpiece. [Qwen2-VL](/paper%20shorts/2024/09/01/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.html) lets visual-token count follow input resolution, preserving small text and document detail at variable cost. [DeepSeek-VL2](/paper%20shorts/2024/12/01/deepseek-vl2-mixture-of-experts-vision-language-models.html) combines dynamic tiling with sparse language capacity and latent attention to manage that cost.
+
+The first useful budget is therefore not “percentage of image data.” It is tokens or FLOPs per capability gain. A 10% video mixture can consume most of the compute if every clip expands into thousands of visual tokens.
+
+### Understanding and generation want different information
+
+Understanding rewards invariance. A classifier should ignore texture changes that preserve object identity. Generation punishes lost detail. A tokenizer optimized for semantic invariance can be a poor reconstruction code; a pixel-faithful code can waste sequence budget on information irrelevant to reasoning.
+
+[Janus](/paper%20shorts/2024/10/17/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.html) responds by separating the visual encoders for understanding and generation while sharing the transformer. [TokenFlow](/paper%20shorts/2024/12/04/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.html) uses dual codebooks linked by shared indices to preserve semantic and fine-grained information. [Transfusion](/paper%20shorts/2024/08/20/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.html) avoids discrete image generation and diffuses continuous patches through a shared trunk.
+
+Those designs are three answers to one question: where should modality specialization live?
+
+| Specialization boundary | Representative paper | What remains shared | Main risk |
 | --- | --- | --- | --- |
-| Discrete early fusion | [Chameleon](https://arxiv.org/abs/2405.09818), Emu3 | One token stream can model text, images, and video | Visual token budgets and cross-modal interference |
-| Hybrid autoregressive + diffusion/flow | [Transfusion](https://arxiv.org/abs/2408.11039), Show-o2 | Text and continuous visual generation need different objectives | Objective balancing and a more complicated serving path |
-| Shared transformer, separate visual routes | [Janus](https://arxiv.org/abs/2410.13848), [TokenFlow](https://arxiv.org/abs/2412.03069) | Understanding and generation require different visual information | More interfaces to train and maintain |
-| Shared trunk with modality experts | [Scaling Laws for Native Multimodal Models](https://arxiv.org/abs/2504.07951) | Preserve transfer while reducing representational conflict | Routing, utilization, and systems complexity |
+| None: one discrete stream | Chameleon | Token space, transformer, next-token loss | Visual compression and modality interference |
+| Separate visual encoders | Janus | Multimodal transformer | More interfaces and capacity accounting |
+| Dual-purpose tokenizer | TokenFlow | Token indices and downstream model | Coupled codebooks may fail under severe compression |
+| Modality-specific loss/I-O | Transfusion | Transformer blocks and cross-modal context | Loss balance and serving complexity |
 
-The question is not which paper wins a benchmark. Under a fixed compute, latency, and data budget, which design has the best expected return? A credible answer needs a small proxy run and a kill criterion for each proposal.
+The kill experiment is matched compute and matched sequence length. If separate routes win only because they add parameters or visual tokens, the result is capacity, not reduced interference.
 
-## A twelve-week preparation plan
+## 3. Sharing is a spectrum, not a binary choice
 
-### Weeks 1–2: map the architecture space
+Architectures often get labeled “early fusion” or “late fusion,” but the operational choices are more granular:
 
-Write an architecture decision memo. Compare representation, parameter sharing, objective, inference cost, sequence-length cost, interference, action extensibility, and expected failure modes. For every candidate, name the smallest experiment that would rule it out.
+- input tokenizer and embedding;
+- positional encoding;
+- attention and MLP blocks;
+- normalization parameters;
+- mixture-of-experts routing;
+- output head and loss;
+- optimizer state and learning-rate schedule.
 
-### Weeks 3–4: measure objective interference
+[Scaling Laws for Native Multimodal Models](/paper%20shorts/2025/04/10/scaling-laws-for-native-multimodal-models.html) finds no inherent late-fusion advantage in its studied regime. Early fusion is stronger at smaller scale and simpler to deploy, while modality-aware MoE parameters restore specialization inside a unified model. [Perceiver IO](/paper%20shorts/2021/07/30/perceiver-io-a-general-architecture-for-structured-inputs-and-outputs.html) offers a different compression principle: map large structured inputs into a fixed latent bottleneck, process there, and query structured outputs.
 
-Build a 100M–1B parameter prototype with text next-token prediction, image-text understanding, image reconstruction or generation, and a lightweight video or action objective. Aggregate loss is not enough. Track per-objective loss, gradient norms, pairwise gradient cosine similarity, parameter-update norms, throughput, and transfer to each evaluation.
+The right sharing boundary depends on whether gradients agree. Build an objective-interaction matrix rather than arguing from intuition:
 
-The deliverable is an objective-interaction matrix: every cell says whether one objective helps, hurts, or leaves another unchanged. [MM1](https://arxiv.org/abs/2403.09611) is especially useful because it separates the influence of image encoder, resolution, visual-token count, connector design, and data mixture.
+| Add this objective ↓ / measure this capability → | Text | VLM | Image generation | Video | Action |
+| --- | --- | --- | --- | --- | --- |
+| Text next-token prediction | — | ? | ? | ? | ? |
+| Image–text understanding | ? | — | ? | ? | ? |
+| Image generation | ? | ? | — | ? | ? |
+| Video prediction | ? | ? | ? | — | ? |
+| Action prediction | ? | ? | ? | ? | — |
 
-### Weeks 5–6: fit a mixture model
+Every cell should report transfer under a matched compute budget, along with gradient cosine similarity, per-objective gradient norm, update norm by module, and throughput. A lower joint loss does not imply that any downstream capability improved.
 
-Treat data allocation as a prediction problem. Vary model size $N$, compute $C$, data volume $D$, modality mixture $h$, visual compression, video duration, context length, and shared versus expert capacity. A useful starting form is:
+This is where [MM1](/paper%20shorts/2024/03/14/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.html) is so useful. Its controlled studies suggest that image encoder quality, resolution, visual-token count, and data composition matter more than endlessly modifying the connector. That is an experiment-allocation result: sweep the variables with large causal leverage before polishing the bridge between them.
+
+## 4. One model can use several losses
+
+A unified transformer does not require a unified objective.
+
+Text commonly uses next-token cross-entropy:
 
 $$
-L_m(N,D,h)=E_m+A_mN^{-\alpha_m}+B_mD_m^{-\beta_m}+I_m(h,N,D),
+\mathcal{L}_{text}
+=-\sum_t\log p_\theta(x_t\mid x_{<t}).
 $$
 
-where $I_m$ represents cross-modal synergy or interference. Report confidence intervals and ranking stability under extrapolation; do not present one allocation as a fact. [Scaling Laws for Optimal Data Mixtures](https://arxiv.org/abs/2507.09404) provides the right mindset: use a small set of runs to estimate a policy for larger budgets.
+Contrastive understanding uses paired image–text scores. [SigLIP](/paper%20shorts/2023/10/01/sigmoid-loss-for-language-image-pre-training-siglip.html) replaces batch-softmax competition with independent sigmoid pair losses, reducing dependence on enormous synchronized negative sets. Diffusion or flow predicts noise, velocity, or a vector field over a sampled time. Robot imitation may use token CE, L1 action error, denoising, or flow matching.
 
-### Weeks 7–8: distinguish video from a world model
+A joint objective looks simple:
 
-Video generation produces plausible futures. A world model preserves action-conditioned consequences. A policy chooses actions to achieve an outcome. Those are related, but not interchangeable, capabilities.
+$$
+\mathcal{L}=\sum_m \lambda_m\,\mathcal{L}_m,
+$$
 
-Study [Wan](https://arxiv.org/abs/2503.20314) for video-generation engineering and [Genie](https://arxiv.org/abs/2402.15391) for latent actions in an interactive generative environment. Evaluate controllability, state persistence, causal response to actions, geometry, object permanence, and long-horizon consistency—not only visual quality. Then compare direct regression, discretization, frequency-space tokens, diffusion or flow heads, and separate action experts. [pi0](https://arxiv.org/abs/2410.24164) and [FAST](https://arxiv.org/abs/2501.09747) make that comparison concrete.
+but $\lambda_m$ is not merely a hyperparameter. Losses average over different units. One image example may contribute hundreds of patches, one video contributes many frames, and one robot episode contributes many correlated action steps. The apparent balance changes with sequence packing, mask count, and gradient accumulation.
 
-### Weeks 9–10: make the run recoverable
+Normalize and log at three levels:
 
-Knowing a parallelism acronym is not a reliability plan. Design the checkpoint cadence, restart-time objective, health dashboards, online data-quality checks, and escalation ownership for a large run. [TorchTitan](https://arxiv.org/abs/2410.06511) is a practical systems reference because it composes parallelism, checkpointing, logging, and debugging tools.
+1. per predicted unit—token, patch, frame, denoising target, or action dimension;
+2. per example or trajectory, so long examples do not silently dominate;
+3. per consumed FLOP, so an expensive modality has to justify its share.
 
-For loss spikes, NaNs, FP8 range errors, expert imbalance, modality dominance, corrupt shards, dataloader stalls, network stragglers, checkpoint corruption, and evaluation regressions, define a detection metric, automatic intervention, rollback rule, root-cause diagnostic, and prevention mechanism.
+Then measure parameter-level conflict. If video gradients are ten times larger in shared attention blocks, a small sampling share can still control the update. If text loss falls while VLM transfer regresses, aggregate convergence is hiding interference.
 
-### Weeks 11–12: turn reading into direction
+## 5. Data mixture is a policy over scarce compute
 
-Propose three bets for the next six months:
+An omni corpus is not a pile of datasets. It is a sampling policy over modalities, domains, quality levels, sequence lengths, and training stages.
 
-1. Modality-specific input and output experts around a shared transformer reduce conflict at fixed inference FLOPs.
-2. Small proxy runs can predict useful text, image, video, and action allocations better than hand-selected mixtures.
-3. Entity-grounded latent-state prediction improves long-horizon action consistency more than scaling unconditional video generation alone.
+[Scaling Laws for Generative Mixed-Modal Language Models](/paper%20shorts/2023/01/10/scaling-laws-for-generative-mixed-modal-language-models.html) adds an interaction term to unimodal scaling so proxy runs can estimate synergy or competition between modalities. [Scaling Laws for Optimal Data Mixtures](/paper%20shorts/2025/07/12/scaling-laws-for-optimal-data-mixtures.html) treats mixture weights as variables in a fitted loss surface conditioned on model size and total data. The useful form is not one universal law but a family of target-specific predictions:
 
-Each bet needs a capability target, compute and data requirements, a three-month evidence milestone, a kill criterion, an alternative path, and named infrastructure dependencies.
+$$
+L_m(N,D,h)
+=E_m+A_mN^{-\alpha_m}+B_mD_m^{-\beta_m}+I_m(h,N,D),
+$$
 
-## Reading order
+where $h$ is the mixture and $I_m$ captures transfer or interference.
 
-The accompanying `Omni-Models` paper section contains the architecture, scaling, video, world-model, and systems set: MM1; Chameleon; Transfusion; Janus; TokenFlow; the native multimodal and data-mixture scaling-law papers; Wan; Genie; and TorchTitan. [pi0](/paper%20shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html) and [FAST](/paper%20shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html) already belong in the Robotics and VLA reading path, so their existing notes remain in those fields.
+The word “target” matters. A mixture optimal for image generation may be wrong for OCR, video reasoning, or action grounding. There is no context-free optimal dataset.
 
-For each paper, answer the same questions: what expensive decision does it inform; what is the training unit; what is shared; how are losses and data balanced; what does the scaling curve establish; what ablation is missing; and what would fail at ten times the scale? That turns a reading list into technical judgment.
+The proxy study should vary:
+
+- model size $N$ and total compute;
+- total examples and effective unique examples;
+- modality/domain weights $h$;
+- image and video compression;
+- frame rate, clip duration, and context length;
+- shared versus expert capacity;
+- curriculum order and learning-rate resets.
+
+Report uncertainty on extrapolated rankings, not only fitted loss. The expensive decision is whether candidate A will still beat candidate B at target scale. If confidence intervals overlap, the proxy run did not justify a nine-figure allocation.
+
+### Curriculum changes the interaction
+
+Data mixtures are often nonstationary. A model may first learn vision-language alignment, then high-resolution grounding, then video, then action. [VideoLLaMA 3](/paper%20shorts/2025/01/01/videollama-3-frontier-multimodal-foundation-models.html) uses strong image-text alignment as the base for video and compresses redundant temporal tokens. [PaliGemma](/paper%20shorts/2024/07/10/paligemma-a-versatile-3b-vlm-for-transfer.html) upcycles resolution in stages. [Eagle 2](/paper%20shorts/2025/01/01/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.html) shows how post-training ordering and curation can make a smaller VLM competitive.
+
+Order can reduce optimization difficulty, but it can also cause forgetting. A staged curriculum needs retention evals after every transition and a controlled comparison with an interleaved mixture under equal compute.
+
+## 6. Video is not automatically a world model
+
+Video generation produces plausible futures. A world model preserves action-conditioned consequences. A policy chooses actions that achieve an outcome.
+
+That distinction is easy to state and easy to ignore when generated video looks good.
+
+[Wan](/paper%20shorts/2025/03/26/wan-open-and-advanced-large-scale-video-generative-models.html) is the systems reference for large-scale latent video generation: spatial/temporal VAE compression, caption and motion filtering, model-size tradeoffs, and a consumer-scale 1.3B variant. [Genie](/paper%20shorts/2024/02/23/genie-generative-interactive-environments.html) learns latent actions from unlabeled video and conditions a dynamics model on those actions.
+
+The evaluation contract must change when control enters. FID and visual preference are not enough. Measure:
+
+- action controllability and intervention consistency;
+- object permanence and state persistence;
+- geometry and contact plausibility;
+- temporal order and causal response;
+- rollout stability under repeated model predictions;
+- whether the learned latent action means the same thing across scenes.
+
+A model that produces a plausible door opening after any action is a video generator with weak conditioning, not a useful world model.
+
+## 7. Actions expose the limits of modality symmetry
+
+Actions are not just another token type. They change the data distribution, carry embodiment-specific units, and operate under a control deadline.
+
+[RT-2](/paper%20shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html) shows the appeal of treating actions as language tokens: one decoder, tractable autoregression, and direct transfer from semantic pretraining. [FAST](/paper%20shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html) compresses action chunks in frequency space so high-frequency trajectories do not explode sequence length. [Pi0](/paper%20shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html) uses a continuous flow expert instead of forcing actions through the text head.
+
+The action-interface memo should compare:
+
+| Choice | Likelihood | Multimodality | Latency | Main failure |
+| --- | --- | --- | --- | --- |
+| Direct regression | Explicit/simple | Weak | Low | Mode averaging |
+| Discrete tokens | Exact autoregressive | Moderate | Sequential | Quantization and slow chunks |
+| Frequency tokens | Exact autoregressive | Moderate | Shorter sequence | Loses abrupt corrections |
+| Diffusion/flow | Implicit or path-based | Strong | Iterative/parallel | Complex post-training likelihood |
+| Separate action expert | Interface-dependent | Strong | Extra serving path | Semantic/control coordination |
+
+The pretraining question is which action prior should be learned across robots. The post-training question is whether that distribution exposes the likelihoods and responsiveness required by the improvement loop.
+
+## 8. Scaling evidence needs a falsification boundary
+
+A smooth curve is not the same as a causal law. Every scaling claim should name:
+
+- the fitted range of model size, data, and compute;
+- the architecture and tokenizer held fixed;
+- the target loss or capability measured;
+- the data quality assumptions;
+- the residuals and confidence interval;
+- the scale jump being extrapolated;
+- the experiment that would make the recommendation reverse.
+
+The most dangerous extrapolation assumes the bottleneck stays fixed. At small scale, parameters may dominate. At larger scale, unique high-quality video, long-context communication, tokenizer distortion, or evaluation contamination may take over. A modality interaction measured with one representation may disappear when compression changes.
+
+For every candidate architecture, write a kill criterion before the proxy runs:
+
+- **Discrete early fusion:** kill if visual-token cost grows faster than capability at matched FLOPs.
+- **Hybrid objectives:** kill if loss balancing is unstable or serving complexity buys no capability.
+- **Separate visual routes:** kill if gains disappear under parameter- and token-matched controls.
+- **Modality experts:** kill if routing imbalance and communication erase active-parameter efficiency.
+- **Action-conditioned world model:** kill if interventions do not produce consistent causal changes.
+
+That habit converts paper reading into capital allocation.
+
+## 9. A large run is a fault-tolerant system
+
+Once the architecture and mixture are chosen, the research question becomes operational: can the training system preserve the intended experiment for months?
+
+[TorchTitan](/paper%20shorts/2024/10/09/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.html) is useful because it treats tensor, pipeline, and data parallelism, checkpointing, compilation, and logging as composable parts of one PyTorch-native stack. The throughput number matters, but restart time and diagnostic quality matter more when a failed run costs days.
+
+The runbook should cover:
+
+| Failure | Detection | Automatic response | Root-cause evidence |
+| --- | --- | --- | --- |
+| Sudden loss spike | Per-modality loss and gradient outlier | Skip/rollback and quarantine batch | Data IDs, optimizer state, activation stats |
+| Slow degradation | Eval residual versus scaling prediction | Pause curriculum transition | Mixture, LR, norm and update trends |
+| NaN/FP8 range failure | Non-finite tensors and amax history | Reduce scale, reload safe checkpoint | First offending layer/rank |
+| MoE imbalance | Expert load and dropped-token rate | Adjust routing/capacity | Modality-by-expert traffic |
+| Modality domination | Gradient/update share by module | Reweight or resample | Per-objective norms and cosine similarity |
+| Corrupt video shard | Decode and temporal-integrity checks | Quarantine shard | Source and preprocessing lineage |
+| Dataloader/network stall | Step-time decomposition | Replace worker/rank | Host, shard, topology, retry logs |
+| Eval regression | Capability dashboard | Block checkpoint promotion | Data/architecture changes since last good point |
+
+Every checkpoint must bind model state to optimizer, scheduler, data cursor, mixture policy, tokenizer, code commit, and evaluation config. A weight file without that lineage is not a recoverable experiment.
+
+## 10. The minimum convincing proxy program
+
+Before a massive run, build a 100M–1B prototype program with at least text prediction, image-text understanding, visual generation, and a lightweight video or action objective.
+
+Run three layers of experiments:
+
+1. **Representation sweep:** image/video compression, visual tokens, action interface, shared versus separate encoders.
+2. **Interaction sweep:** mixture weights, loss normalization, gradient conflict, curriculum order.
+3. **Scaling sweep:** several model and data sizes with held-out capability evaluations and confidence intervals.
+
+The deliverables should be decision artifacts:
+
+- an architecture memo with matched-budget alternatives;
+- an objective-interaction matrix;
+- a fitted mixture model with uncertainty;
+- a throughput and memory model by modality;
+- a failure playbook and restart objective;
+- a capability dashboard with kill criteria.
+
+Do not present one mixture such as “45% text, 25% image-text, 10% image generation, 15% video, 5% action” as a universal answer. Present how that allocation was estimated, which target it optimizes, how uncertainty changes the ranking, and what evidence triggers a new allocation.
+
+## 11. Reading path: broad map to literature depth
+
+**Layer 1: representation foundations.** Read [ViT](/paper%20shorts/2020/10/01/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.html), [CLIP](/paper%20shorts/2021/02/28/learning-transferable-visual-models-from-natural-language-supervision.html), [SigLIP](/paper%20shorts/2023/10/01/sigmoid-loss-for-language-image-pre-training-siglip.html), and [LLaVA](/paper%20shorts/2023/04/01/visual-instruction-tuning-llava.html). Track the training unit and the visual information each interface preserves.
+
+**Layer 2: unified architecture families.** Read [Chameleon](/paper%20shorts/2024/05/16/chameleon-mixed-modal-early-fusion-foundation-models.html), [Transfusion](/paper%20shorts/2024/08/20/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.html), [Janus](/paper%20shorts/2024/10/17/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.html), [TokenFlow](/paper%20shorts/2024/12/04/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.html), and [Native Multimodal Scaling Laws](/paper%20shorts/2025/04/10/scaling-laws-for-native-multimodal-models.html). For each, mark exactly where parameters and objectives split.
+
+**Layer 3: experimental allocation.** Read [MM1](/paper%20shorts/2024/03/14/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.html), [Generative Mixed-Modal Scaling](/paper%20shorts/2023/01/10/scaling-laws-for-generative-mixed-modal-language-models.html), and [Optimal Data Mixtures](/paper%20shorts/2025/07/12/scaling-laws-for-optimal-data-mixtures.html). Reconstruct which curve is measured, which is extrapolated, and which control is missing.
+
+**Layer 4: video, worlds, and actions.** Read [Wan](/paper%20shorts/2025/03/26/wan-open-and-advanced-large-scale-video-generative-models.html), [Genie](/paper%20shorts/2024/02/23/genie-generative-interactive-environments.html), [FAST](/paper%20shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html), and [Pi0](/paper%20shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html). Ask whether the representation preserves causality or only appearance.
+
+**Layer 5: systems.** Read [TorchTitan](/paper%20shorts/2024/10/09/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.html) with an operator's eye: what fails, what is checkpointed, what is measured, and which parallelism choice changes the research experiment?
+
+Then move to the [post-training companion](/blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html). Pretraining decides what the model can represent and how cheaply it can learn. Post-training decides whether those priors survive contact with deployment.
+
+## The research thesis
+
+The strongest omni model will probably not be the one that makes every modality identical. It will share the parameters that benefit from transfer and specialize the interfaces where invariance, fidelity, time, and control impose genuinely different requirements.
+
+My preferred starting hypothesis is a shared transformer with modality-specific input/output experts, explicit per-objective accounting, and a data mixture chosen by proxy scaling rather than intuition. For physical intelligence, I would preserve metric, temporally persistent entity representations alongside open-vocabulary semantics. The generative model can imagine; the world model must preserve consequences; the policy must act; and the training system must reveal when one capability is improving at another's expense.
+
+That is what “zero to hero” means in pretraining: not knowing every paper, but knowing how to turn a literature map into an experiment plan, a compute allocation, a kill decision, and a run that can survive long enough to answer the question.

--- a/src/content/posts/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.md
+++ b/src/content/posts/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.md
@@ -1,0 +1,44 @@
+---
+title: 'Open X-Embodiment: Robotic Learning Datasets and RT-X Models'
+date: '2023-10-13T09:00:00.000Z'
+section: paper-shorts
+postSlug: open-x-embodiment-robotic-learning-datasets-and-rt-x-models
+legacyPath: /paper shorts/2023/10/13/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.html
+tags:
+  - Robotics
+  - Data
+field: 'Vision-Language-Action & Robotics'
+summary: 2023 – Open X-Embodiment standardizes heterogeneous robot datasets and studies cross-robot transfer.
+---
+
+## 2023 – Open X-Embodiment: Robotic Learning Datasets and RT-X Models
+
+**arXiv:** [2310.08864](https://arxiv.org/abs/2310.08864)
+
+**Project:** [robotics-transformer-x.github.io](https://robotics-transformer-x.github.io/)
+
+Open X-Embodiment asks whether robotics can build a shared pretraining corpus despite incompatible robots, cameras, action spaces, and collection procedures. The collaboration standardizes data from 22 embodiments and 21 institutions, covering 527 skills and more than a million episodes in later releases.
+
+## Paper Insights
+
+RT-X models trained on the mixture show positive transfer across several robots. The result makes dataset diversity a reusable asset, but standardization does not erase embodiment mismatch. A delta end-effector command, joint target, and mobile-base action can share a schema while retaining different physical meanings.
+
+The paper's deeper contribution is infrastructural: data format, task language, mixture sampling, and evaluation must be designed together. Without per-dataset balancing, the largest source becomes the de facto objective. Without embodiment metadata, the policy cannot distinguish different control conventions.
+
+| Heterogeneity | What must be normalized | What should remain explicit |
+| --- | --- | --- |
+| Sensors | Shapes, timestamps, calibration records | Viewpoint and missing modalities |
+| Actions | Common trajectory container | Embodiment-specific semantics and scale |
+| Tasks | Language or goal interface | Collection policy and success definition |
+
+## Decision Lens
+
+Open X-Embodiment informs whether to spend the next robot-data budget inside one platform or on a mixture that may transfer across platforms. Its atomic unit is a standardized trajectory, while the meaningful curriculum is the distribution over datasets, tasks, and embodiments.
+
+The RT-X results establish positive transfer for part of the mixture, not universal benefit from every dataset. The missing experiment is a full leave-one-embodiment-out matrix normalized by trajectory quality and sampling weight. At ten times the sources, hidden controller, timing, and annotation differences become dominant. The foundation-data claim fails if adding embodiments improves average benchmarks but increases adaptation data or harms safety on a target robot.
+
+**Context:** Open X-Embodiment supplies the data substrate used by Octo, OpenVLA, and later generalist policies.
+
+**Limits:** Dataset scale counts episodes more easily than it measures coverage, quality, or recoveries.
+
+**Takeaway:** Cross-robot data becomes transferable only when the schema preserves the differences that matter for control.

--- a/src/content/posts/openvla-oft-optimizing-speed-and-success.md
+++ b/src/content/posts/openvla-oft-optimizing-speed-and-success.md
@@ -1,0 +1,44 @@
+---
+title: 'Fine-Tuning Vision-Language-Action Models: Optimizing Speed and Success (OpenVLA-OFT)'
+date: '2025-02-27T09:00:00.000Z'
+section: paper-shorts
+postSlug: openvla-oft-optimizing-speed-and-success
+legacyPath: /paper shorts/2025/02/27/openvla-oft-optimizing-speed-and-success.html
+tags:
+  - Robotics
+  - Fine-Tuning
+field: 'Vision-Language-Action & Robotics'
+summary: 2025 – OpenVLA-OFT replaces slow autoregressive action tokens with fast continuous parallel chunks.
+---
+
+## 2025 – Fine-Tuning Vision-Language-Action Models: Optimizing Speed and Success
+
+**arXiv:** [2502.19645](https://arxiv.org/abs/2502.19645)
+
+**Project:** [openvla-oft.github.io](https://openvla-oft.github.io/)
+
+OpenVLA-OFT shows that the fine-tuning interface can matter more than preserving a VLA's pretraining objective. It replaces autoregressive discrete action-token decoding with parallel continuous action chunks and trains them with a simple L1 regression loss.
+
+## Paper Insights
+
+The paper ablates three coupled decisions: serial versus parallel decoding, discrete versus continuous actions, and next-token versus regression/diffusion objectives. The resulting recipe raises OpenVLA's reported LIBERO average from 76.5% to 97.1% and increases action-generation throughput by 26×. In real ALOHA evaluations it supports higher-frequency bimanual control and beats the compared default VLA recipes and from-scratch imitation policies.
+
+The surprising result is that a simple L1 head can match diffusion fine-tuning in the studied setting. Pretrained semantics remain useful even when the action interface and training loss change completely.
+
+| Adaptation choice | OFT selection | Reason |
+| --- | --- | --- |
+| Decoding | Parallel action chunks | Removes sequential token latency. |
+| Representation | Continuous actions | Avoids quantization error. |
+| Objective | L1 regression | Fast convergence and inference in the tested tasks. |
+
+## Decision Lens
+
+OpenVLA-OFT informs which parts of a pretrained VLA should be treated as reusable semantics and which should be replaced for deployment. Its unit is an observation paired with a continuous action chunk. The VLM backbone is shared; the action head abandons the language-token interface.
+
+The results establish a strong speed–success recipe on LIBERO and ALOHA, not universal superiority of L1 regression. A missing stress test varies multimodality, perturbation frequency, and chunk length at equal control rate. At ten times the behavioral ambiguity, L1 can average valid modes. The recipe would fail if a diffusion or flow head wins consistently once tasks require multiple precise strategies rather than one dominant trajectory.
+
+**Context:** OpenVLA-OFT is the practical SFT baseline that later RL post-training papers improve.
+
+**Limits:** Near-saturated LIBERO success leaves little room to measure robustness and recovery.
+
+**Takeaway:** Reuse the representation, not necessarily the pretraining decoder; control latency can justify a different action objective.

--- a/src/content/posts/pi0-5-vision-language-action-model-with-open-world-generalization.md
+++ b/src/content/posts/pi0-5-vision-language-action-model-with-open-world-generalization.md
@@ -1,0 +1,45 @@
+---
+title: 'Pi0.5: A Vision-Language-Action Model with Open-World Generalization'
+date: '2025-04-22T09:00:00.000Z'
+section: paper-shorts
+postSlug: pi0-5-vision-language-action-model-with-open-world-generalization
+legacyPath: /paper shorts/2025/04/22/pi0-5-vision-language-action-model-with-open-world-generalization.html
+tags:
+  - Robotics
+  - Vision-Language-Action
+field: 'Vision-Language-Action & Robotics'
+summary: 2025 – Pi0.5 co-trains web semantics, high-level subtasks, and continuous actions for new-home generalization.
+---
+
+## 2025 – Pi0.5: A Vision-Language-Action Model with Open-World Generalization
+
+**arXiv:** [2504.16054](https://arxiv.org/abs/2504.16054)
+
+**Project:** [Physical Intelligence](https://www.pi.website/blog/pi05)
+
+Pi0.5 extends Pi0 by co-training a VLM/action policy on heterogeneous examples: web vision-language tasks, object detection, language instructions, high-level subtask predictions, and low-level trajectories from multiple robots. The hierarchy remains inside one model: language predicts useful intermediate goals while a flow-based action expert controls the robot.
+
+## Paper Insights
+
+The paper targets long-horizon generalization rather than isolated tabletop skills. It reports mobile manipulation in entirely new homes, including kitchen and bedroom cleanup tasks lasting 10–15 minutes. Ablations attribute that behavior to heterogeneous co-training and semantic subtask prediction, not simply more robot episodes.
+
+The architecture separates time scales. High-level tokens express what should happen next; continuous action chunks express how. This reduces the burden on low-level control to remember an entire household task, but subtask errors can still compound and are difficult to correct without feedback.
+
+| Data/interface | Knowledge contributed |
+| --- | --- |
+| Web image–text and detection | Open-world semantics and object grounding |
+| High-level subtask prediction | Long-horizon decomposition |
+| Multi-robot trajectories | Embodied control priors |
+| Flow action expert | Smooth continuous action chunks |
+
+## Decision Lens
+
+Pi0.5 informs whether long-horizon generalization should come from a monolithic low-level policy or heterogeneous co-training with an explicit semantic time scale. Its units range from web tokens to action chunks; the backbone shares representations while the action expert specializes continuous control.
+
+The demonstrations establish compelling open-world behavior, but the private mixture makes contribution accounting difficult. A missing ablation matches robot hours, web data, and subtask labels against a hierarchical two-model baseline. At ten times the horizon, subtask drift and error recovery become the bottleneck. The central claim weakens if the policy succeeds only when high-level predictions follow familiar household scripts or if a planner/action decomposition recovers more reliably.
+
+**Context:** Pi0.5 shows why VLA post-training cannot be reduced to one loss: semantic retention, task decomposition, and motor adaptation interact.
+
+**Limits:** Few public details allow exact reproduction of mixture weights and data quality.
+
+**Takeaway:** Heterogeneous co-training is useful when each data type owns a time scale and the system can measure transfer between them.

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -1,0 +1,276 @@
+---
+title: 'Post-Training Vision-Language-Action Models: Zero to Hero'
+date: '2026-07-16T10:00:00.000Z'
+section: blog
+postSlug: post-training-vision-language-action-models-zero-to-hero
+legacyPath: /blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html
+tags:
+  - Robotics
+  - Post-Training
+  - Reinforcement Learning
+summary: A paper-linked guide to turning a pretrained VLA into a closed-loop policy improvement system through SFT, failure mining, preference learning, RL, critics, and real evaluation.
+---
+
+# Post-Training Vision-Language-Action Models: Zero to Hero
+
+The shortest description of post-training is “make a pretrained model behave better.” That description is harmless for a chatbot and dangerous for a robot. A robot's output changes the next input. It can enter states absent from the training data, make an irreversible contact, recover from its own mistake, or create a failure that an offline dataset never contained.
+
+The right object is therefore not an optimizer. It is a closed-loop policy improvement system:
+
+> Base VLA → task SFT → deployment rollouts → failure mining → preference or reward supervision → policy optimization → real evaluation → redeployment.
+
+The loop is the product. SFT, DPO, PPO, critics, and distillation are replaceable components inside it.
+
+![Closed-loop VLA post-training system](/assets/images/vla-post-training-closed-loop.svg)
+_A VLA improves only when deployment failures become correctly attributed supervision and survive independent evaluation._
+
+This guide builds that system from first principles. It assumes familiarity with the companion [Omni-Model Pretraining: Zero to Hero](/blog/2026/07/15/omni-model-pretraining-decisions.html), which covers how representation, sharing, data mixtures, scaling, and run health create the base model that post-training inherits.
+
+## 1. What pretraining gives you—and what it does not
+
+A modern VLA begins with two useful priors. Vision-language pretraining supplies objects, concepts, instructions, and scene semantics. Robot pretraining supplies a distribution over physically plausible behavior. [RT-2](/paper%20shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html) demonstrates the first transfer by expressing actions in the language-token interface. [Open X-Embodiment](/paper%20shorts/2023/10/13/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.html), [Octo](/paper%20shorts/2024/05/20/octo-an-open-source-generalist-robot-policy.html), and [OpenVLA](/paper%20shorts/2024/06/01/openvla-open-source-vision-language-action-model.html) make the second transfer concrete across heterogeneous robot data.
+
+Neither prior guarantees that the deployed policy occupies familiar states. [DAgger](/paper%20shorts/2011/04/11/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.html) explains the mathematical reason. In sequential prediction, an error changes the next observation. A small supervised error under the expert distribution can compound over the horizon because the learner visits states the expert never visited.
+
+This is the first mental model to keep:
+
+> Supervised fine-tuning learns what to do in the states represented by its data. Interactive post-training changes which states become data.
+
+That difference is why another million successful demonstrations may be worth less than ten thousand carefully selected recoveries.
+
+## 2. SFT is a family of decisions, not one loss
+
+For an autoregressive action-token policy, supervised fine-tuning often looks like:
+
+$$
+\mathcal{L}_{\text{SFT}}
+=-\mathbb{E}_{(o,\ell,a)\sim\mathcal{D}}
+\left[\sum_t \log \pi_\theta(a_t\mid o_{\le t},\ell,a_{<t})\right].
+$$
+
+The equation hides most of the engineering. What is $a_t$? A scalar joint bin, a whole action chunk, a diffusion denoising target, or a continuous regression vector? How much observation history is available? Does the policy act at 3 Hz or 50 Hz? Does it predict one step, replan a receding horizon, or temporally ensemble overlapping chunks?
+
+The literature is best read as a sequence of action-interface decisions:
+
+| Interface | Representative paper | What it buys | What it makes harder |
+| --- | --- | --- | --- |
+| Discrete action tokens | [RT-1](/paper%20shorts/2022/12/13/rt-1-robotics-transformer-for-real-world-control-at-scale.html), [RT-2](/paper%20shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html) | One autoregressive interface and tractable token likelihoods | Quantization and sequential latency |
+| Transformer action chunks | [ACT](/paper%20shorts/2023/04/23/action-chunking-with-transformers-act.html) | Temporal coherence and a shorter effective horizon | Reduced response to disturbances inside the chunk |
+| Diffusion trajectories | [Diffusion Policy](/paper%20shorts/2023/03/07/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.html) | Multimodal continuous actions | Iterative sampling and complex RL likelihoods |
+| Frequency-domain tokens | [FAST](/paper%20shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html) | Compact autoregressive trajectories | Compression can remove sharp corrections |
+| Flow action expert | [Pi0](/paper%20shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html) | Smooth continuous chunks alongside VLM semantics | Separate expert and sampling path |
+| Parallel continuous chunks | [OpenVLA-OFT](/paper%20shorts/2025/02/27/openvla-oft-optimizing-speed-and-success.html) | High-throughput control with simple L1 tuning | Regression can average genuinely multimodal actions |
+
+[OpenVLA-OFT](/paper%20shorts/2025/02/27/openvla-oft-optimizing-speed-and-success.html) is the sharpest warning against copying the pretraining loss into adaptation. Its parallel continuous chunks and L1 objective improve both speed and success over OpenVLA's original autoregressive tokens. The model retains pretrained semantics while replacing the action interface.
+
+[Pi0.5](/paper%20shorts/2025/04/22/pi0-5-vision-language-action-model-with-open-world-generalization.html) adds another axis: high-level semantic subtask prediction. Long-horizon household behavior becomes easier when language handles what should happen next and a continuous expert handles how. The cost is a new failure boundary. A wrong subtask can send a perfect low-level controller toward the wrong goal.
+
+The SFT baseline should therefore be an adaptation matrix, not one run:
+
+- frozen VLM versus joint tuning;
+- full tuning versus LoRA;
+- single actions versus several chunk lengths;
+- discrete, L1, diffusion, and flow action heads;
+- successful demonstrations only versus successes plus interventions and recoveries;
+- per-task adapter versus shared multi-task adapter.
+
+Measure success, robot-data efficiency, control frequency, latency, forgetting, and semantic retention together. A policy that succeeds 3% more often but halves the control rate may be worse before the first rollout.
+
+## 3. Language-model post-training supplies tools, not a recipe
+
+The classic language pipeline is documented by [InstructGPT](/paper%20shorts/2022/02/28/training-language-models-to-follow-instructions-with-human-feedback.html): supervised fine-tuning, a Bradley–Terry preference model, then [PPO](/paper%20shorts/2017/07/01/proximal-policy-optimization-ppo.html) against the learned reward with a KL penalty. [DPO](/paper%20shorts/2023/05/01/direct-preference-optimization-dpo.html) removes the explicit reward model and expresses the KL-regularized optimum directly through chosen and rejected responses.
+
+For a matched prompt $x$ and preference $y^+\succ y^-$, DPO optimizes a logistic margin between policy and reference log-ratios:
+
+$$
+\mathcal{L}_{\text{DPO}}
+=-\mathbb{E}\log\sigma\left(
+\beta\left[
+\log\frac{\pi_\theta(y^+\mid x)}{\pi_{\text{ref}}(y^+\mid x)}
+-\log\frac{\pi_\theta(y^-\mid x)}{\pi_{\text{ref}}(y^-\mid x)}
+\right]
+\right).
+$$
+
+This is elegant because both responses share the same prompt. Robot trajectories rarely give that counterfactual. If a human intervenes after a bad grasp, the corrected action occurs in a new state. If a rollout succeeds on Tuesday and fails on Wednesday, camera pose, friction, initialization, or object identity may differ. Treating those episodes as a clean pair can teach the policy the wrong cause.
+
+[KTO](/paper%20shorts/2024/02/02/kto-model-alignment-as-prospect-theoretic-optimization.html) is often a better conceptual starting point. It learns from individual desirable and undesirable outputs rather than requiring pairs. [Action Preference Optimization](/paper%20shorts/2025/06/08/action-preference-optimization-for-robotic-policy-refinement.html) adapts that idea to intervention data and reweights token updates using decoded continuous-action error.
+
+The feedback interface should match what deployment actually observed:
+
+| Deployment signal | Honest training interpretation | Common mistake |
+| --- | --- | --- |
+| Successful/failed episode | Binary outcome for a trajectory | Assuming the last action caused the outcome |
+| Human takeover | Failure evidence near an intervention window | Treating the entire pre-intervention episode as rejected |
+| Corrective action | Preferred local behavior in the reached state | Pairing it with an action from a different state |
+| Smooth versus oscillatory motion | Style/control preference on a segment | Letting smoothness dominate task success |
+| Safety violation | Constraint failure | Folding it into one scalar reward without severity |
+| Progress judgment | Process supervision between states | Assuming temporal order always means progress |
+
+The central question is not “Can DPO be applied?” It is “What event has a defensible likelihood and a defensible preference label?”
+
+## 4. Failure mining determines the value of robot hours
+
+Rollouts are not automatically useful. A thousand identical successes provide little gradient. A thousand catastrophic failures may be unsafe and too far outside the policy's recoverable region. The valuable middle consists of near-boundary states: recoverable mistakes, ambiguous objects, distribution shifts, and action segments where a different local decision changes the outcome.
+
+A useful failure taxonomy separates at least five causes:
+
+1. **Semantic failure:** the policy chooses the wrong object, goal, or subtask.
+2. **Perceptual/metric failure:** identity is correct but pose, geometry, depth, or contact is wrong.
+3. **Planning failure:** a valid local action commits to a globally bad sequence.
+4. **Control failure:** timing, latency, smoothness, or actuator mismatch ruins the plan.
+5. **Evaluation failure:** the policy behaved correctly and the success detector or critic mislabeled it.
+
+That taxonomy routes data. Semantic failures may need web/VLM retention or instruction augmentation. Metric failures may need tracked geometry or calibrated state. Planning failures may need longer history, subtask supervision, or process rewards. Control failures may need a different action head or chunk length. Evaluation failures demand critic work before any policy update.
+
+[RLDG](/paper%20shorts/2024/12/13/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.html) offers a useful alternative when direct RL on the generalist is risky. Train task-specific RL specialists, collect their high-quality trajectories, and distill those into the foundation policy. RL improves the data distribution without directly moving every shared parameter.
+
+The next 1,000 robot hours should go where expected marginal information is highest: high-uncertainty critic regions, recoverable failures, rare safety cases, new environments, and tasks that discriminate between candidate post-training methods. Uniform collection is easy to schedule and often a poor research allocation.
+
+## 5. Four improvement paths
+
+Once failures are labeled, four families cover most practical updates.
+
+### Correction SFT
+
+Train on human interventions, recoveries, or successful reruns. This is stable, simple, and compatible with any differentiable action objective. It ignores why the original behavior was bad and can overfit to states that appear only after a human takeover.
+
+Correction SFT should be the default baseline. If a preference or RL method cannot beat it under the same robot and human budget, the extra machinery has not earned its place.
+
+### Binary or preference optimization
+
+Use DPO when alternatives begin from a defensibly matched context and the policy exposes meaningful likelihoods. Use KTO/APO-style binary objectives when feedback arrives independently or physical irreversibility prevents pairs. Keep task success, safety, efficiency, and style as separate labels long enough to see their conflicts.
+
+### Reward-model RL
+
+Train a critic and optimize the policy against it. PPO uses a clipped surrogate such as:
+
+$$
+\mathcal{L}_{\text{clip}}(\theta)
+=\mathbb{E}_t\left[
+\min\left(r_t(\theta)\hat A_t,
+\operatorname{clip}(r_t(\theta),1-\epsilon,1+\epsilon)\hat A_t\right)
+\right].
+$$
+
+Clipping controls update size; it does not validate the reward. [Scaling Laws for Reward Model Overoptimization](/paper%20shorts/2022/10/19/scaling-laws-for-reward-model-overoptimization.html) shows that proxy reward can continue rising after a stronger gold reward peaks. [Reward Model Ensembles](/paper%20shorts/2023/10/04/reward-model-ensembles-help-mitigate-overoptimization.html) shows that conservative optimization over disagreement can reduce the problem, but correlated critics can still share one blind spot.
+
+For diffusion actors, [DPPO](/paper%20shorts/2024/09/01/dppo-diffusion-policy-policy-optimization.html) is the right technical reference. It treats denoising as part of the stochastic policy rather than pretending a diffusion trajectory has the same likelihood interface as a Gaussian action.
+
+### Sparse-reward interactive RL
+
+[RIPT-VLA](/paper%20shorts/2025/05/22/ript-vla-interactive-post-training-for-vision-language-action-models.html) and [SimpleVLA-RL](/paper%20shorts/2025/09/11/simplevla-rl-scaling-vla-training-via-reinforcement-learning.html) show how far binary success can go when rollouts are cheap and parallel. Both rely on reward variation inside comparable groups. If every rollout succeeds or fails, relative advantages collapse and the batch teaches nothing.
+
+That observation produces a systems requirement: rollout scheduling must create informative contrasts. Sample tasks near the competence boundary, record policy versions, prevent correlated environments from masquerading as independent evidence, and reject groups with no reward variance.
+
+## 6. The critic is often the real bottleneck
+
+A terminal success detector is sparse. A generic VLM reward can miss geometry, contact, occlusion, and temporal progress. A dense hand-engineered reward can teach the simulator rather than the task. The right critic is rarely “a bigger VLM asked whether the robot did well.”
+
+[VisualPRM](/paper%20shorts/2025/03/13/visualprm-process-reward-model-for-multimodal-reasoning.html) supplies a useful methodology: build process-supervision data, train a critic, and evaluate that critic on human-labeled intermediate errors before using it to select or optimize outputs. Its reasoning domain is not robotics, but the separation between critic training and critic evaluation transfers directly.
+
+[VLAC](/paper%20shorts/2025/09/19/vlac-vision-language-action-critic-for-real-world-rl.html) makes the robotics version concrete. Given a goal and two observations, it predicts signed progress and completion. Its data include regressions, stagnation, irrelevant goals, and mismatched samples—not only successful temporal order.
+
+A serious process critic should output a vector rather than one opaque score:
+
+$$
+f_\phi(g,o_0,o_{t-1},o_t,a_t)
+\rightarrow
+(\Delta p_t, P_{done}, P_{fail}, P_{unsafe}, u_t, c_t),
+$$
+
+where $\Delta p_t$ is progress, $u_t$ is uncertainty, and $c_t$ is a failure class. Add structured state—tracked objects, geometry, contact, controller state—when pixels cannot identify the physical event. That is not a retreat from end-to-end learning. It is an attempt to give the critic evidence the policy may not need at inference.
+
+[Constitutional AI](/paper%20shorts/2022/12/15/constitutional-ai-harmlessness-from-ai-feedback.html) adds a complementary idea: make constraints explicit, use models to generate critiques and counterexamples, and keep humans as the auditor. A robot constitution might define forbidden contacts, workspace boundaries, uncertainty-triggered stops, and recovery priorities. The constitution cannot verify its own physical grounding.
+
+Never celebrate rising critic reward alone. Track ground-truth task success, human judgment, critic disagreement, intervention rate, unsafe contact, entropy, KL from SFT, and the causal content of high-reward rollouts.
+
+## 7. Evaluation must be a pyramid
+
+Post-training claims are only as strong as the next evaluation layer they predict.
+
+### Level 1 · Offline diagnostics
+
+Measure action error, chunk likelihood, critic accuracy, preference accuracy, representation probes, and instruction/object grounding. These are cheap debugging tools. They do not measure recovery from the model's own actions.
+
+### Level 2 · Closed-loop simulation
+
+[LIBERO](/paper%20shorts/2023/06/05/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.html) separates spatial, object, goal, and mixed transfer across 130 tasks. [RoboTwin 2.0](/paper%20shorts/2025/06/20/robotwin-2-scalable-data-generator-and-benchmark.html) adds bimanual tasks, structured domain randomization, and synthetic data generation. Report success by failure category and shift, not only the mean.
+
+### Level 3 · Real-to-sim correlation
+
+[SIMPLER](/paper%20shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html) asks whether simulation preserves real policy rankings and failure sensitivities. That correlation must be measured prospectively for every new policy family. A simulator calibrated for RT-style discrete actions may not rank a new flow policy correctly.
+
+### Level 4 · Reproducible real trials
+
+[VLA-REPLICA](/paper%20shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html) standardizes an inexpensive physical setup so independent labs can reproduce the result. Measure success with confidence intervals, intervention frequency, unsafe contacts, time, smoothness, latency, and hardware-versus-policy faults.
+
+### Level 5 · Natural interaction robustness
+
+[LIBERO-Para](/paper%20shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html) reveals 22–52 point drops under instruction paraphrases and attributes most failures to planning divergence. A policy that succeeds only when the user repeats the fine-tuning phrase has not retained semantic grounding.
+
+[RobustVLA](/paper%20shorts/2025/11/03/robustvla-robustness-aware-reinforcement-post-training.html) adds observation-sensitivity and action-smoothness regularization to the optimization side. Evaluation and optimization should meet on the same perturbations: latency, camera shifts, occlusion, calibration error, actuation noise, object substitutions, and language variation.
+
+The staff-level metric sits above every level:
+
+> Reliable policy improvement per robot-hour, human-hour, annotation-hour, and unit of compute.
+
+## 8. Systems ownership: the loop must be reproducible
+
+An online VLA program needs more than an RL trainer. It needs versioned policies, rollout workers, environment and robot calibration records, synchronized video/state/action logs, feedback provenance, immutable dataset snapshots, critic versions, and rollback.
+
+At minimum, every trajectory should identify:
+
+- policy, critic, tokenizer/action head, and controller versions;
+- task, environment, embodiment, sensors, and calibration;
+- observation/action timestamps and dropped-frame indicators;
+- human interventions and their latency;
+- reward components, uncertainty, termination reason, and evaluator version;
+- whether the trajectory was used for SFT, preferences, reward learning, RL, or only evaluation.
+
+Asynchronous fleets add one more problem: a rollout may be generated by a policy several updates behind the learner. Off-policy correction does not repair missing provenance. Staleness should be measured, bounded, and included in the analysis.
+
+The launch checklist should specify minimum lower-confidence-bound success, maximum unsafe-contact and intervention rates, latency limits, regression gates by task family, automatic rollback, and a canary population. A new aggregate record is not a launch criterion if one safety-critical slice regressed.
+
+## 9. A decision guide
+
+Use the cheapest method that attacks the diagnosed failure.
+
+| Observed problem | First intervention | Escalate when |
+| --- | --- | --- |
+| New robot/action interface | OpenVLA-OFT-style SFT matrix | Demonstrations cover the state but the policy still fails |
+| Covariate shift and recovery | DAgger/correction SFT | Corrections are abundant but preferred and failed behavior remain confused |
+| Unpaired success/failure logs | KTO/APO-style binary training | Outcome labels are too sparse or causal attribution is poor |
+| Multimodal continuous behavior | Diffusion/flow action head | Imitation plateaus despite good coverage |
+| Reliable terminal success, cheap simulator | RIPT/SimpleVLA-RL | Reward variation exists and simulation predicts real behavior |
+| Strong task-specific RL specialist | RLDG distillation | Direct generalist RL forgets or destabilizes |
+| Sparse task reward | Process critic such as VLAC | Critic passes held-out error-localization tests |
+| Reward exploitation | Ensembles, conservative objective, real stopping metric | Critics disagree or gold performance turns down |
+
+## 10. Reading path: broad understanding to literature depth
+
+Read in layers, and carry one question from each layer into the next.
+
+**Layer 1: why closed loop changes the problem.** Read [DAgger](/paper%20shorts/2011/04/11/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.html), [PPO](/paper%20shorts/2017/07/01/proximal-policy-optimization-ppo.html), [InstructGPT](/paper%20shorts/2022/02/28/training-language-models-to-follow-instructions-with-human-feedback.html), [DPO](/paper%20shorts/2023/05/01/direct-preference-optimization-dpo.html), and [KTO](/paper%20shorts/2024/02/02/kto-model-alignment-as-prospect-theoretic-optimization.html). Be able to explain state-distribution shift, reference policies, and what feedback unit each objective assumes.
+
+**Layer 2: how actions change the optimizer.** Read [ACT](/paper%20shorts/2023/04/23/action-chunking-with-transformers-act.html), [Diffusion Policy](/paper%20shorts/2023/03/07/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.html), [RT-1](/paper%20shorts/2022/12/13/rt-1-robotics-transformer-for-real-world-control-at-scale.html), [RT-2](/paper%20shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html), [Octo](/paper%20shorts/2024/05/20/octo-an-open-source-generalist-robot-policy.html), [OpenVLA-OFT](/paper%20shorts/2025/02/27/openvla-oft-optimizing-speed-and-success.html), and [Pi0.5](/paper%20shorts/2025/04/22/pi0-5-vision-language-action-model-with-open-world-generalization.html). For each, write down the action distribution and the real control rate.
+
+**Layer 3: how deployment becomes supervision.** Read [RLDG](/paper%20shorts/2024/12/13/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.html), [RIPT-VLA](/paper%20shorts/2025/05/22/ript-vla-interactive-post-training-for-vision-language-action-models.html), [APO](/paper%20shorts/2025/06/08/action-preference-optimization-for-robotic-policy-refinement.html), [DPPO](/paper%20shorts/2024/09/01/dppo-diffusion-policy-policy-optimization.html), and [SimpleVLA-RL](/paper%20shorts/2025/09/11/simplevla-rl-scaling-vla-training-via-reinforcement-learning.html). Identify what is on-policy, what receives reward, and what likelihood is optimized.
+
+**Layer 4: who judges the policy.** Read [Reward Overoptimization](/paper%20shorts/2022/10/19/scaling-laws-for-reward-model-overoptimization.html), [Reward Model Ensembles](/paper%20shorts/2023/10/04/reward-model-ensembles-help-mitigate-overoptimization.html), [VisualPRM](/paper%20shorts/2025/03/13/visualprm-process-reward-model-for-multimodal-reasoning.html), and [VLAC](/paper%20shorts/2025/09/19/vlac-vision-language-action-critic-for-real-world-rl.html). Ask what independent metric would catch each critic's favorite shortcut.
+
+**Layer 5: what evidence survives deployment.** Read [LIBERO](/paper%20shorts/2023/06/05/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.html), [SIMPLER](/paper%20shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html), [RoboTwin 2.0](/paper%20shorts/2025/06/20/robotwin-2-scalable-data-generator-and-benchmark.html), [VLA-REPLICA](/paper%20shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html), and [LIBERO-Para](/paper%20shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html). Ask which real decision each benchmark predicts.
+
+## Frontier signals, not settled recipes
+
+Several 2026 papers extend the loop toward fleet-scale asynchronous training, model-based optimization, continual reinforcement fine-tuning, and learned robot rewards: [SOP](https://arxiv.org/abs/2601.03044), [LifeLong-RFT](https://arxiv.org/abs/2602.10503), [VLA-MBPO](https://arxiv.org/abs/2603.20607), [Large Reward Models](https://arxiv.org/abs/2603.16065), [BORA](https://arxiv.org/abs/2605.30226), [ProcVLM](https://arxiv.org/abs/2605.08774), and [Advantage Collapse in GRPO](https://arxiv.org/abs/2605.21125). These are useful research signals, but their claims should be re-tested under common robot-hour, compute, and evaluation budgets before they become default infrastructure.
+
+## The research thesis
+
+The strongest VLA post-training program will not be the one with the fanciest optimizer. It will be the one that closes attribution gaps.
+
+The policy needs broad pretrained semantics. The action head needs the right temporal and continuous interface. Deployment needs to expose the states the policy actually creates. Failure mining needs to locate the causal segment. Feedback needs to preserve what a human, success detector, or critic truly observed. Optimization needs to respect the policy distribution. Evaluation needs to predict real deployment. The system needs to remember which version produced every piece of evidence.
+
+My strongest bet is a structured, uncertainty-aware process critic: keep the VLA broad and end-to-end, but let the critic see persistent entities, geometry, contact, controller state, and task progress. Use that critic to find high-value failures and conservative updates, then distill the improvement into the deployable policy.
+
+That is the path from “a model that can act” to a policy improvement system that can be trusted to learn.

--- a/src/content/posts/reward-model-ensembles-help-mitigate-overoptimization.md
+++ b/src/content/posts/reward-model-ensembles-help-mitigate-overoptimization.md
@@ -1,0 +1,44 @@
+---
+title: 'Reward Model Ensembles Help Mitigate Overoptimization'
+date: '2023-10-04T09:00:00.000Z'
+section: paper-shorts
+postSlug: reward-model-ensembles-help-mitigate-overoptimization
+legacyPath: /paper shorts/2023/10/04/reward-model-ensembles-help-mitigate-overoptimization.html
+tags:
+  - Alignment
+  - Reward Models
+field: 'Alignment & Post-Training'
+summary: 2023 – Conservative optimization over reward ensembles reduces proxy-reward overoptimization.
+---
+
+## 2023 – Reward Model Ensembles Help Mitigate Overoptimization
+
+**arXiv:** [2310.02743](https://arxiv.org/abs/2310.02743)
+
+**Conference:** ICLR 2024
+
+This paper asks whether uncertainty across reward models can identify the regions where policy optimization is exploiting a proxy. It trains ensembles and optimizes either the worst predicted reward or an uncertainty-penalized reward instead of trusting a single mean score.
+
+## Paper Insights
+
+The evaluation extends the synthetic gold-reward setup used by the reward-overoptimization scaling paper and adds 25% label noise. For best-of-$n$, conservative ensemble objectives nearly eliminate overoptimization in the reported setting and improve performance by as much as 70%. For PPO, ensembles consistently reduce overoptimization; combining them with a small KL penalty prevents it in the studied runs without sacrificing performance.
+
+The ensemble is useful because disagreement provides a local warning about extrapolation. It is not a guarantee: models trained on the same data and architecture can share the same blind spot. In robot learning, useful diversity may require different sensor views, label sources, architectures, or structured state rather than random seeds alone.
+
+| Objective | Behavior |
+| --- | --- |
+| Single reward model | Cheap, but easy to exploit outside its labeled support |
+| Worst-case ensemble | Conservative where any member predicts low reward |
+| Uncertainty-weighted ensemble | Trades predicted reward against disagreement |
+
+## Decision Lens
+
+This paper informs whether extra critic capacity should buy a larger single model or an ensemble that exposes epistemic uncertainty. The unit is a response scored by several reward models; the policy objective changes how those scores are normalized and aggregated. The measured gains are orthogonal to simply scaling one reward model in the synthetic study.
+
+The missing control is diversity: compare independently seeded replicas with critics trained from different label sources and representations. At ten times the deployment shift, correlated errors can make the ensemble confidently wrong. The approach is falsified if ensemble disagreement fails to rank real robot failures or if a held-out human/ground-truth metric regresses while the conservative objective rises.
+
+**Context:** Ensembles turn uncertainty into an optimization constraint rather than a dashboard metric.
+
+**Limits:** Synthetic gold rewards and language outputs understate shared physical-perception failures.
+
+**Takeaway:** An ensemble helps only when its members disagree for reasons related to the failures that matter.

--- a/src/content/posts/ript-vla-interactive-post-training-for-vision-language-action-models.md
+++ b/src/content/posts/ript-vla-interactive-post-training-for-vision-language-action-models.md
@@ -1,0 +1,44 @@
+---
+title: 'RIPT-VLA: Interactive Post-Training for Vision-Language-Action Models'
+date: '2025-05-22T09:00:00.000Z'
+section: paper-shorts
+postSlug: ript-vla-interactive-post-training-for-vision-language-action-models
+legacyPath: /paper shorts/2025/05/22/ript-vla-interactive-post-training-for-vision-language-action-models.html
+tags:
+  - Robotics
+  - Reinforcement Learning
+field: 'Robot Post-Training & Evaluation'
+summary: 2025 – RIPT-VLA adds sparse-reward interactive RL after VLA pretraining and SFT.
+---
+
+## 2025 – RIPT-VLA: Interactive Post-Training for Vision-Language-Action Models
+
+**arXiv:** [2505.17016](https://arxiv.org/abs/2505.17016)
+
+**Project:** [RIPT-VLA](https://ariostgx.github.io/ript_vla/)
+
+RIPT-VLA proposes a third VLA training stage after pretraining and supervised fine-tuning: interact with the environment, score complete rollouts with sparse binary success, and update the policy through reinforcement learning.
+
+## Paper Insights
+
+The optimizer combines dynamic rollout sampling with leave-one-out advantage estimation. Grouping rollouts by task turns a sparse $0/1$ outcome into a relative signal; batches are constructed to retain non-zero advantage rather than wasting updates on groups where every rollout has the same result. The method applies to both a lightweight QueST policy and the 7B OpenVLA-OFT model.
+
+The paper reports a 21.2-point gain for QueST and 97.5% success for OpenVLA-OFT on the studied LIBERO suites. In a one-demonstration case, interactive training moves a 4% SFT policy to 97% within 15 iterations. These numbers show the potential of on-policy state coverage, but near-saturated simulation does not reveal reward hacking, real-world wear, or safety cost.
+
+| Mechanism | Problem addressed |
+| --- | --- |
+| Interactive rollouts | Exposes policy-induced states absent from demonstrations |
+| Leave-one-out advantages | Converts relative outcomes into lower-variance updates |
+| Dynamic sampling | Avoids groups with no useful reward contrast |
+
+## Decision Lens
+
+RIPT-VLA informs whether the next marginal robot hour should collect expert demonstrations or autonomous rollouts with cheap terminal labels. Its atomic unit is a complete trajectory; action-token likelihoods factor the policy update, while the reward arrives only at episode end.
+
+The results establish strong sample efficiency in simulation under reliable success signals. A missing comparison matches environment interactions and hyperparameter search against DAgger-style corrections and KTO-style binary training. At ten times the task diversity, homogeneous-reward groups, unsafe exploration, and stale asynchronous policies become bottlenecks. The claim would fail if gains do not survive new initial states, reward perturbations, or real-robot trials.
+
+**Context:** RIPT-VLA is the clearest demonstration of SFT as an initialization rather than the endpoint of VLA training.
+
+**Limits:** Sparse success works when the simulator can score the task perfectly; physical tasks often lack that oracle.
+
+**Takeaway:** Interactive RL is most valuable where demonstrations fail to cover the states produced by the current policy.

--- a/src/content/posts/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.md
+++ b/src/content/posts/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.md
@@ -1,0 +1,44 @@
+---
+title: 'RLDG: Robotic Generalist Policy Distillation via Reinforcement Learning'
+date: '2024-12-13T09:00:00.000Z'
+section: paper-shorts
+postSlug: rldg-robotic-generalist-policy-distillation-via-reinforcement-learning
+legacyPath: /paper shorts/2024/12/13/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.html
+tags:
+  - Robotics
+  - Distillation
+field: 'Robot Post-Training & Evaluation'
+summary: 2024 – RLDG uses task-specific RL policies to generate data that improves a generalist policy.
+---
+
+## 2024 – RLDG: Robotic Generalist Policy Distillation via Reinforcement Learning
+
+**arXiv:** [2412.09858](https://arxiv.org/abs/2412.09858)
+
+**Project:** [generalist-distillation.github.io](https://generalist-distillation.github.io/)
+
+RLDG avoids applying unstable RL updates directly to a large generalist policy. It trains smaller task-specific RL specialists, rolls them out to collect higher-quality and broader-coverage trajectories, and distills those trajectories back into the generalist with supervised fine-tuning.
+
+## Paper Insights
+
+On precise insertion and assembly tasks, the paper reports that generalists trained on RL-generated data outperform those trained on human demonstrations by as much as 40%. Analysis attributes the gain to both cleaner action distributions and state coverage: RL specialists visit states and execute corrections that teleoperators may not demonstrate consistently.
+
+The separation also protects general capabilities. The specialist can optimize aggressively under a task reward; the generalist only consumes selected trajectories. The cost is maintaining one RL pipeline per task and deciding which specialist behavior is safe to distill.
+
+| Stage | Model | Objective |
+| --- | --- | --- |
+| Specialist learning | Task-specific policy | Maximize environment reward |
+| Data generation | Converged specialist | Produce high-quality state/action coverage |
+| Distillation | Generalist policy | Imitate selected RL trajectories |
+
+## Decision Lens
+
+RLDG informs whether RL should update a generalist directly or serve as a data-generation tool. Its atomic unit is the distilled specialist trajectory. Parameters are not shared during RL; knowledge crosses the boundary through curated experience.
+
+The results establish that specialist-generated data can beat human demonstrations on precise tasks. A missing comparison holds total robot hours constant across direct generalist RL, specialist distillation, and correction SFT. At ten times the task count, training specialists becomes the bottleneck and their styles may conflict. The thesis fails if distilled gains vanish on new tasks or if direct post-training achieves equal improvement without forgetting at lower systems cost.
+
+**Context:** RLDG turns RL into a data flywheel rather than insisting it be the final optimizer.
+
+**Limits:** Task rewards and specialist training remain expensive to engineer and validate.
+
+**Takeaway:** When direct RL is too brittle for a foundation policy, let RL improve the data before it improves the model.

--- a/src/content/posts/robotwin-2-scalable-data-generator-and-benchmark.md
+++ b/src/content/posts/robotwin-2-scalable-data-generator-and-benchmark.md
@@ -1,0 +1,45 @@
+---
+title: 'RoboTwin 2.0: A Scalable Data Generator and Benchmark for Bimanual Manipulation'
+date: '2025-06-20T09:00:00.000Z'
+section: paper-shorts
+postSlug: robotwin-2-scalable-data-generator-and-benchmark
+legacyPath: /paper shorts/2025/06/20/robotwin-2-scalable-data-generator-and-benchmark.html
+tags:
+  - Robotics
+  - Evaluation
+field: 'Robot Post-Training & Evaluation'
+summary: 2025 – RoboTwin 2.0 couples automated bimanual task generation with structured domain randomization.
+---
+
+## 2025 – RoboTwin 2.0: A Scalable Data Generator and Benchmark
+
+**arXiv:** [2506.18088](https://arxiv.org/abs/2506.18088)
+
+**Project:** [RoboTwin](https://robotwin-platform.github.io/)
+
+RoboTwin 2.0 combines a synthetic-data factory with a 50-task bimanual benchmark. Its object library contains 731 instances across 147 categories, while an MLLM proposes task code and simulation-in-the-loop feedback validates and refines execution.
+
+## Paper Insights
+
+Domain randomization spans clutter, lighting, backgrounds, tabletop height, and language. Embodiment-aware generation adapts grasps and action candidates across five dual-arm platforms. The paper reports a 10.9-point gain in code-generation success, large relative gains from synthetic pretraining, and a 367% relative improvement when synthetic data are combined with ten real demonstrations over the ten-demo baseline.
+
+The benchmark is valuable because data generation and evaluation share explicit variation axes. The danger is co-adaptation: policies can learn the generator's visual and physical conventions, making benchmark robustness look broader than it is.
+
+| Asset | Scale | Role |
+| --- | --- | --- |
+| RoboTwin-OD | 731 objects, 147 categories | Object and affordance diversity |
+| Task suite | 50 bimanual tasks | Standardized policy comparison |
+| Embodiments | Five dual-arm platforms | Cross-robot robustness |
+| Randomization | Five structured axes | Sim-to-real variation |
+
+## Decision Lens
+
+RoboTwin 2.0 informs whether the next data budget should buy real demonstrations or a synthetic generator plus a small real calibration set. Its unit is a generated bimanual trajectory with task code and validation. MLLM synthesis expands task coverage; simulator feedback filters obviously invalid programs.
+
+The reported gains establish that structured synthetic diversity can improve the tested VLA policies. A missing control evaluates an independently built real task distribution with no shared assets or prompts. At ten times the generated volume, correlated simulator artifacts and validation blind spots dominate. The claim fails if synthetic scale improves benchmark success but not real bimanual transfer per real demonstration.
+
+**Context:** RoboTwin 2.0 is both a training-data intervention and an evaluation environment; those roles should be analyzed separately.
+
+**Limits:** Relative gains from a low-data baseline can look large while absolute real-world reliability remains modest.
+
+**Takeaway:** Synthetic data is most credible when the held-out evaluation breaks the generator's assumptions.

--- a/src/content/posts/robustvla-robustness-aware-reinforcement-post-training.md
+++ b/src/content/posts/robustvla-robustness-aware-reinforcement-post-training.md
@@ -1,0 +1,41 @@
+---
+title: 'RobustVLA: Robustness-Aware Reinforcement Post-Training for Vision-Language-Action Models'
+date: '2025-11-03T09:00:00.000Z'
+section: paper-shorts
+postSlug: robustvla-robustness-aware-reinforcement-post-training
+legacyPath: /paper shorts/2025/11/03/robustvla-robustness-aware-reinforcement-post-training.html
+tags:
+  - Robotics
+  - Robustness
+field: 'Robot Post-Training & Evaluation'
+summary: 2025 – RobustVLA regularizes observation sensitivity and action smoothness during online RL.
+---
+
+## 2025 – RobustVLA: Robustness-Aware Reinforcement Post-Training
+
+**arXiv:** [2511.01331](https://arxiv.org/abs/2511.01331)
+
+RobustVLA argues that maximizing nominal task reward during online post-training can make a VLA more brittle. Its analysis bounds performance degradation under observation and action perturbations, motivating Jacobian regularization for perception sensitivity and smoothness regularization for policy updates/actions.
+
+## Paper Insights
+
+Observation perturbations model lighting, camera, latency, or state-estimation error; action perturbations model actuator and execution mismatch. Standard RL can overfit to the nominal environment even as success rises. RobustVLA adds lightweight penalties to constrain the sensitivity terms identified by the analysis and reports improved reliability across perturbed robot environments.
+
+The paper shifts robustness from an evaluation afterthought into the post-training objective. The tradeoff is familiar: too much regularization can suppress necessary high-frequency corrections or adaptation to real changes.
+
+| Perturbation | Regularizer | Intended effect |
+| --- | --- | --- |
+| Observation noise | Policy Jacobian penalty | Reduce sensitivity to irrelevant visual changes |
+| Action disturbance | Smoothness penalty | Prevent unstable reactions and oscillation |
+
+## Decision Lens
+
+RobustVLA informs whether post-training should optimize nominal success alone or explicitly reserve capacity for perturbation tolerance. Its unit is a rollout under sampled observation/action noise, with regularizers applied to policy sensitivity in addition to reward.
+
+The experiments support the proposed penalties under studied disturbances. A missing comparison uses physically grounded latency, occlusion, calibration drift, and contact errors rather than generic noise. At ten times the environment diversity, one smoothness coefficient cannot express all controller dynamics. The claim fails if robustness gains disappear under structured shifts or if reduced sensitivity prevents fast recovery from real disturbances.
+
+**Context:** RobustVLA supplies the objective-level counterpart to benchmark suites that measure perturbation sensitivity.
+
+**Limits:** Mathematical bounds depend on how faithfully the perturbation model represents deployment.
+
+**Takeaway:** Robustness must be optimized against the disturbances the robot will actually face, not an abstract noise distribution.

--- a/src/content/posts/rt-1-robotics-transformer-for-real-world-control-at-scale.md
+++ b/src/content/posts/rt-1-robotics-transformer-for-real-world-control-at-scale.md
@@ -1,0 +1,44 @@
+---
+title: 'RT-1: Robotics Transformer for Real-World Control at Scale'
+date: '2022-12-13T09:00:00.000Z'
+section: paper-shorts
+postSlug: rt-1-robotics-transformer-for-real-world-control-at-scale
+legacyPath: /paper shorts/2022/12/13/rt-1-robotics-transformer-for-real-world-control-at-scale.html
+tags:
+  - Robotics
+  - Generalist Policies
+field: 'Vision-Language-Action & Robotics'
+summary: 2022 – RT-1 scales a compact tokenized-action transformer across real robot tasks and data diversity.
+---
+
+## 2022 – RT-1: Robotics Transformer for Real-World Control at Scale
+
+**arXiv:** [2212.06817](https://arxiv.org/abs/2212.06817)
+
+**Project:** [robotics-transformer1.github.io](https://robotics-transformer1.github.io/)
+
+RT-1 tests whether a single real-time policy can absorb a broad robot dataset without losing execution speed. It combines a FiLM-conditioned EfficientNet, TokenLearner visual compression, a transformer, and discretized arm/base actions in a 35M-parameter controller that runs at 3 Hz.
+
+## Paper Insights
+
+The paper's scaling variable is not only episode count. Task and object diversity produce better generalization than adding redundant examples from the same narrow distribution. TokenLearner compresses the spatial feature map into a small set of visual tokens, making transformer control feasible under a real-time budget.
+
+RT-1 established the multi-task robot policy as a scalable object, but its semantic knowledge comes mainly from the robot dataset. RT-2 later asks what changes when web-scale vision-language data joins the mixture.
+
+| Component | Role | Constraint |
+| --- | --- | --- |
+| FiLM EfficientNet | Language-conditioned visual features | Perception is tied to the trained visual domain. |
+| TokenLearner | Compresses image features | Salient detail can be discarded. |
+| Discrete action tokens | Makes control autoregressive | Quantization and 3 Hz execution cap precision. |
+
+## Decision Lens
+
+RT-1 informs whether to scale robot capability through one diverse policy or a collection of task-specific controllers. Its atomic unit is an observation–instruction paired with tokenized action dimensions. Visual compression and action discretization are what let shared transformer capacity meet the deployment rate.
+
+The experiments support positive returns from data and task diversity in the tested robot fleet. They do not separate diversity from collection quality or controller conventions. At ten times the embodiments, incompatible action spaces and sensor layouts will dominate. The generalist-policy claim would fail if task specialists trained on equal total data retain higher success and require less adaptation on held-out tasks.
+
+**Context:** RT-1 is the scaling baseline from which web-grounded VLAs and cross-embodiment datasets developed.
+
+**Limits:** Real-time success at 3 Hz does not cover high-frequency, contact-rich control.
+
+**Takeaway:** Diversity is useful only when the interface compresses heterogeneous experience into actions the deployed robot can execute reliably.

--- a/src/content/posts/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.md
+++ b/src/content/posts/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.md
@@ -1,0 +1,44 @@
+---
+title: 'RT-2: Vision-Language-Action Models Transfer Web Knowledge to Robotic Control'
+date: '2023-07-28T09:00:00.000Z'
+section: paper-shorts
+postSlug: rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control
+legacyPath: /paper shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html
+tags:
+  - Robotics
+  - Vision-Language-Action
+field: 'Vision-Language-Action & Robotics'
+summary: 2023 – RT-2 co-trains web vision-language tasks and tokenized robot actions in one VLA model.
+---
+
+## 2023 – RT-2: Vision-Language-Action Models Transfer Web Knowledge to Robotic Control
+
+**arXiv:** [2307.15818](https://arxiv.org/abs/2307.15818)
+
+**Project:** [robotics-transformer2.github.io](https://robotics-transformer2.github.io/)
+
+RT-2 turns robot control into another output language for a vision-language model. Continuous action dimensions are discretized into tokens, serialized as text-like outputs, and co-fine-tuned with Internet-scale VQA and image-language tasks.
+
+## Paper Insights
+
+The shared token interface allows semantic knowledge from web data to influence action selection. Across roughly 6,000 evaluation trials, RT-2 improves generalization to novel objects and instructions and exhibits behaviors such as selecting an improvised tool. The system demonstrates transfer from semantic pretraining into control, not a general solution to contact dynamics.
+
+Co-training creates an important retention problem: robot data must ground the model without erasing its visual-language priors, while web data must not dominate action learning. Encoding actions as text simplifies the architecture but inherits autoregressive latency and quantization.
+
+| Shared element | Benefit | Risk |
+| --- | --- | --- |
+| Token vocabulary | One decoder for language and action | Token likelihood may poorly reflect physical error. |
+| Transformer parameters | Web knowledge can transfer to control | Gradients from abundant web data can dominate robot data. |
+| Co-training mixture | Preserves semantic capability during robot tuning | Mixture ratios become a critical hidden variable. |
+
+## Decision Lens
+
+RT-2 informs whether semantic transfer is worth using a common language/action interface. Its unit is a multimodal sequence ending in either text or action tokens. The model shares nearly the entire transformer; discretization is the bridge between continuous control and next-token prediction.
+
+The evaluations establish semantic generalization in the studied manipulation domain. A missing ablation would compare shared tokens, a continuous action head, and a separate action expert under matched VLM retention and latency. At ten times the control frequency, autoregressive decoding becomes the bottleneck. The central claim weakens if semantic probes improve while closed-loop task success under geometric perturbations does not.
+
+**Context:** RT-2 coined the practical VLA recipe: reuse a VLM, represent actions in its interface, and co-train semantics with control.
+
+**Limits:** Web knowledge does not supply metric state, force awareness, or recovery data.
+
+**Takeaway:** A shared vocabulary transfers meaning efficiently; it does not make language-token probability a complete control objective.

--- a/src/content/posts/scaling-laws-for-reward-model-overoptimization.md
+++ b/src/content/posts/scaling-laws-for-reward-model-overoptimization.md
@@ -1,0 +1,42 @@
+---
+title: 'Scaling Laws for Reward Model Overoptimization'
+date: '2022-10-19T09:00:00.000Z'
+section: paper-shorts
+postSlug: scaling-laws-for-reward-model-overoptimization
+legacyPath: /paper shorts/2022/10/19/scaling-laws-for-reward-model-overoptimization.html
+tags:
+  - Alignment
+  - Reward Models
+field: 'Alignment & Post-Training'
+summary: 2022 – Proxy reward improves before Goodhart's law turns further optimization into regression.
+---
+
+## 2022 – Scaling Laws for Reward Model Overoptimization
+
+**arXiv:** [2210.10760](https://arxiv.org/abs/2210.10760)
+
+This paper measures Goodhart's law instead of citing it. A large “gold” reward model stands in for human judgment, a smaller proxy reward model is trained from its labels, and a policy is pushed against the proxy using reinforcement learning or best-of-$n$ sampling. Proxy reward keeps rising after gold reward peaks.
+
+## Paper Insights
+
+The paper parameterizes optimization pressure by distance from the initial policy, using $d=\sqrt{D_{KL}(\pi\|\pi_{init})}$. The fitted gold-reward curves differ by optimizer: best-of-$n$ is well described by $d(\alpha-\beta d)$, while RL follows $d(\alpha-\beta\log d)$ in the synthetic setup. Larger reward models and more reward data change the coefficients smoothly, which makes the location of the peak somewhat predictable.
+
+The practical result is a stopping rule, not permission to optimize harder. Policy size has weak influence on the proxy–gold gap, and a KL penalty does not repair a misspecified reward; it controls movement, not truth. In a robot loop, the analogue is a critic score that rises while real success, safety, or human intervention rate flattens.
+
+| Signal | What it reveals | Robot analogue |
+| --- | --- | --- |
+| Proxy reward | What training directly optimizes | Learned progress or success score |
+| Gold reward | Held-out target quality | Real success, safety, and human judgment |
+| KL distance | Optimization pressure | Policy drift from the deployed SFT controller |
+
+## Decision Lens
+
+This paper informs how far to push against a learned critic before collecting better labels or changing the reward. The training unit is a preference-labeled completion in the experiment, but the reusable object is the proxy-versus-ground-truth frontier. Scaling the proxy can postpone overoptimization; it cannot eliminate the fact that the proxy omits something.
+
+The fitted laws hold in a synthetic language setting with a model acting as gold truth. At ten times the deployment diversity, critic blind spots and policy-induced states will change the reward distribution itself. A robot post-training program should therefore sweep optimization pressure and pre-register a real-world stopping metric. The central safety claim fails if a curve fitted on offline critic judgments cannot predict the point where held-out robot success begins to decline.
+
+**Context:** This is the quantitative foundation for treating reward optimization as a budgeted intervention rather than an unlimited objective.
+
+**Limits:** A synthetic gold model is cheaper and more stationary than human or physical evaluation.
+
+**Takeaway:** Rising reward is evidence of optimization; only an independent measure can tell whether it is evidence of progress.

--- a/src/content/posts/simpler-evaluating-real-world-robot-policies-in-simulation.md
+++ b/src/content/posts/simpler-evaluating-real-world-robot-policies-in-simulation.md
@@ -1,0 +1,43 @@
+---
+title: 'SIMPLER: Evaluating Real-World Robot Manipulation Policies in Simulation'
+date: '2024-05-09T09:00:00.000Z'
+section: paper-shorts
+postSlug: simpler-evaluating-real-world-robot-policies-in-simulation
+legacyPath: /paper shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html
+tags:
+  - Robotics
+  - Evaluation
+field: 'Robot Post-Training & Evaluation'
+summary: 2024 – SIMPLER builds purpose-made real-to-sim evaluations whose policy rankings correlate with real robots.
+---
+
+## 2024 – SIMPLER: Evaluating Real-World Robot Manipulation Policies in Simulation
+
+**arXiv:** [2405.05941](https://arxiv.org/abs/2405.05941)
+
+**Project:** [simpler-env.github.io](https://simpler-env.github.io/)
+
+SIMPLER asks a more useful question than whether a simulator is photorealistic: does an evaluation inside it predict how real policies rank and fail? The benchmark recreates common Google Robot and WidowX setups, reduces control and visual mismatches, and runs real-data-trained policies without retraining them in simulation.
+
+## Paper Insights
+
+Across RT-1, RT-1-X, RT-2-X, and Octo and roughly 1,500 evaluation episodes, simulated success correlates strongly with paired real-world performance. The simulator also reflects behavioral sensitivities under several distribution shifts. The result makes simulation a screening layer, not a replacement for real trials.
+
+The main design choice is calibration at the policy interface. Robot control mode, camera pose, observation preprocessing, and object appearance must be close enough that differences between policies survive the domain gap. A visually impressive environment that changes the controller distribution can give worse rankings.
+
+| Evaluation layer | Strength | Boundary |
+| --- | --- | --- |
+| SIMPLER | Cheap, reproducible, high-volume comparison | Correlation is specific to tasks, policies, and matched interfaces |
+| Real robot | Captures actual physics and operations | Expensive, noisy, difficult to reproduce |
+
+## Decision Lens
+
+SIMPLER informs which regressions can be screened in simulation before spending robot hours. Its atomic unit is a closed-loop simulated episode executed by a policy trained on real data. The scaling claim concerns rank correlation and failure-mode similarity, not simulation realism by itself.
+
+A missing test repeatedly recalibrates the correlation as new policy families, controllers, and tasks arrive. At ten times the capability breadth, one simulator may preserve rankings for some skills and invert them for others. The central claim fails if improvements selected by SIMPLER do not predict real gains prospectively rather than retrospectively.
+
+**Context:** SIMPLER supplies the real-to-sim middle layer in an evaluation pyramid.
+
+**Limits:** Correlation on existing policies can break after architecture or action-interface changes.
+
+**Takeaway:** Use simulation when it predicts a decision you care about; measure that prediction continuously.

--- a/src/content/posts/simplevla-rl-scaling-vla-training-via-reinforcement-learning.md
+++ b/src/content/posts/simplevla-rl-scaling-vla-training-via-reinforcement-learning.md
@@ -1,0 +1,45 @@
+---
+title: 'SimpleVLA-RL: Scaling VLA Training via Reinforcement Learning'
+date: '2025-09-11T09:00:00.000Z'
+section: paper-shorts
+postSlug: simplevla-rl-scaling-vla-training-via-reinforcement-learning
+legacyPath: /paper shorts/2025/09/11/simplevla-rl-scaling-vla-training-via-reinforcement-learning.html
+tags:
+  - Robotics
+  - Reinforcement Learning
+field: 'Robot Post-Training & Evaluation'
+summary: 2025 – SimpleVLA-RL adapts group-relative RL and parallel rollouts to OpenVLA-OFT.
+---
+
+## 2025 – SimpleVLA-RL: Scaling VLA Training via Reinforcement Learning
+
+**arXiv:** [2509.09674](https://arxiv.org/abs/2509.09674)
+
+**GitHub:** [PRIME-RL/SimpleVLA-RL](https://github.com/PRIME-RL/SimpleVLA-RL)
+
+SimpleVLA-RL treats VLA reinforcement learning as a systems problem as much as an objective problem. Built on veRL and OpenVLA-OFT, it adds robot-specific trajectory sampling, parallel environments, multi-environment rendering, and optimized loss computation around a group-relative policy update.
+
+## Paper Insights
+
+The framework reports state-of-the-art results on LIBERO and strong RoboTwin 1.0/2.0 performance, including large gains when SFT data are scarce. The paper also reports a “pushcut” behavior not present in the demonstrations, using it as evidence that RL can discover action patterns beyond imitation.
+
+The claim depends on exploration. Group-relative methods produce no useful gradient when every rollout in a group receives the same reward. The paper introduces exploration-enhancing strategies, but the same mechanism can favor simulator-specific shortcuts if reward and environment diversity are weak.
+
+| Layer | VLA-specific requirement |
+| --- | --- |
+| Rollouts | Parallel control environments and policy-version tracking |
+| Advantages | Reward variation within task-conditioned groups |
+| Loss | Correct masks and likelihoods over action chunks |
+| Evaluation | Seen tasks, held-out shifts, and real-world confirmation |
+
+## Decision Lens
+
+SimpleVLA-RL informs whether scaling rollout infrastructure can extract more from a strong SFT policy than scaling demonstration data. Its atomic unit is a group of task-conditioned trajectories whose relative rewards produce advantages. The policy remains an OpenVLA-OFT continuous chunk model, so likelihood and masking must align with that action interface.
+
+The results establish that RL can outperform SFT in several simulation and real settings. A missing control measures total environment, tuning, and compute cost against failure-targeted SFT. At ten times the worker count, policy staleness and correlated environments become critical; at ten times the task count, reward homogeneity causes advantage collapse. The claim fails if newly discovered behaviors do not transfer outside the training simulator.
+
+**Context:** SimpleVLA-RL is the reference implementation for fleet-like parallel VLA rollouts and group-relative updates.
+
+**Limits:** High success on benchmark rewards can hide changes in smoothness, safety, and strategy diversity.
+
+**Takeaway:** VLA RL scales only when rollout diversity produces informative advantages and the infrastructure preserves their provenance.

--- a/src/content/posts/visualprm-process-reward-model-for-multimodal-reasoning.md
+++ b/src/content/posts/visualprm-process-reward-model-for-multimodal-reasoning.md
@@ -1,0 +1,42 @@
+---
+title: 'VisualPRM: An Effective Process Reward Model for Multimodal Reasoning'
+date: '2025-03-13T09:00:00.000Z'
+section: paper-shorts
+postSlug: visualprm-process-reward-model-for-multimodal-reasoning
+legacyPath: /paper shorts/2025/03/13/visualprm-process-reward-model-for-multimodal-reasoning.html
+tags:
+  - Multimodal Reasoning
+  - Reward Models
+field: 'Alignment & Post-Training'
+summary: 2025 – VisualPRM supplies step-level multimodal supervision and a benchmark for critic quality.
+---
+
+## 2025 – VisualPRM: An Effective Process Reward Model for Multimodal Reasoning
+
+**arXiv:** [2503.10291](https://arxiv.org/abs/2503.10291)
+
+VisualPRM is an 8B process reward model trained to judge intermediate steps in multimodal reasoning. It introduces an automated 400K-example process-supervision dataset and VisualProcessBench, which contains human-labeled step correctness for evaluating critics rather than only final answers.
+
+## Paper Insights
+
+At inference, a policy model generates several reasoning traces and VisualPRM selects among them. Best-of-8 improves six model sizes/families; the paper reports a 5.9-point average gain even for InternVL2.5-78B across seven benchmarks. VisualPRM outperforms outcome reward and self-consistency baselines in the studied comparisons.
+
+The transferable lesson for robotics is methodological. A process critic needs its own benchmark with localized error labels. However, a text reasoning step is inspectable and reversible in ways a physical transition is not. Robot progress supervision must additionally represent geometry, contact, timing, and causal state change.
+
+| Artifact | Purpose |
+| --- | --- |
+| VisualPRM400K | Trains step-level multimodal error detection |
+| VisualProcessBench | Measures critic accuracy on human-labeled steps |
+| Best-of-$N$ evaluation | Tests whether critic ranking improves the policy output |
+
+## Decision Lens
+
+VisualPRM informs whether to spend compute on more policy samples or on a critic capable of ranking their reasoning paths. Its unit is an intermediate multimodal reasoning step. The critic is separate from the policy, so policy scale and critic quality can be varied independently.
+
+The paper establishes value for selection among generated reasoning traces, not for dense robot reward. A missing transfer experiment aligns critic judgments with physical subgoal completion under occlusion and temporal ambiguity. At ten times the rollout length, local step accuracy can still produce globally inconsistent rankings. The process-supervision thesis fails in robotics if step labels do not predict closed-loop outcomes better than terminal success.
+
+**Context:** VisualPRM provides the clean blueprint for evaluating a critic as a model, dataset, and benchmark—not merely as an RL component.
+
+**Limits:** Automated reasoning traces and physical trajectories have different counterfactual and observability structure.
+
+**Takeaway:** Before optimizing a policy against a process reward, prove that the critic can localize the errors that cause final failure.

--- a/src/content/posts/vla-replica-low-cost-reproducible-real-world-evaluation.md
+++ b/src/content/posts/vla-replica-low-cost-reproducible-real-world-evaluation.md
@@ -1,0 +1,44 @@
+---
+title: 'VLA-REPLICA: A Low-Cost, Reproducible Benchmark for Real-World VLA Evaluation'
+date: '2026-05-20T09:00:00.000Z'
+section: paper-shorts
+postSlug: vla-replica-low-cost-reproducible-real-world-evaluation
+legacyPath: /paper shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html
+tags:
+  - Robotics
+  - Evaluation
+field: 'Robot Post-Training & Evaluation'
+summary: 2026 – VLA-REPLICA standardizes an inexpensive real-world benchmark that independent labs can rebuild.
+---
+
+## 2026 – VLA-REPLICA: A Low-Cost, Reproducible Benchmark for Real-World VLA Evaluation
+
+**arXiv:** [2605.20774](https://arxiv.org/abs/2605.20774)
+
+**Project:** [VLA-REPLICA](https://irvlutd.github.io/VLAReplica/)
+
+VLA-REPLICA addresses a gap between scalable simulation and expensive centralized robot evaluation. It specifies a low-cost SO-101 arm, cameras, lighting enclosure, fixed workspace, ten manipulation tasks, adaptation demonstrations, and in-/out-of-distribution protocols that independent labs can assemble locally.
+
+## Paper Insights
+
+The tasks span pick-and-place, object interaction, and memory-dependent behavior. Independent replicas produce consistent policy results, which is the paper's most important evidence: a benchmark is useful only if rebuilding it does not change the ranking. The controlled light box reduces nuisance variation while deliberate OOD settings reintroduce chosen shifts.
+
+Low cost changes the cadence of evaluation. Instead of one lab reporting a small number of real trials, multiple groups can reproduce the setup and accumulate evidence about hardware, operator, and site variability.
+
+| Design choice | Benefit | Tradeoff |
+| --- | --- | --- |
+| Off-the-shelf hardware | Broad reproducibility | Limited dexterity and task envelope |
+| Controlled workspace | Comparable trials | Understates open-world variation |
+| Local execution | Fast, transparent iteration | Requires calibration discipline across sites |
+
+## Decision Lens
+
+VLA-REPLICA informs whether to centralize evaluation on expensive hardware or distribute a standardized low-cost real setup. Its unit is a real closed-loop trial with a fixed protocol and explicit shift condition. Replication across independently assembled systems is the scaling variable that matters.
+
+The paper establishes initial cross-site consistency for a bounded task suite. A missing study measures how calibration drift, wear, and operator choices affect confidence intervals over months. At ten times the sites, protocol compliance becomes the bottleneck. The benchmark fails its central claim if inter-lab variance is comparable to the policy improvements it is meant to detect.
+
+**Context:** VLA-REPLICA complements SIMPLER: one scales simulation, the other makes real evaluation cheap enough to repeat.
+
+**Limits:** A reproducible tabletop does not represent the breadth of household or industrial robotics.
+
+**Takeaway:** A smaller real benchmark can be more decision-useful than a broader one that nobody else can reproduce.

--- a/src/content/posts/vlac-vision-language-action-critic-for-real-world-rl.md
+++ b/src/content/posts/vlac-vision-language-action-critic-for-real-world-rl.md
@@ -1,0 +1,42 @@
+---
+title: 'VLAC: A Vision-Language-Action-Critic Model for Real-World Reinforcement Learning'
+date: '2025-09-19T09:00:00.000Z'
+section: paper-shorts
+postSlug: vlac-vision-language-action-critic-for-real-world-rl
+legacyPath: /paper shorts/2025/09/19/vlac-vision-language-action-critic-for-real-world-rl.html
+tags:
+  - Robotics
+  - Reward Models
+field: 'Robot Post-Training & Evaluation'
+summary: 2025 – VLAC predicts dense visual progress and completion signals inside an asynchronous real-robot RL loop.
+---
+
+## 2025 – VLAC: A Vision-Language-Action-Critic Model for Real-World Reinforcement Learning
+
+**arXiv:** [2509.15937](https://arxiv.org/abs/2509.15937)
+
+VLAC turns a multimodal model into a process critic. Given a language goal and two observations, it predicts signed progress and completion; prompt control also lets the same autoregressive model emit actions. Training mixes vision-language tasks, more than 4,000 hours of robot/human trajectories, and constructed negatives for regressions, stagnation, irrelevant goals, and semantic mismatches.
+
+## Paper Insights
+
+The critic sits inside an asynchronous real-world RL system with graded human support: demonstration replay, return-and-explore, and human-guided exploration. Across four real manipulation tasks, the paper reports improvement from roughly 30% to roughly 90% success within 200 interaction episodes; human intervention improves sample efficiency by about 50% and final success reaches as high as 100%.
+
+Dense progress is more informative than terminal success, but also easier to exploit. A model can reward visual motion, object proximity, or familiar subtask order without understanding contact or irreversible damage. VLAC's negative construction is therefore as important as its scale.
+
+| Critic output | Intended role | Failure risk |
+| --- | --- | --- |
+| Progress delta | Dense learning signal | Rewards visible motion without causal progress |
+| Done probability | Episode termination | Confuses appearance with completion |
+| Action tokens | Shared actor interface | Actor and critic errors become correlated |
+
+## Decision Lens
+
+VLAC informs whether to hand-engineer rewards, learn a task-specific success detector, or train a general visual-language process critic. Its atomic unit is a pair of temporally related observations plus a goal; progress labels come from ordering and curated negatives. Actor and critic share one model interface, buying transfer while increasing correlated-failure risk.
+
+The real-robot loop establishes promising sample efficiency on four tasks, not universal reward validity. A missing ablation gives the critic structured geometry/contact state and tests whether that changes reward hacking and transfer. At ten times the task diversity, visually similar but physically different progress will dominate. The central claim fails if critic score improves while blinded human success, safety, or intervention rate does not.
+
+**Context:** VLAC makes the learned critic—not the policy—the central reusable model in real-world post-training.
+
+**Limits:** Progress supervision inferred from time can label pauses or necessary backtracking incorrectly.
+
+**Takeaway:** A general critic needs explicit negative cases for regression, stagnation, and goal mismatch; scale alone does not make progress causal.


### PR DESCRIPTION
## Summary
- add 26 decision-oriented notes spanning alignment, robot policy learning, VLA post-training, critics, and evaluation
- publish a deep Post-Training Vision-Language-Action Models: Zero to Hero guide
- rewrite the omni-model pretraining article as a literature-led Zero to Hero guide
- add two cross-paper decision graphics and a dedicated Robot Post-Training & Evaluation category

## Validation
- npm run ci
- 47 Astro files: 0 errors, 0 warnings, 0 hints
- 18 tests passed
- 155 static pages built
- build verifier confirmed 9 critical pages and 23 post routes
- browser QA confirmed both guides render without overflow, broken images, or console warnings