### PR TITLE
Add three arXiv paper notes on world models and self-play

### DIFF
--- a/src/content/posts/qwen-robotworld-unifying-embodied-world-modeling-through-language-conditioned-video-generation.md
+++ b/src/content/posts/qwen-robotworld-unifying-embodied-world-modeling-through-language-conditioned-video-generation.md
@@ -1,0 +1,59 @@
+---
+title: 'Qwen-RobotWorld: Unifying Embodied World Modeling through Language-Conditioned Video Generation'
+date: '2026-07-24T13:00:00.000Z'
+section: paper-shorts
+postSlug: qwen-robotworld-unifying-embodied-world-modeling-through-language-conditioned-video-generation
+legacyPath: /paper shorts/2026/07/24/qwen-robotworld-unifying-embodied-world-modeling-through-language-conditioned-video-generation.html
+tags:
+  - World Models
+  - Robotics
+  - Video Generation
+field: 'Video & Interactive World Models'
+topics:
+  - generation
+  - embodied
+  - multimodal
+summary: '2026 – Qwen-RobotWorld: Unifying Embodied World Modeling through Language-Conditioned Video Generation'
+---
+
+## 2026 – Qwen-RobotWorld
+
+**arXiv:** [2606.17030](https://arxiv.org/abs/2606.17030)
+
+**Project:** [Qwen-RobotWorld](https://qwen.ai/blog?id=qwen-robotworld)
+
+Qwen-RobotWorld treats natural language as a common action interface for robotic manipulation, autonomous driving, indoor navigation, and human-to-robot transfer. Given an initial observation and an instruction, the model generates the future video rather than predicting embodiment-specific joint commands. The contribution is therefore a shared visual transition model: heterogeneous experience can train one backbone after each action has been expressed as language.
+
+The reported model combines a frozen 7B Qwen2.5-VL action encoder, a 127M-parameter Wan VAE, and a 20B-parameter, 60-block double-stream multimodal diffusion transformer. Its Embodied World Knowledge corpus contains 8.6M video-text pairs and more than 200M frames, spanning more than 20 embodiments and 500 action categories. This is unusually broad evidence for instruction-conditioned embodied video, but the paper evaluates generated futures rather than a policy acting from those futures.
+
+## Paper Insights
+
+The architecture keeps language understanding and video generation in separate token streams. Qwen2.5-VL converts the instruction into hidden states; the VAE compresses the observed and target frames; and every MMDiT block uses joint attention to couple the semantic stream with noisy video latents. A 3D rotary encoding allocates position dimensions asymmetrically across time, height, and width, while synchronized views are concatenated during training so the same denoising problem must remain geometrically consistent across cameras.
+
+Training proceeds from general visual priors to embodied specialization. Pretraining mixes text-to-image, text-to-video, and text-image-to-video objectives with general videos, images, and first-person manipulation data. Supervised fine-tuning then increases multi-embodiment, wrist-view, third-person, synchronized multi-view, and high-complexity task data in phases, while retaining general-world samples in every batch. The objective is flow matching in VAE latent space. Exact per-source mixture ratios, total training FLOPs, and optimizer-scale details are not reported.
+
+Scene2Robot extends first-frame conditioning into three segments: a human demonstration with the hands removed, a simulated reference execution by the target robot, and noisy latents for the output. Only the output segment receives the denoising loss; joint attention can read scene appearance, target morphology and motion, and the language instruction at every block. This turns human-to-robot transfer into conditioned video editing, not direct policy learning.
+
+| Evaluation | Qwen-RobotWorld | Strong comparison | Boundary |
+| --- | ---: | ---: | --- |
+| EWMBench overall | 4.60 | LVP: 4.05 | Only 21 samples across 7 ordered manipulation tasks |
+| EWMBench motion fidelity, HSD | 0.566 | LVP: 0.425 | Metric evidence, not closed-loop contact success |
+| DreamGen total | 4.952 | LVP: 4.758 | GR1-Behavior instruction following trails LVP and GigaWorld |
+| WorldModelBench total | 8.99 | Wan2.6: 9.27; Veo3: 9.25 | Best open model in the table, third overall |
+| PBench overall | 0.804 | Best open model; Kling: 0.821 | Aesthetic and imaging quality are comparatively lower |
+
+The benchmark pattern is coherent: the model leads the open embodied baselines on motion, scene consistency, and instruction-conditioned physical behavior, while lower-resolution generation gives up pixel-level image quality. RoboTwin-IF and cross-domain examples add zero-shot qualitative evidence for multi-view consistency and instruction following, but the report does not provide a closed-loop intervention study showing that a robot policy improves when trained, planned, or evaluated with the generated rollouts.
+
+## Decision Lens
+
+Qwen-RobotWorld informs whether an embodied world-model program should preserve native action spaces or translate heterogeneous actions into a language interface before learning dynamics. Language substantially enlarges the usable data mixture and permits one transition model to span hands, manipulators, vehicles, and navigation agents. The cost is that a high-level caption can discard timing, force, and control precision that joint-space or trajectory conditions retain.
+
+The expensive decision is therefore the interface, not merely the 20B backbone. A matched-compute test should train a language-conditioned generalist and action-native domain experts on the same underlying episodes, then compare counterfactual instruction sensitivity, multi-step state accuracy, and downstream policy gains. The generalist claim weakens if its benchmark advantage disappears under matched data or if generated futures cannot improve closed-loop control over ordinary video augmentation.
+
+At ten times the task diversity, annotation fidelity and action ambiguity are likely to dominate model capacity. The paper’s hierarchical captions reduce heterogeneity, but they do not prove that language preserves every control-relevant variable. A useful deployment gate is intervention consistency: changing only the commanded object, destination, or action should change the corresponding future while leaving unrelated scene state invariant.
+
+**Context:** Qwen-RobotWorld moves embodied video models from domain-specific action encodings toward one language-conditioned transition model trained across manipulation and mobility.
+
+**Limits:** The strongest results are generation benchmarks, several evaluators depend on vision-language models, and the report does not establish policy improvement or real-world closed-loop safety. Long-horizon behavior following, output resolution, and exact training-cost accounting remain weaker or unreported.
+
+**Takeaway:** Language can unify embodied experience at data scale, but a useful world model must still prove that its generated consequences preserve the control variables a downstream policy needs.

--- a/src/content/posts/robust-autonomy-emerges-from-self-play.md
+++ b/src/content/posts/robust-autonomy-emerges-from-self-play.md
@@ -1,0 +1,56 @@
+---
+title: 'Robust Autonomy Emerges from Self-Play'
+date: '2026-07-24T13:00:00.000Z'
+section: paper-shorts
+postSlug: robust-autonomy-emerges-from-self-play
+legacyPath: /paper shorts/2026/07/24/robust-autonomy-emerges-from-self-play.html
+tags:
+  - Autonomous Driving
+  - Reinforcement Learning
+  - Self-Play
+field: 'Reinforcement Learning'
+topics:
+  - autonomy
+  - learning
+summary: '2025 – Robust Autonomy Emerges from Self-Play'
+---
+
+## 2025 – Robust Autonomy Emerges from Self-Play
+
+**arXiv:** [2502.03349](https://arxiv.org/abs/2502.03349)
+
+GIGAFLOW asks how far autonomous-driving policy learning can go without demonstrations, recorded traffic, or hand-scripted scenarios. Its answer is a six-million-parameter policy trained by PPO for one trillion state transitions—1.6B simulated kilometers—while every vehicle, pedestrian, and cyclist is controlled by the same network. Evaluated zero-shot, that policy exceeds the reported specialist results on CARLA, nuPlan, and Waymax despite never training on their logs.
+
+The result depends on simulation throughput as much as reinforcement learning. One eight-A100 node runs 38,400 environments and as many as 5.76M agents, collects 4.4B state transitions per hour, and completes the full run in about 1,900 GPU-hours. This makes rare interactive failures common enough to train on, but the policy observes structured map and actor state rather than camera or lidar measurements.
+
+## Paper Insights
+
+Each agent sees an egocentric set representation of lane samples, road boundaries, stop controls, nearby actors, its own state, and a goal. A permutation-invariant Deep Sets-style network maps those observations to low-level actions. The same weights control bodies ranging from pedestrians to trucks; dimensions and dynamics enter as conditioning, so one batched forward pass serves all actors.
+
+Behavioral diversity comes from reward conditioning. Per-agent coefficients vary the priority assigned to goals, collision and off-road avoidance, comfort, lane alignment, lane centering, speed, reversing, and traffic controls. An agent sees its own coefficients but not those of surrounding agents, forcing the policy to respond to drivers whose styles are uncertain. At inference, the coefficients can select a cautious policy from the learned family without retraining.
+
+PPO would otherwise spend most updates on ordinary, near-zero-advantage driving. GIGAFLOW filters as much as 80% of samples with small absolute estimated advantage, concentrating optimization on transitions where an action is measurably better or worse. The paper’s ablation shows that this advantage filtering accelerates nuPlan, CARLA, robustness, and task-completion learning, although the main comparison does not separate the contribution of every simulator and policy design choice under equal compute.
+
+| Evaluation | GIGAFLOW | Prior comparison | Important qualification |
+| --- | ---: | ---: | --- |
+| nuPlan Val14 closed-loop score | 93.8 ± 0.11 | Diffusion-ES: 92.2 | Uses Challenge 3 proxy because the online server was unavailable |
+| CARLA LAV driving score | 99 ± 1 | Jaeger expert: 94 reported, 92 ± 9 rerun | Privileged structured observations and adapted benchmark setup |
+| CARLA Longest6 driving score | 92 ± 2 | Jaeger expert rerun: 83 ± 1 | Three stochastic evaluation runs |
+| Waymax aggregate score | 99.16 ± 0.009 | BC: at most 94.3 | Paper-defined aggregate because Waymax has no official single score |
+| WOSAC realism meta-metric | 0.619 | Expert demonstration: 0.722 | Zero-shot and human-data-free, but below specialist imitation models |
+
+Scaling changes qualitative behavior. Diagnostic merges that fail at $10^8$ transitions become reliable only around $10^{11}$, and the most complex road-closure interactions require roughly $10^{12}$. In a safety-configured self-play evaluation, the final policy averages more than 3M km, or 17.5 years of continuous driving, between collision or off-road incidents. That figure measures the paper’s abstract simulator, not public-road exposure.
+
+## Decision Lens
+
+GIGAFLOW informs whether an autonomy program should invest first in more logged human driving or in a simulator capable of generating interactive on-policy experience. Its evidence supports self-play for planning and negotiation when structured state is available: scale exposes recovery, contention, and long-horizon rerouting states that passive logs sample sparsely.
+
+The atomic training unit is a transition from millions of concurrently acting agents, but parameter sharing makes those samples correlated. Reward randomization supplies behavioral diversity without maintaining separate opponent populations. A decisive matched-budget control would compare the shared conditional policy with independently parameterized or population-based agents while holding simulator steps and compute fixed; the claim weakens if robustness comes mainly from reward engineering or shared-policy conventions.
+
+At ten times the perceptual realism, simulator throughput is the likely bottleneck. The current result deliberately abstracts sensing, and photorealistic rendering would make one trillion transitions far more expensive. The next falsification step is to transfer the policy through a learned perception stack and measure closed-loop failures under sensor noise, novel geometry, and real vehicles—not merely replayed human scenarios.
+
+**Context:** GIGAFLOW shows that self-play can produce a generalist driving policy when environment throughput, shared-agent inference, and tail-focused updates are designed as one system.
+
+**Limits:** Training and evaluation remain in simulation; the policy receives privileged structured state and does not solve perception. Several benchmark actors are scripted or log-replayed, and the strongest robustness number comes from a simplified internal environment.
+
+**Takeaway:** Self-play can replace much of the driving log with interactive experience for planning, but its road relevance depends on whether the structured-state policy survives perception and sim-to-real transfer.

--- a/src/content/posts/scaling-self-play-for-end-to-end-driving.md
+++ b/src/content/posts/scaling-self-play-for-end-to-end-driving.md
@@ -1,0 +1,61 @@
+---
+title: 'Scaling Self-Play for End-to-End Driving'
+date: '2026-07-24T13:00:00.000Z'
+section: paper-shorts
+postSlug: scaling-self-play-for-end-to-end-driving
+legacyPath: /paper shorts/2026/07/24/scaling-self-play-for-end-to-end-driving.html
+tags:
+  - Autonomous Driving
+  - Reinforcement Learning
+  - End-to-End Driving
+field: 'Autonomous Driving: VLA & Planning'
+topics:
+  - autonomy
+  - embodied
+  - learning
+summary: '2026 – Scaling Self-Play for End-to-End Driving'
+---
+
+## 2026 – Scaling Self-Play for End-to-End Driving
+
+**arXiv:** [2606.19641](https://arxiv.org/abs/2606.19641)
+
+**Project:** [Gigapixel](https://montrealrobotics.ca/gigapixel)
+
+GIGAFLOW showed that self-play can train a strong driving policy from privileged vector state; Gigapixel asks whether the same interactive experience can train an end-to-end planner from pixels. Direct pixel-space reinforcement learning is too sample-inefficient at this model scale, so the paper separates the problem: train a compact privileged teacher with PPO, distill it on the student’s own self-play states, then adapt only the student’s perception backbone to real images.
+
+The key systems choice is to avoid photorealism during self-play. Gigapixel renders cuboid agents, lane strips, traffic lights, and simple obstacles from ego-centric perspective at roughly 50,000 agent steps per second. Those images preserve planning geometry while remaining cheap enough for closed-loop multi-agent training. The resulting policy uses pixels, ego state, and a navigation command, but its simulator still begins from 335,000 twenty-second nuPlan scenarios and log-replays pedestrians, cyclists, and traffic lights.
+
+## Paper Insights
+
+Training has three stages. First, a 2.7M-parameter permutation-invariant teacher receives privileged vector observations and trains for 25B agent steps with decentralized PPO. Reward coefficients are randomized and exposed to the policy, producing multiple driving styles from the same weights.
+
+Second, every simulated vehicle is controlled by a pixel student. At each visited state, the simulator forks a parallel rollout in which the teacher produces a future trajectory for every agent. DAgger then trains the student on the distribution created by its own joint behavior rather than on expert-only states. The student receives 150M such steps; because all agents contribute targets, each rollout yields more supervision and more varied interactions than single-agent DAgger.
+
+Third, sim-to-real adaptation uses paired abstract renderings and real NAVSIM frames. The planning head stays frozen while the DINOv2 perception backbone is tuned to match the simulated teacher’s planning outputs and intermediate features. The paper therefore uses real sensor data, but not human trajectories as action supervision. Teacher training takes 24 hours on eight H200 GPUs and pixel-student training takes 36 hours on the same hardware; the adaptation cost is not reported in the main compute summary.
+
+| Evaluation | Self-play result | Matched or strongest comparison | What the result isolates |
+| --- | ---: | ---: | --- |
+| HUGSIM average HD-Score, DrivoR | 38.5 | Behavior-cloned DrivoR: 35.7 | Closed-loop self-play gain for the scoring planner |
+| HUGSIM average HD-Score, DrivoR-Reg | 33.2 | Behavior-cloned DrivoR-Reg: 20.7 | 12.5 points, or 60% relative, for the regression planner |
+| NAVSIM-v2 EPDMS, DrivoR | 50.1 | BC DrivoR: 48.3; DrivoR + SimScale: 54.7 | Competitive without human trajectories, but not best overall |
+| NAVSIM-v2 Stage 2, DrivoR | 63.5 | BC DrivoR: 59.4; DrivoR + SimScale: 64.6 | Gain concentrates in perturbed recovery states |
+| HUGSIM adaptation ablation, DrivoR-Reg | 33.2 | No feature loss: 18.5; also unfreeze planner: 15.8 | Preserving the learned planning interface is essential |
+
+The scale ablation is the clearest evidence for self-play rather than generic distillation. Self-play DAgger overtakes behavior cloning and single-agent DAgger after 10M steps, keeps improving through 150M, and retains a 3.1-point HUGSIM advantage over single-agent DAgger after perception adaptation. Behavior cloning plateaus around 100M steps because it never collects states induced by its own errors.
+
+The gains are not uniform. On HUGSIM’s Extreme tier, behavior-cloned DrivoR scores 32.5 while Gigapixel-DrivoR scores 21.6. The self-play policy is more cautious and can become stuck while adversarial actors close in; the faster behavior-cloned policy sometimes escapes them despite colliding at higher speed. This is a useful warning that an aggregate safety score can reward incompatible strategies across difficulty regimes.
+
+## Decision Lens
+
+Gigapixel informs whether end-to-end driving should learn closed-loop recovery through direct pixel RL, offline imitation, or privileged-teacher distillation. Its evidence favors the third option when a fast vector simulator and teacher are available: DAgger retains the student’s on-policy state distribution while avoiding billions of expensive gradient-bearing pixel-policy interactions.
+
+The expensive interface is the teacher–student boundary. The privileged teacher can act on geometry that is unrecoverable from an occluded camera, so distillation targets may be impossible for the student to match. A matched test should vary teacher observability while holding student architecture, steps, and compute fixed, then measure whether less privilege sacrifices benchmark score but improves calibration and failure recovery.
+
+At ten times the scenario diversity, initialization becomes the next constraint. Gigapixel still starts from nuPlan logs, and its abstract renderer omits debris, unusual obstacles, weather, and lighting. The claim would weaken if gains vanish on procedurally generated initial states or if a behavior-cloned policy with equally targeted recovery data matches self-play at lower compute.
+
+**Context:** Gigapixel connects structured-state self-play to camera-based end-to-end planning by treating privileged RL, on-policy distillation, and perception adaptation as separate stages.
+
+**Limits:** The renderer cannot represent many visual hazards; non-vehicle actors are log-replayed; sim-to-real adaptation requires paired views; and real-world benchmarks remain reconstructed or pseudo-closed-loop. The system does not demonstrate deployment on a physical vehicle.
+
+**Takeaway:** Pixel-based self-play becomes practical when RL stays in the cheap privileged teacher and the end-to-end student learns on its own states—but the remaining sim-to-real gap is a perception and observability problem.


### PR DESCRIPTION
## What changed
- add a source-grounded Qwen-RobotWorld note
- add a GIGAFLOW self-play autonomy note
- add a Gigapixel end-to-end driving note
- classify each note in the research map with compact evidence tables and Decision Lens analysis

## Why
Add the three requested arXiv papers as reviewable, decision-oriented Arxiv Notes.

## Validation
- npm run ci
- generated-route verification for all three legacy paths
- desktop and 390 px mobile browser QA
- no console errors or horizontal page overflow