### PR TITLE
Route website writing through layered skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Agent Notes
 
+## Website Writing Skills
+
+- Apply the global `writing-style` skill to every prose change in this repository, including shelf copy and Code practice text.
+- Also apply exactly the matching category overlay: `write-paper-note`, `write-blog-post`, `write-build-intuition`, `write-revision-notes`, or `write-code-practice-problem`.
+- Use `publish-website-writing` when the request includes adding, publishing, or shipping content. It owns routing and validation; category skills own format; `writing-style` alone owns shared topic, continuity, and prose rules.
+- Do not copy shared prose rules into category skills. Update `writing-style` when a rule should apply everywhere and update an overlay only when the category genuinely differs.
+
 ## Math In Posts
 
 - Use `$...$` for inline math and `$$...$$` for display math in markdown posts.


### PR DESCRIPTION
## What changed
- require the global writing-style base for every prose edit
- route each website category through one matching template
- keep publishing, category format, and shared prose rules in separate layers

## Why
The writing skills now live in the public skill-garden repository and need one durable integration point in the website repo.

## Validation
- git diff --check
- npm run ci