### PR TITLE
Add persistent retro music player

### DIFF
--- a/public/assets/js/music.js
+++ b/public/assets/js/music.js
@@ -1,94 +1,447 @@
-const SPOTIFY_SRC =
-  'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
-const YOUTUBE_VIDEO_IDS = ['kGuGH_UvvxA', 'z8Dz-IFFFY4', 'tRsQsTMvPNg'];
-const YOUTUBE_SRC = `https://www.youtube.com/embed/${YOUTUBE_VIDEO_IDS[0]}?playlist=${YOUTUBE_VIDEO_IDS
-  .slice(1)
-  .join(',')}&rel=0`;
-const MUSIC_PROVIDER_KEY = 'musicPlayerProvider';
-const MUSIC_SRC_KEY = 'musicPlayerSrc';
-const DEFAULT_MUSIC_PROVIDER = 'spotify';
+const MUSIC_CHANNEL_KEY = 'musicPlayerChannel';
+const MUSIC_PLAYBACK_KEY = 'musicPlayerPlayback';
+const DEFAULT_MUSIC_CHANNEL = 'iranian-jazz';
+const closeTimers = new WeakMap();
+const tuneTimers = new WeakMap();
+const youtubePlayers = new WeakMap();
+let youtubeApiPromise;
 
-function normalizeProvider(value) {
-  return value === 'youtube' ? 'youtube' : DEFAULT_MUSIC_PROVIDER;
+function readPlaybackState() {
+  try {
+    return JSON.parse(sessionStorage.getItem(MUSIC_PLAYBACK_KEY) || '{}');
+  } catch {
+    return {};
+  }
 }
 
-function getRequestedProvider() {
-  const params = new URLSearchParams(window.location.search);
-  const queryProvider = params.get('provider');
+function writePlaybackState(channelId, nextState) {
+  const playback = readPlaybackState();
+  playback[channelId] = {
+    ...playback[channelId],
+    ...nextState,
+    updatedAt: Date.now(),
+  };
+  sessionStorage.setItem(MUSIC_PLAYBACK_KEY, JSON.stringify(playback));
+}
 
-  if (queryProvider === 'spotify' || queryProvider === 'youtube') {
-    return queryProvider;
+function loadYouTubeApi() {
+  if (window.YT?.Player) {
+    return Promise.resolve(window.YT);
   }
 
-  return normalizeProvider(localStorage.getItem(MUSIC_PROVIDER_KEY));
+  if (youtubeApiPromise) {
+    return youtubeApiPromise;
+  }
+
+  youtubeApiPromise = new Promise((resolve) => {
+    const previousReady = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = () => {
+      if (typeof previousReady === 'function') {
+        previousReady();
+      }
+      resolve(window.YT);
+    };
+
+    if (!document.querySelector('script[src="https://www.youtube.com/iframe_api"]')) {
+      const script = document.createElement('script');
+      script.src = 'https://www.youtube.com/iframe_api';
+      script.async = true;
+      document.head.append(script);
+    }
+  });
+
+  return youtubeApiPromise;
 }
 
-function getProviderSrc(provider) {
-  return provider === 'youtube' ? YOUTUBE_SRC : SPOTIFY_SRC;
+function getActiveChannel(player) {
+  return getChannelButtons(player).find((button) => button.classList.contains('music-channel--active'));
 }
 
-function syncUrl(provider) {
-  const url = new URL(window.location.href);
-  url.searchParams.set('provider', provider);
-  window.history.replaceState({}, '', url);
+function persistYouTubePlayback(player) {
+  const iframe = player.querySelector('[data-music-iframe]');
+  const record = iframe instanceof HTMLIFrameElement ? youtubePlayers.get(iframe) : null;
+  const channel = getActiveChannel(player);
+
+  if (!record || channel?.dataset.channelKind !== 'youtube') {
+    return;
+  }
+
+  try {
+    const time = record.api.getCurrentTime();
+    const state = record.api.getPlayerState();
+    if (Number.isFinite(time)) {
+      writePlaybackState(channel.dataset.musicChannel, {
+        time,
+        playing: state === window.YT.PlayerState.PLAYING || state === window.YT.PlayerState.BUFFERING,
+      });
+    }
+  } catch {
+    // The iframe may be between channels or reconnecting during navigation.
+  }
 }
 
-function initMusicPlayer() {
-  const spotifyOption = document.getElementById('choose-spotify');
-  const youtubeOption = document.getElementById('choose-youtube');
-  const closePlayerBtn = document.getElementById('close-music-player');
-  const musicIframe = document.getElementById('music-iframe');
+function startYouTubeProgress(player, iframe, api) {
+  const previousRecord = youtubePlayers.get(iframe);
+  if (previousRecord?.timer) {
+    window.clearInterval(previousRecord.timer);
+  }
+
+  const timer = window.setInterval(() => persistYouTubePlayback(player), 1000);
+  youtubePlayers.set(iframe, { api, timer });
+}
+
+function stopYouTubeProgress(iframe) {
+  const record = youtubePlayers.get(iframe);
+  if (record?.timer) {
+    window.clearInterval(record.timer);
+    youtubePlayers.set(iframe, { api: record.api, timer: null });
+  }
+}
+
+function restoreYouTubePlayback(player, api) {
+  const channel = getActiveChannel(player);
+  const channelId = channel?.dataset.musicChannel;
+  const saved = channelId ? readPlaybackState()[channelId] : null;
+
+  if (!saved || !Number.isFinite(saved.time) || saved.time < 1) {
+    return;
+  }
+
+  try {
+    api.seekTo(saved.time, true);
+    if (saved.playing) {
+      api.playVideo();
+    } else {
+      api.pauseVideo();
+    }
+  } catch {
+    // The player will remain usable even if a provider blocks programmatic resume.
+  }
+}
+
+function connectYouTubePlayer(player) {
+  const iframe = player.querySelector('[data-music-iframe]');
+  const channel = getActiveChannel(player);
 
   if (
-    !(spotifyOption instanceof HTMLButtonElement) ||
-    !(youtubeOption instanceof HTMLButtonElement) ||
-    !(closePlayerBtn instanceof HTMLButtonElement) ||
-    !(musicIframe instanceof HTMLIFrameElement)
+    !(iframe instanceof HTMLIFrameElement) ||
+    channel?.dataset.channelKind !== 'youtube' ||
+    !iframe.src.includes('youtube.com/embed/')
   ) {
     return;
   }
 
-  function syncChoiceState(provider) {
-    spotifyOption.classList.toggle('music-choice--active', provider === 'spotify');
-    spotifyOption.setAttribute('aria-pressed', String(provider === 'spotify'));
-    youtubeOption.classList.toggle('music-choice--active', provider === 'youtube');
-    youtubeOption.setAttribute('aria-pressed', String(provider === 'youtube'));
-  }
-
-  function renderProvider(provider) {
-    const nextProvider = normalizeProvider(provider);
-    const nextSrc = getProviderSrc(nextProvider);
-
-    document.body.dataset.musicProvider = nextProvider;
-    musicIframe.src = nextSrc;
-    localStorage.setItem(MUSIC_PROVIDER_KEY, nextProvider);
-    localStorage.setItem(MUSIC_SRC_KEY, nextSrc);
-    syncUrl(nextProvider);
-    syncChoiceState(nextProvider);
-  }
-
-  spotifyOption.addEventListener('click', () => {
-    renderProvider('spotify');
-  });
-
-  youtubeOption.addEventListener('click', () => {
-    renderProvider('youtube');
-  });
-
-  closePlayerBtn.addEventListener('click', () => {
-    if (window.opener) {
-      window.close();
+  loadYouTubeApi().then((YT) => {
+    const existing = youtubePlayers.get(iframe);
+    if (existing) {
+      restoreYouTubePlayback(player, existing.api);
+      startYouTubeProgress(player, iframe, existing.api);
       return;
     }
 
-    window.location.href = '/';
+    const api = new YT.Player(iframe, {
+      events: {
+        onReady: (event) => {
+          startYouTubeProgress(player, iframe, event.target);
+          restoreYouTubePlayback(player, event.target);
+        },
+        onStateChange: (event) => {
+          startYouTubeProgress(player, iframe, event.target);
+          persistYouTubePlayback(player);
+        },
+      },
+    });
+    youtubePlayers.set(iframe, { api, timer: null });
   });
-
-  renderProvider(getRequestedProvider());
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initMusicPlayer, { once: true });
+function getChannelButtons(player) {
+  return Array.from(player.querySelectorAll('[data-music-channel]')).filter(
+    (button) => button instanceof HTMLButtonElement,
+  );
+}
+
+function getChannel(player, requestedId) {
+  const channels = getChannelButtons(player);
+  return (
+    channels.find((button) => button.dataset.musicChannel === requestedId) ||
+    channels.find((button) => button.dataset.musicChannel === DEFAULT_MUSIC_CHANNEL) ||
+    channels[0]
+  );
+}
+
+function getRequestedChannel(player) {
+  if (player.dataset.musicStandalone === 'true') {
+    const requested = new URLSearchParams(window.location.search).get('channel');
+    if (requested) {
+      return requested;
+    }
+  }
+
+  return localStorage.getItem(MUSIC_CHANNEL_KEY) || DEFAULT_MUSIC_CHANNEL;
+}
+
+function syncStandaloneUrl(player, channelId) {
+  if (player.dataset.musicStandalone !== 'true') {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+  url.searchParams.set('channel', channelId);
+  window.history.replaceState({}, '', url);
+}
+
+function syncChannelDetails(player, channel) {
+  const number = player.querySelector('[data-music-channel-number]');
+  const name = player.querySelector('[data-music-channel-name]');
+  const detail = player.querySelector('[data-music-channel-detail]');
+
+  if (number) number.textContent = `CH ${channel.dataset.channelNumber}`;
+  if (name) name.textContent = channel.dataset.channelName || '';
+  if (detail) detail.textContent = channel.dataset.channelDetail || '';
+
+  getChannelButtons(player).forEach((button) => {
+    const isActive = button === channel;
+    button.classList.toggle('music-channel--active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function tuneToChannel(player, requestedId, animate = true) {
+  const channel = getChannel(player, requestedId);
+  const iframe = player.querySelector('[data-music-iframe]');
+  const tv = player.querySelector('[data-music-tv]');
+
+  if (!(channel instanceof HTMLButtonElement) || !(iframe instanceof HTMLIFrameElement)) {
+    return;
+  }
+
+  const channelId = channel.dataset.musicChannel || DEFAULT_MUSIC_CHANNEL;
+  const channelSrc = channel.dataset.channelSrc;
+  if (!channelSrc) {
+    return;
+  }
+
+  const previousTimer = tuneTimers.get(player);
+  if (previousTimer) {
+    window.clearTimeout(previousTimer);
+  }
+
+  syncChannelDetails(player, channel);
+  if (tv instanceof HTMLElement) {
+    tv.dataset.musicKind = channel.dataset.channelKind || 'youtube';
+  }
+  localStorage.setItem(MUSIC_CHANNEL_KEY, channelId);
+  syncStandaloneUrl(player, channelId);
+
+  if (animate && tv) {
+    tv.classList.add('retro-tv--tuning');
+  }
+
+  const updateFrame = () => {
+    const nextUrl = new URL(channelSrc);
+    if (channel.dataset.channelKind === 'youtube') {
+      nextUrl.searchParams.set('origin', window.location.origin);
+    }
+
+    iframe.title = `${channel.dataset.channelName || 'Music'} player`;
+    if (channel.dataset.channelKind !== 'youtube') {
+      stopYouTubeProgress(iframe);
+    }
+    iframe.src = nextUrl.toString();
+
+    const settle = () => {
+      tv?.classList.remove('retro-tv--tuning');
+      connectYouTubePlayer(player);
+    };
+    iframe.addEventListener('load', settle, { once: true });
+    window.setTimeout(settle, 900);
+  };
+
+  if (animate) {
+    tuneTimers.set(player, window.setTimeout(updateFrame, 140));
+  } else {
+    updateFrame();
+  }
+}
+
+function clearCloseTimer(player) {
+  const priorTimer = closeTimers.get(player);
+  if (priorTimer) {
+    window.clearTimeout(priorTimer);
+  }
+}
+
+function syncTriggerState(trigger, status) {
+  if (!(trigger instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  const isOpen = status === 'open';
+  const isPlaying = status === 'open' || status === 'minimized';
+  trigger.setAttribute('aria-expanded', String(isOpen));
+  trigger.setAttribute(
+    'aria-label',
+    isOpen ? 'Minimize music player' : isPlaying ? 'Restore music player' : 'Open music player',
+  );
+  trigger.classList.toggle('page-controls__button--active', isOpen);
+  trigger.classList.toggle('page-controls__button--playing', isPlaying);
+}
+
+function showPlayer(player, trigger) {
+  clearCloseTimer(player);
+  const wasMinimized = player.dataset.musicStatus === 'minimized';
+
+  player.dataset.musicStatus = 'open';
+  player.hidden = false;
+  player.setAttribute('aria-hidden', 'false');
+  syncTriggerState(trigger, 'open');
+
+  window.requestAnimationFrame(() => {
+    player.classList.add('music-player--visible');
+  });
+
+  if (!wasMinimized) {
+    tuneToChannel(player, getRequestedChannel(player), false);
+  }
+}
+
+function minimizePlayer(player, trigger) {
+  clearCloseTimer(player);
+  player.dataset.musicStatus = 'minimized';
+  player.classList.remove('music-player--visible');
+  player.setAttribute('aria-hidden', 'true');
+  syncTriggerState(trigger, 'minimized');
+
+  closeTimers.set(
+    player,
+    window.setTimeout(() => {
+      if (player.dataset.musicStatus === 'minimized') {
+        player.hidden = true;
+      }
+    }, 240),
+  );
+}
+
+function closePlayer(player, trigger) {
+  clearCloseTimer(player);
+  player.dataset.musicStatus = 'closed';
+  player.classList.remove('music-player--visible');
+  player.setAttribute('aria-hidden', 'true');
+  syncTriggerState(trigger, 'closed');
+
+  closeTimers.set(
+    player,
+    window.setTimeout(() => {
+      player.hidden = true;
+      const iframe = player.querySelector('[data-music-iframe]');
+      if (iframe instanceof HTMLIFrameElement) {
+        persistYouTubePlayback(player);
+        stopYouTubeProgress(iframe);
+        iframe.src = 'about:blank';
+      }
+    }, 240),
+  );
+}
+
+function initMusicPlayer(player) {
+  if (!(player instanceof HTMLElement) || player.dataset.musicReady === 'true') {
+    return;
+  }
+
+  player.dataset.musicReady = 'true';
+  const controller = player.closest('[data-music-controller]');
+  const trigger = controller?.querySelector('[data-music-open]');
+  const minimizeButton = player.querySelector('[data-music-minimize]');
+  const closeButton = player.querySelector('[data-music-close]');
+  const isStandalone = player.dataset.musicStandalone === 'true';
+  const iframe = player.querySelector('[data-music-iframe]');
+
+  if (trigger instanceof HTMLButtonElement) {
+    trigger.addEventListener('click', (event) => {
+      event.stopPropagation();
+      if (player.dataset.musicStatus === 'open') {
+        minimizePlayer(player, trigger);
+      } else {
+        showPlayer(player, trigger);
+      }
+    });
+  }
+
+  if (minimizeButton instanceof HTMLButtonElement) {
+    minimizeButton.addEventListener('click', () => {
+      minimizePlayer(player, trigger instanceof HTMLButtonElement ? trigger : null);
+      trigger?.focus();
+    });
+  }
+
+  if (closeButton instanceof HTMLButtonElement) {
+    closeButton.addEventListener('click', () => {
+      if (isStandalone) {
+        if (window.opener) {
+          window.close();
+        } else {
+          window.location.href = '/';
+        }
+        return;
+      }
+
+      closePlayer(player, trigger instanceof HTMLButtonElement ? trigger : null);
+      trigger?.focus();
+    });
+  }
+
+  getChannelButtons(player).forEach((button) => {
+    button.addEventListener('click', () => {
+      persistYouTubePlayback(player);
+      tuneToChannel(player, button.dataset.musicChannel);
+    });
+  });
+
+  if (iframe instanceof HTMLIFrameElement) {
+    iframe.addEventListener('load', () => connectYouTubePlayer(player));
+  }
+
+  if (isStandalone) {
+    tuneToChannel(player, getRequestedChannel(player), false);
+  }
+}
+
+function initMusicPlayers() {
+  document.querySelectorAll('[data-music-player]').forEach(initMusicPlayer);
+}
+
+function closeMusicPlayersWithEscape(event) {
+  if (event.key !== 'Escape') {
+    return;
+  }
+
+  document.querySelectorAll('[data-music-player]:not([hidden])').forEach((player) => {
+    if (!(player instanceof HTMLElement) || player.dataset.musicStandalone === 'true') {
+      return;
+    }
+
+    const trigger = player.closest('[data-music-controller]')?.querySelector('[data-music-open]');
+    minimizePlayer(player, trigger instanceof HTMLButtonElement ? trigger : null);
+    trigger?.focus();
+  });
+}
+
+if (!window.__musicPlayerNavigationReady) {
+  window.__musicPlayerNavigationReady = true;
+  document.addEventListener('keydown', closeMusicPlayersWithEscape);
+  document.addEventListener('astro:before-swap', () => {
+    document.querySelectorAll('[data-music-player]').forEach((player) => {
+      if (player instanceof HTMLElement) {
+        persistYouTubePlayback(player);
+      }
+    });
+  });
+  document.addEventListener('astro:page-load', initMusicPlayers);
+}
+
+if (document.readyState !== 'loading') {
+  initMusicPlayers();
 } else {
-  initMusicPlayer();
+  document.addEventListener('DOMContentLoaded', initMusicPlayers, { once: true });
 }

--- a/public/assets/js/site-controls.js
+++ b/public/assets/js/site-controls.js
@@ -1,73 +1,8 @@
 const THEME_STORAGE_KEY = 'theme';
-const MUSIC_PROVIDER_KEY = 'musicPlayerProvider';
-const MUSIC_PLAYER_NAME = 'music-player';
-const MUSIC_PLAYER_FEATURES = 'width=420,height=560,resizable=yes,scrollbars=yes';
-const MUSIC_PAGE_PATH = '/music.html';
-const DEFAULT_MUSIC_PROVIDER = 'spotify';
-
-function normalizeProvider(value) {
-  return value === 'youtube' ? 'youtube' : DEFAULT_MUSIC_PROVIDER;
-}
 
 function applyTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme);
   localStorage.setItem(THEME_STORAGE_KEY, theme);
-}
-
-function getMusicPlayerUrl(provider) {
-  const url = new URL(MUSIC_PAGE_PATH, window.location.origin);
-  url.searchParams.set('provider', normalizeProvider(provider));
-  return url.toString();
-}
-
-function setMusicMenuState(control, isOpen) {
-  const toggle = control.querySelector('[data-music-menu-toggle]');
-  const menu = control.querySelector('[data-music-menu]');
-
-  if (!(toggle instanceof HTMLButtonElement) || !(menu instanceof HTMLElement)) {
-    return;
-  }
-
-  toggle.setAttribute('aria-expanded', String(isOpen));
-  toggle.classList.toggle('page-controls__button--active', isOpen);
-  menu.hidden = !isOpen;
-}
-
-function closeMusicMenus(exceptControl = null) {
-  document.querySelectorAll('[data-music-control]').forEach((control) => {
-    if (exceptControl && control === exceptControl) {
-      return;
-    }
-
-    if (control instanceof HTMLElement) {
-      setMusicMenuState(control, false);
-    }
-  });
-}
-
-function syncMusicProviderButtons(provider) {
-  document.querySelectorAll('[data-music-provider]').forEach((button) => {
-    if (!(button instanceof HTMLButtonElement)) {
-      return;
-    }
-
-    const isActive = button.dataset.musicProvider === provider;
-    button.classList.toggle('music-menu__item--active', isActive);
-    button.setAttribute('aria-pressed', String(isActive));
-  });
-}
-
-function openMusicPlayer(provider) {
-  const nextProvider = normalizeProvider(provider);
-  const requestedUrl = getMusicPlayerUrl(nextProvider);
-
-  localStorage.setItem(MUSIC_PROVIDER_KEY, nextProvider);
-  syncMusicProviderButtons(nextProvider);
-
-  const playerWindow = window.open(requestedUrl, MUSIC_PLAYER_NAME, MUSIC_PLAYER_FEATURES);
-  if (!playerWindow) {
-    window.location.href = requestedUrl;
-  }
 }
 
 function slugifyHeading(text) {
@@ -107,7 +42,9 @@ function ensureHeadingIds(headings) {
   });
 }
 
-function buildSectionsNav() {
+let siteControlsAbortController;
+
+function buildSectionsNav(signal) {
   const root = document.querySelector('[data-sections-root]');
   const aside = document.querySelector('[data-sections-nav]');
   const list = document.querySelector('[data-sections-list]');
@@ -158,79 +95,24 @@ function buildSectionsNav() {
   };
 
   updateActiveSection();
-  window.addEventListener('scroll', updateActiveSection, { passive: true });
-  window.addEventListener('resize', updateActiveSection, { passive: true });
+  window.addEventListener('scroll', updateActiveSection, { passive: true, signal });
+  window.addEventListener('resize', updateActiveSection, { passive: true, signal });
 }
 
 function initSiteControls() {
+  siteControlsAbortController?.abort();
+  siteControlsAbortController = new AbortController();
+  const { signal } = siteControlsAbortController;
   const html = document.documentElement;
-  const savedProvider = normalizeProvider(localStorage.getItem(MUSIC_PROVIDER_KEY));
-
-  syncMusicProviderButtons(savedProvider);
 
   document.querySelectorAll('[data-theme-toggle]').forEach((button) => {
     button.addEventListener('click', () => {
       const nextTheme = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
       applyTheme(nextTheme);
-    });
+    }, { signal });
   });
 
-  document.querySelectorAll('[data-home-button]').forEach((button) => {
-    button.addEventListener('click', () => {
-      window.location.href = '/';
-    });
-  });
-
-  document.querySelectorAll('[data-music-control]').forEach((control) => {
-    if (!(control instanceof HTMLElement)) {
-      return;
-    }
-
-    const toggle = control.querySelector('[data-music-menu-toggle]');
-    const providerButtons = control.querySelectorAll('[data-music-provider]');
-
-    if (toggle instanceof HTMLButtonElement) {
-      toggle.addEventListener('click', (event) => {
-        event.stopPropagation();
-
-        const isOpen = toggle.getAttribute('aria-expanded') === 'true';
-        closeMusicMenus(control);
-        setMusicMenuState(control, !isOpen);
-      });
-    }
-
-    providerButtons.forEach((button) => {
-      if (!(button instanceof HTMLButtonElement)) {
-        return;
-      }
-
-      button.addEventListener('click', () => {
-        openMusicPlayer(button.dataset.musicProvider);
-        closeMusicMenus();
-      });
-    });
-  });
-
-  document.addEventListener('click', (event) => {
-    const target = event.target;
-    if (!(target instanceof Element) || target.closest('[data-music-control]')) {
-      return;
-    }
-
-    closeMusicMenus();
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      closeMusicMenus();
-    }
-  });
-
-  buildSectionsNav();
+  buildSectionsNav(signal);
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initSiteControls, { once: true });
-} else {
-  initSiteControls();
-}
+document.addEventListener('astro:page-load', initSiteControls);

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -465,6 +465,19 @@ img:not(.float-right):not(.float-left) {
   box-shadow: var(--button-shadow-hover);
 }
 
+.page-controls__button--playing::after {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--button-bg);
+  border-radius: 50%;
+  background: #ff5a52;
+  box-shadow: 0 0 9px rgba(255, 90, 82, 0.78);
+  content: "";
+}
+
 .button-icon {
   width: 24px;
   height: 24px;
@@ -489,143 +502,528 @@ img:not(.float-right):not(.float-left) {
   transform: scale(1);
 }
 
-.music-menu {
-  position: absolute;
-  top: calc(100% + 10px);
-  right: 0;
-  display: grid;
-  gap: 0.5rem;
-  min-width: 11rem;
-  padding: 0.75rem;
+.music-player {
+  --tv-cabinet: linear-gradient(145deg, #d8e2f2 0%, #aebbd0 52%, #8999b2 100%);
+  --tv-cabinet-edge: rgba(37, 63, 108, 0.36);
+  --tv-console-ink: #273755;
+  --tv-panel-bg: color-mix(in srgb, var(--button-bg) 94%, transparent);
+  --tv-panel-shadow: 0 24px 70px rgba(26, 48, 92, 0.2), var(--button-shadow);
+  --tv-cabinet-highlight: rgba(255, 255, 255, 0.62);
+  --tv-cabinet-shadow: rgba(24, 39, 64, 0.2);
+  --tv-cabinet-drop-shadow: rgba(35, 54, 87, 0.18);
+  --tv-screen-bezel: #111822;
+  --tv-screen-edge: rgba(4, 12, 24, 0.78);
+  --tv-screen-glow: rgba(61, 105, 135, 0.4);
+  color-scheme: light;
+  position: fixed;
+  top: 100px;
+  right: 28px;
+  z-index: 29;
+  width: min(430px, calc(100vw - 36px));
+  box-sizing: border-box;
+  padding: 18px;
+  overflow: visible;
   border: 1px solid var(--button-border);
-  border-radius: 18px;
-  background: var(--button-bg);
-  box-shadow: var(--button-shadow);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  border-radius: 26px;
+  background: var(--tv-panel-bg);
+  box-shadow: var(--tv-panel-shadow);
+  color: var(--text-color);
+  opacity: 0;
+  transform: translateY(-10px) scale(0.97);
+  transform-origin: top right;
+  transition:
+    opacity 0.2s ease,
+    transform 0.24s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.24s ease,
+    border-color 0.24s ease,
+    box-shadow 0.24s ease,
+    color 0.24s ease;
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
 }
 
-.music-menu[hidden] {
+.music-player[hidden] {
   display: none;
 }
 
-.music-menu__item {
-  width: 100%;
-  padding: 0.7rem 0.9rem;
-  border: 1px solid rgba(125, 162, 247, 0.18);
-  border-radius: 14px;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(14, 165, 233, 0.18));
+.music-player--visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.music-player--standalone {
+  position: relative;
+  inset: auto;
+  z-index: 1;
+  width: min(500px, calc(100vw - 32px));
+  margin: auto;
+  transform-origin: center;
+}
+
+:root[data-theme="dark"] .music-player {
+  --tv-cabinet: linear-gradient(145deg, #34342c 0%, #22231e 55%, #151611 100%);
+  --tv-cabinet-edge: rgba(255, 228, 92, 0.32);
+  --tv-console-ink: #f7df68;
+  --tv-panel-bg: color-mix(in srgb, var(--button-bg) 96%, transparent);
+  --tv-panel-shadow: 0 28px 80px rgba(0, 0, 0, 0.62), var(--button-shadow);
+  --tv-cabinet-highlight: rgba(255, 239, 153, 0.1);
+  --tv-cabinet-shadow: rgba(0, 0, 0, 0.5);
+  --tv-cabinet-drop-shadow: rgba(0, 0, 0, 0.48);
+  --tv-screen-bezel: #080a08;
+  --tv-screen-edge: rgba(255, 228, 92, 0.2);
+  --tv-screen-glow: rgba(255, 207, 59, 0.16);
+  color-scheme: dark;
+}
+
+.music-player__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 16px;
+}
+
+.music-player__eyebrow {
+  margin: 0 0 2px;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.music-player__header h2 {
+  margin: 0;
   color: var(--text-color);
-  font: inherit;
-  font-weight: 600;
-  text-align: left;
+  font-family: var(--font-heading);
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.music-player__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.music-player__minimize,
+.music-player__close {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  border: 1px solid var(--button-border);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--button-bg-hover) 92%, transparent);
+  color: var(--text-color);
   cursor: pointer;
   transition:
-    transform 0.15s ease,
-    background 0.2s ease,
-    color 0.2s ease,
-    box-shadow 0.2s ease;
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background 0.18s ease;
 }
 
-.music-menu__item:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.14);
+.music-player__minimize span::after {
+  position: absolute;
+  bottom: 11px;
+  left: 10px;
+  width: 15px;
+  height: 1.5px;
+  border-radius: 999px;
+  background: currentColor;
+  content: "";
 }
 
-.music-menu__item:focus-visible {
+.music-player__close span::before,
+.music-player__close span::after {
+  position: absolute;
+  top: 17px;
+  left: 10px;
+  width: 15px;
+  height: 1.5px;
+  border-radius: 999px;
+  background: currentColor;
+  content: "";
+}
+
+.music-player__close span::before {
+  transform: rotate(45deg);
+}
+
+.music-player__close span::after {
+  transform: rotate(-45deg);
+}
+
+.music-player__minimize:hover,
+.music-player__close:hover {
+  border-color: var(--accent-color);
+  background: var(--button-bg-hover);
+}
+
+.music-player__minimize:hover {
+  transform: translateY(1px);
+}
+
+.music-player__close:hover {
+  transform: rotate(4deg);
+}
+
+.music-player__minimize:focus-visible,
+.music-player__close:focus-visible,
+.music-channel:focus-visible {
   outline: 2px solid var(--accent-color);
-  outline-offset: 2px;
+  outline-offset: 3px;
 }
 
-.music-menu__item--active {
-  border-color: transparent;
-  background: linear-gradient(135deg, var(--music-bg-start), var(--music-bg-end));
-  color: #ffffff;
+.retro-tv {
+  position: relative;
+  padding-top: 12px;
 }
 
-#music-widget {
-  text-align: center;
-  background-color: var(--button-bg);
-  border: 1px solid var(--button-border);
-  border-radius: 24px;
-  box-shadow: var(--button-shadow);
+.retro-tv__aerial {
+  position: absolute;
+  top: -7px;
+  left: 50%;
+  width: 82px;
+  height: 30px;
+  transform: translateX(-50%);
+}
+
+.retro-tv__aerial::after {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 28px;
+  height: 8px;
+  border: 1px solid var(--tv-cabinet-edge);
+  border-radius: 8px 8px 2px 2px;
+  background: var(--tv-cabinet);
+  content: "";
+  transform: translateX(-50%);
+}
+
+.retro-tv__aerial span {
+  position: absolute;
+  bottom: 5px;
+  left: 50%;
+  width: 2px;
+  height: 34px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tv-console-ink) 62%, transparent);
+  transform-origin: bottom;
+}
+
+.retro-tv__aerial span:first-child {
+  transform: rotate(-38deg);
+}
+
+.retro-tv__aerial span:last-child {
+  transform: rotate(38deg);
+}
+
+.retro-tv__cabinet {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 66px;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--tv-cabinet-edge);
+  border-radius: 28px 28px 23px 23px;
+  background: var(--tv-cabinet);
+  box-shadow:
+    inset 0 1px 1px var(--tv-cabinet-highlight),
+    inset 0 -2px 3px var(--tv-cabinet-shadow),
+    0 14px 26px var(--tv-cabinet-drop-shadow);
+  transition:
+    background 0.24s ease,
+    border-color 0.24s ease,
+    box-shadow 0.24s ease;
+}
+
+.retro-tv__cabinet::after {
+  position: absolute;
+  right: 15%;
+  bottom: -7px;
+  left: 15%;
+  height: 7px;
+  border-radius: 0 0 12px 12px;
+  background: color-mix(in srgb, var(--tv-console-ink) 48%, transparent);
+  content: "";
+  filter: blur(0.2px);
+}
+
+.retro-tv__screen-bezel {
+  min-width: 0;
+  padding: 7px;
+  border: 1px solid var(--tv-screen-edge);
+  border-radius: 21px;
+  background: var(--tv-screen-bezel);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 255, 255, 0.05),
+    0 1px 0 rgba(255, 255, 255, 0.2);
+  transition:
+    background 0.24s ease,
+    border-color 0.24s ease;
+}
+
+.retro-tv__screen {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border-radius: 15px;
+  background:
+    radial-gradient(circle at center, var(--tv-screen-glow), transparent 65%),
+    #030609;
+  box-shadow:
+    inset 0 0 28px rgba(0, 0, 0, 0.78),
+    inset 0 0 0 1px rgba(174, 216, 239, 0.14);
+}
+
+.retro-tv__screen iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #000;
+}
+
+.retro-tv__scanlines,
+.retro-tv__static {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.retro-tv__scanlines {
+  z-index: 2;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.07), transparent 20% 76%, rgba(255, 255, 255, 0.025)),
+    repeating-linear-gradient(0deg, rgba(3, 8, 12, 0.18) 0, rgba(3, 8, 12, 0.18) 1px, transparent 1px, transparent 4px);
+  mix-blend-mode: screen;
+  opacity: 0.45;
+}
+
+.retro-tv__static {
+  z-index: 3;
+  background:
+    repeating-radial-gradient(circle at 18% 32%, #fff 0 0.5px, transparent 0.8px 3px),
+    repeating-radial-gradient(circle at 72% 61%, #a8c5d8 0 0.6px, transparent 1px 4px),
+    #111;
+  background-size: 7px 9px, 11px 8px, auto;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.retro-tv--tuning .retro-tv__static {
+  opacity: 0.88;
+  animation: tv-static 0.12s steps(2, end) infinite;
+}
+
+.retro-tv__console {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: center;
+  padding: 9px 4px 5px;
+  color: var(--tv-console-ink);
+}
+
+.retro-tv__on-air {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+}
+
+.retro-tv__on-air span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ff5a52;
+  box-shadow: 0 0 8px rgba(255, 67, 58, 0.75);
+  animation: on-air-pulse 2.6s ease-in-out infinite;
+}
+
+.retro-tv__dial {
+  position: relative;
+  width: 38px;
+  height: 38px;
+  margin-top: 16px;
+  border: 1px solid color-mix(in srgb, var(--tv-console-ink) 55%, transparent);
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(from -5deg, rgba(255, 255, 255, 0.24) 0 3deg, transparent 3deg 18deg),
+    color-mix(in srgb, var(--tv-console-ink) 16%, transparent);
+  box-shadow:
+    inset 0 0 0 5px color-mix(in srgb, var(--tv-console-ink) 10%, transparent),
+    0 3px 7px rgba(9, 15, 27, 0.24);
+}
+
+.retro-tv__dial span {
+  position: absolute;
+  top: 5px;
+  left: 50%;
+  width: 2px;
+  height: 11px;
+  border-radius: 999px;
+  background: var(--tv-console-ink);
+  transform: translateX(-50%) rotate(28deg);
+  transform-origin: 50% 14px;
+}
+
+.retro-tv__speaker {
+  width: 42px;
+  flex: 1;
+  min-height: 54px;
+  margin-top: 16px;
+  border-radius: 9px;
+  background-image: radial-gradient(circle, color-mix(in srgb, var(--tv-console-ink) 64%, transparent) 0 1.2px, transparent 1.4px);
+  background-position: center;
+  background-size: 7px 7px;
+  opacity: 0.76;
+}
+
+.music-player__now-playing {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 11px;
+  margin: 17px 2px 12px;
+  text-align: left;
+}
+
+.music-player__channel-number {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 9px;
+  border: 1px solid color-mix(in srgb, var(--accent-color) 32%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-color) 9%, transparent);
+  color: var(--accent-color);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+}
+
+.music-player__now-playing strong,
+.music-player__now-playing small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.music-player__now-playing strong {
   color: var(--text-color);
-  padding: 18px;
-  width: min(100%, 380px);
-  margin: auto;
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  font-family: var(--font-heading);
+  font-size: 0.78rem;
+  letter-spacing: 0.035em;
 }
 
-:root[data-theme="light"] #music-widget,
+.music-player__now-playing small {
+  margin-top: 2px;
+  color: var(--text-secondary-color);
+  font-size: 0.78rem;
+  line-height: 1.25;
+}
+
+.music-channels {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.music-channel {
+  min-width: 0;
+  padding: 9px 8px 8px;
+  overflow: hidden;
+  border: 1px solid var(--button-border);
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--button-bg-hover) 74%, transparent);
+  color: var(--text-secondary-color);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: 0.76rem;
+  font-weight: 600;
+  line-height: 1.15;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition:
+    transform 0.16s ease,
+    border-color 0.18s ease,
+    background 0.18s ease,
+    color 0.18s ease;
+}
+
+.music-channel span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.56rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+}
+
+.music-channel:hover {
+  border-color: color-mix(in srgb, var(--accent-color) 46%, transparent);
+  color: var(--text-color);
+  transform: translateY(-1px);
+}
+
+.music-channel--active {
+  border-color: color-mix(in srgb, var(--accent-color) 54%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 12%, var(--button-bg));
+  color: var(--text-color);
+}
+
+.music-channel--active span {
+  color: var(--accent-color);
+}
+
+@keyframes tv-static {
+  0% {
+    background-position: 0 0, 0 0, 0 0;
+  }
+  50% {
+    background-position: 3px -4px, -5px 2px, 0 0;
+  }
+  100% {
+    background-position: -4px 3px, 4px -3px, 0 0;
+  }
+}
+
+@keyframes on-air-pulse {
+  0%,
+  100% {
+    opacity: 0.65;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+:root[data-theme="light"] .music-player,
 :root[data-theme="light"] .quick-overview {
   box-shadow:
     0 0 0 1px rgba(53, 109, 255, 0.06),
     0 16px 40px rgba(53, 85, 150, 0.12);
 }
 
-:root[data-theme="dark"] #music-widget,
+:root[data-theme="dark"] .music-player,
 :root[data-theme="dark"] .quick-overview {
   box-shadow:
     0 0 0 1px rgba(255, 228, 92, 0.12),
     0 16px 40px rgba(0, 0, 0, 0.52);
-}
-
-.music-controls {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.65rem;
-  margin-bottom: 14px;
-}
-
-
-.music-choice {
-  padding: 0.6rem 1rem;
-  background: rgba(125, 162, 247, 0.12);
-  border: 1px solid rgba(125, 162, 247, 0.24);
-  border-radius: 999px;
-  color: var(--text-color);
-  cursor: pointer;
-  font: inherit;
-  font-weight: 600;
-  transition:
-    transform 0.15s ease,
-    background 0.2s ease,
-    color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.music-choice:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.14);
-}
-
-.music-choice:focus-visible {
-  outline: 2px solid var(--accent-color);
-  outline-offset: 2px;
-}
-
-.music-choice--active {
-  border-color: transparent;
-  background: linear-gradient(135deg, var(--music-bg-start), var(--music-bg-end));
-  color: #ffffff;
-}
-
-#music-iframe {
-  width: 100%;
-  border: none;
-  border-radius: 18px;
-  background: rgba(15, 23, 42, 0.08);
-  transition: height 0.2s ease;
-}
-
-body.music-page[data-music-provider="spotify"] #music-iframe {
-  height: 352px;
-}
-
-body.music-page[data-music-provider="youtube"] #music-iframe {
-  height: 214px;
 }
 
 /* ------------------------------------------------------
@@ -724,15 +1122,86 @@ a:visited {
   .main-container {
     margin: 1rem;
   }
-  .music-menu {
-    min-width: 10rem;
-    padding: 0.625rem;
+  .music-player {
+    top: 82px;
+    right: 18px;
+    width: min(430px, calc(100vw - 36px));
+    max-height: calc(100vh - 100px);
+    padding: 15px;
+    overflow-y: auto;
   }
-  #music-widget {
-    padding: 16px;
+  .music-player--standalone {
+    inset: auto;
+    max-height: none;
   }
-  .music-choice {
-    flex: 1 1 calc(50% - 0.65rem);
+  .retro-tv__cabinet {
+    grid-template-columns: minmax(0, 1fr) 58px;
+    gap: 9px;
+    padding: 11px;
+  }
+  .retro-tv__dial {
+    width: 33px;
+    height: 33px;
+  }
+  .retro-tv__speaker {
+    width: 36px;
+    min-height: 44px;
+  }
+  .music-channel {
+    padding-inline: 7px;
+    font-size: 0.7rem;
+  }
+}
+
+@media (max-width: 430px) {
+  .music-player {
+    right: 12px;
+    width: calc(100vw - 24px);
+  }
+  .retro-tv__cabinet {
+    grid-template-columns: minmax(0, 1fr) 48px;
+    border-radius: 23px 23px 19px 19px;
+  }
+  .retro-tv__console {
+    padding-inline: 0;
+  }
+  .retro-tv__on-air {
+    font-size: 0;
+  }
+  .retro-tv__dial {
+    width: 29px;
+    height: 29px;
+  }
+  .retro-tv__speaker {
+    width: 30px;
+  }
+  .music-player__now-playing {
+    margin-top: 14px;
+  }
+  .music-channels {
+    grid-template-columns: 1fr;
+  }
+  .music-channel {
+    display: grid;
+    grid-template-columns: 3rem minmax(0, 1fr);
+    align-items: center;
+    padding: 9px 11px;
+  }
+  .music-channel span {
+    margin: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .music-player,
+  .music-channel,
+  .music-player__minimize,
+  .music-player__close {
+    transition-duration: 0.01ms;
+  }
+  .retro-tv--tuning .retro-tv__static,
+  .retro-tv__on-air span {
+    animation: none;
   }
 }
 

--- a/src/components/MusicPlayer.astro
+++ b/src/components/MusicPlayer.astro
@@ -1,0 +1,144 @@
+---
+interface Props {
+  standalone?: boolean;
+}
+
+const { standalone = false } = Astro.props;
+
+const channels = [
+  {
+    id: 'iranian-jazz',
+    number: '01',
+    name: 'Iranian Jazz',
+    detail: 'Qajar Jazz · one-hour lo-fi fusion',
+    kind: 'youtube',
+    src: 'https://www.youtube.com/embed/z8Dz-IFFFY4?autoplay=1&rel=0&playsinline=1&enablejsapi=1',
+  },
+  {
+    id: 'claude-fm',
+    number: '02',
+    name: 'Claude FM',
+    detail: 'Claude · music for thinking and building',
+    kind: 'youtube',
+    src: 'https://www.youtube.com/embed/tRsQsTMvPNg?autoplay=1&rel=0&playsinline=1&enablejsapi=1',
+  },
+  {
+    id: 'sunset-lofi',
+    number: '03',
+    name: 'Sunset Lo-fi',
+    detail: 'Mind Amend · focus session',
+    kind: 'youtube',
+    src: 'https://www.youtube.com/embed/kGuGH_UvvxA?autoplay=1&rel=0&playsinline=1&enablejsapi=1',
+  },
+  {
+    id: 'spotify-mix',
+    number: '04',
+    name: 'Spotify Mix',
+    detail: 'The original site playlist',
+    kind: 'spotify',
+    src: 'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0',
+  },
+];
+
+const defaultChannel = channels[0];
+---
+
+<section
+  id="music-player"
+  class:list={['music-player', { 'music-player--standalone': standalone, 'music-player--visible': standalone }]}
+  data-music-player
+  data-music-status={standalone ? 'open' : 'closed'}
+  data-music-standalone={standalone ? 'true' : undefined}
+  aria-label="Music channels"
+  aria-hidden={standalone ? 'false' : 'true'}
+  role="dialog"
+  hidden={!standalone}
+>
+  <header class="music-player__header">
+    <div>
+      <p class="music-player__eyebrow">Listening room</p>
+      <h2>Airwaves</h2>
+    </div>
+    <div class="music-player__header-actions">
+      {
+        !standalone && (
+          <button
+            class="music-player__minimize"
+            type="button"
+            data-music-minimize
+            aria-label="Minimize music player"
+          >
+            <span aria-hidden="true"></span>
+          </button>
+        )
+      }
+      <button
+        class="music-player__close"
+        type="button"
+        data-music-close
+        aria-label={standalone ? 'Close music player' : 'Stop and close music player'}
+      >
+        <span aria-hidden="true"></span>
+      </button>
+    </div>
+  </header>
+
+  <div class="retro-tv" data-music-tv>
+    <div class="retro-tv__aerial" aria-hidden="true">
+      <span></span>
+      <span></span>
+    </div>
+    <div class="retro-tv__cabinet">
+      <div class="retro-tv__screen-bezel">
+        <div class="retro-tv__screen">
+          <iframe
+            id="music-player-frame"
+            data-music-iframe
+            title={`${defaultChannel.name} music player`}
+            allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+          ></iframe>
+          <div class="retro-tv__scanlines" aria-hidden="true"></div>
+          <div class="retro-tv__static" aria-hidden="true"></div>
+        </div>
+      </div>
+      <div class="retro-tv__console" aria-hidden="true">
+        <div class="retro-tv__on-air"><span></span>ON</div>
+        <div class="retro-tv__dial"><span></span></div>
+        <div class="retro-tv__speaker"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="music-player__now-playing" aria-live="polite">
+    <span class="music-player__channel-number" data-music-channel-number>CH {defaultChannel.number}</span>
+    <span>
+      <strong data-music-channel-name>{defaultChannel.name}</strong>
+      <small data-music-channel-detail>{defaultChannel.detail}</small>
+    </span>
+  </div>
+
+  <div class="music-channels" role="group" aria-label="Switch music channel">
+    {
+      channels.map((channel, index) => (
+        <button
+          type="button"
+          class:list={['music-channel', { 'music-channel--active': index === 0 }]}
+          data-music-channel={channel.id}
+          data-channel-number={channel.number}
+          data-channel-name={channel.name}
+          data-channel-detail={channel.detail}
+          data-channel-kind={channel.kind}
+          data-channel-src={channel.src}
+          aria-pressed={index === 0 ? 'true' : 'false'}
+        >
+          <span>CH {channel.number}</span>
+          {channel.name}
+        </button>
+      ))
+    }
+  </div>
+</section>
+
+<script is:inline src="/assets/js/music.js"></script>

--- a/src/components/PageControls.astro
+++ b/src/components/PageControls.astro
@@ -1,5 +1,6 @@
 ---
 import Icon from './Icon.astro';
+import MusicPlayer from './MusicPlayer.astro';
 
 interface Props {
   showHomeButton?: boolean;
@@ -11,25 +12,23 @@ const { showHomeButton = false, showMusicButton = true } = Astro.props;
 
 <div class="page-controls" data-page-controls>
   {showMusicButton && (
-    <div class="page-controls__item page-controls__item--music" data-music-control>
+    <div
+      class="page-controls__item page-controls__item--music"
+      data-music-controller
+      transition:persist="music-dock"
+    >
       <button
         type="button"
         class="small-rounded-button icon-only-button page-controls__button page-controls__button--music"
-        aria-label="Open music menu"
-        aria-haspopup="menu"
+        aria-label="Open music player"
+        aria-haspopup="dialog"
         aria-expanded="false"
-        data-music-menu-toggle
+        aria-controls="music-player"
+        data-music-open
       >
         <Icon name="music" class="button-icon" />
       </button>
-      <div class="music-menu" data-music-menu role="menu" aria-label="Choose music provider" hidden>
-        <button type="button" class="music-menu__item" data-music-provider="spotify" role="menuitem">
-          Spotify
-        </button>
-        <button type="button" class="music-menu__item" data-music-provider="youtube" role="menuitem">
-          YouTube
-        </button>
-      </div>
+      <MusicPlayer />
     </div>
   )}
   <button
@@ -43,13 +42,13 @@ const { showHomeButton = false, showMusicButton = true } = Astro.props;
   </button>
 
   {showHomeButton && (
-    <button
-      type="button"
+    <a
+      href="/"
       class="small-rounded-button icon-only-button page-controls__button page-controls__button--home"
       aria-label="Go home"
       data-home-button
     >
       <Icon name="arrow-left" class="button-icon" />
-    </button>
+    </a>
   )}
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from 'astro:transitions';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../lib/site';
 
 interface Props {
@@ -13,7 +14,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
-const themeStylesheetHref = '/css/override.css?v=20260722-home-badge-copy';
+const themeStylesheetHref = '/css/override.css?v=20260726-music-tv';
 ---
 
 <!DOCTYPE html>
@@ -27,16 +28,25 @@ const themeStylesheetHref = '/css/override.css?v=20260722-home-badge-copy';
     <title>{pageTitle}</title>
     <script is:inline>
       (() => {
-        const saved = localStorage.getItem('theme');
-        const theme =
-          saved === 'light' || saved === 'dark'
-            ? saved
-            : window.matchMedia('(prefers-color-scheme: dark)').matches
-              ? 'dark'
-              : 'light';
-        document.documentElement.setAttribute('data-theme', theme);
+        const applySavedTheme = () => {
+          const saved = localStorage.getItem('theme');
+          const theme =
+            saved === 'light' || saved === 'dark'
+              ? saved
+              : window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light';
+          document.documentElement.setAttribute('data-theme', theme);
+        };
+
+        applySavedTheme();
+        if (!window.__siteThemeSwapReady) {
+          window.__siteThemeSwapReady = true;
+          document.addEventListener('astro:after-swap', applySavedTheme);
+        }
       })();
     </script>
+    <ClientRouter fallback="swap" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
@@ -73,22 +83,29 @@ const themeStylesheetHref = '/css/override.css?v=20260722-home-badge-copy';
     <slot />
     <script is:inline src="/assets/js/site-controls.js"></script>
     <script is:inline>
-      document.addEventListener('DOMContentLoaded', () => {
-        if (typeof renderMathInElement !== 'function') {
-          return;
-        }
+      (() => {
+        const renderPageMath = () => {
+          if (typeof renderMathInElement !== 'function') {
+            return;
+          }
 
-        renderMathInElement(document.body, {
-          delimiters: [
-            { left: '$$', right: '$$', display: true },
-            { left: '\\[', right: '\\]', display: true },
-            { left: '$', right: '$', display: false },
-            { left: '\\(', right: '\\)', display: false },
-          ],
-          ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
-          throwOnError: false,
-        });
-      });
+          renderMathInElement(document.body, {
+            delimiters: [
+              { left: '$$', right: '$$', display: true },
+              { left: '\\[', right: '\\]', display: true },
+              { left: '$', right: '$', display: false },
+              { left: '\\(', right: '\\)', display: false },
+            ],
+            ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+            throwOnError: false,
+          });
+        };
+
+        if (!window.__siteMathNavigationReady) {
+          window.__siteMathNavigationReady = true;
+          document.addEventListener('astro:page-load', renderPageMath);
+        }
+      })();
     </script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -163,7 +163,7 @@ const journeyHref = '/blog/2025/02/08/my-journey-so-far-full-story.html';
     </section>
   </section>
 
-  <script is:inline>
+  <script is:inline data-astro-rerun>
     (() => {
       const landing = document.querySelector('[data-sky-landing]');
       const canvas = document.querySelector('[data-sky-reveal]');
@@ -188,6 +188,8 @@ const journeyHref = '/blog/2025/02/08/my-journey-so-far-full-story.html';
       let frame = 0;
       let lastMove = 0;
       const stars = [];
+      const navigationController = new AbortController();
+      let resizeObserver;
 
       const resize = () => {
         const bounds = landing.getBoundingClientRect();
@@ -281,16 +283,28 @@ const journeyHref = '/blog/2025/02/08/my-journey-so-far-full-story.html';
           lastMove = now;
           addStars(event.clientX, event.clientY, 3);
         },
-        { passive: true },
+        { passive: true, signal: navigationController.signal },
       );
 
       landing.addEventListener('pointerdown', (event) => addStars(event.clientX, event.clientY, 14), {
         passive: true,
+        signal: navigationController.signal,
       });
 
       resize();
       landing.dataset.skyReady = 'true';
-      new ResizeObserver(resize).observe(landing);
+      resizeObserver = new ResizeObserver(resize);
+      resizeObserver.observe(landing);
+
+      document.addEventListener(
+        'astro:before-swap',
+        () => {
+          navigationController.abort();
+          resizeObserver?.disconnect();
+          if (frame) window.cancelAnimationFrame(frame);
+        },
+        { once: true },
+      );
     })();
   </script>
 </HomeLayout>

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -1,22 +1,10 @@
 ---
+import MusicPlayer from '../components/MusicPlayer.astro';
 import PageControls from '../components/PageControls.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Music Player" pageClass="music-page">
   <PageControls showMusicButton={false} />
-  <div id="music-widget">
-    <div class="music-controls">
-      <button id="choose-spotify" class="music-choice" type="button">Spotify</button>
-      <button id="choose-youtube" class="music-choice" type="button">YouTube</button>
-      <button id="close-music-player" class="music-choice" type="button">Close</button>
-    </div>
-    <iframe
-      id="music-iframe"
-      title="Music player"
-      style="border:0;"
-      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-    ></iframe>
-  </div>
-  <script is:inline src="/assets/js/music.js"></script>
+  <MusicPlayer standalone={true} />
 </BaseLayout>

--- a/src/pages/paper_summaries_field.astro
+++ b/src/pages/paper_summaries_field.astro
@@ -438,10 +438,11 @@ const formatDate = (date: Date) =>
     </section>
   </div>
 
-  <script is:inline>
+  <script is:inline data-astro-rerun>
     (() => {
       const root = document.querySelector('[data-research-index]');
       if (!(root instanceof HTMLElement)) return;
+      const navigationController = new AbortController();
 
       const viewButtons = Array.from(root.querySelectorAll('[data-view-button]'));
       const viewPanels = Array.from(root.querySelectorAll('[data-view-panel]'));
@@ -646,7 +647,13 @@ const formatDate = (date: Date) =>
           event.preventDefault();
           if (searchInput instanceof HTMLInputElement) searchInput.focus();
         }
-      });
+      }, { signal: navigationController.signal });
+
+      document.addEventListener(
+        'astro:before-swap',
+        () => navigationController.abort(),
+        { once: true },
+      );
 
       const params = new URL(window.location.href).searchParams;
       const initialTopic = params.get('topic');


### PR DESCRIPTION
## What changed
- add a persistent retro-TV music dock with Iranian Jazz, Claude FM, Sunset Lo-fi, and Spotify channels
- keep the live iframe playing across Astro page navigation and while minimized
- add explicit stop-and-close behavior, responsive sizing, and light/dark theme styling
- reinitialize page controls safely across client-side navigation

## Why
Make the site's music control useful across the whole browsing session without obstructing the reading experience.

## Tested
- git diff --check
- npm run ci
- browser QA for channel switching, minimize/restore continuity, cross-page persistence, stop behavior, and light/dark themes