### PR TITLE
Sort paper index by release date

### DIFF
--- a/src/content/posts/a-survey-on-vision-language-action-models-for-autonomous-driving.md
+++ b/src/content/posts/a-survey-on-vision-language-action-models-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'A Survey on Vision-Language-Action Models for Autonomous Driving'
-date: '2025-06-30T04:00:00.000Z'
+date: '2025-06-30T00:00:00.000Z'
 section: paper-shorts
 postSlug: a-survey-on-vision-language-action-models-for-autonomous-driving
 legacyPath: /paper shorts/2025/06/30/a-survey-on-vision-language-action-models-for-autonomous-driving.html

--- a/src/content/posts/action-chunking-with-transformers-act.md
+++ b/src/content/posts/action-chunking-with-transformers-act.md
@@ -1,6 +1,6 @@
 ---
 title: 'Learning Fine-Grained Bimanual Manipulation with Low-Cost Hardware (ACT)'
-date: '2023-04-23T09:00:00.000Z'
+date: '2023-04-23T00:00:00.000Z'
 section: paper-shorts
 postSlug: action-chunking-with-transformers-act
 legacyPath: /paper shorts/2023/04/23/action-chunking-with-transformers-act.html

--- a/src/content/posts/action-preference-optimization-for-robotic-policy-refinement.md
+++ b/src/content/posts/action-preference-optimization-for-robotic-policy-refinement.md
@@ -1,6 +1,6 @@
 ---
 title: 'Human-Assisted Robotic Policy Refinement via Action Preference Optimization'
-date: '2025-06-08T09:00:00.000Z'
+date: '2025-06-08T00:00:00.000Z'
 section: paper-shorts
 postSlug: action-preference-optimization-for-robotic-policy-refinement
 legacyPath: /paper shorts/2025/06/08/action-preference-optimization-for-robotic-policy-refinement.html

--- a/src/content/posts/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
+++ b/src/content/posts/an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
@@ -1,6 +1,6 @@
 ---
 title: 'An Image Is Worth 16×16 Words: Transformers for Image Recognition at Scale'
-date: '2020-10-01T04:00:00.000Z'
+date: '2020-10-22T00:00:00.000Z'
 section: paper-shorts
 postSlug: an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale
 legacyPath: >-

--- a/src/content/posts/ar-vla-true-autoregressive-action-expert-for-vision-language-action-models.md
+++ b/src/content/posts/ar-vla-true-autoregressive-action-expert-for-vision-language-action-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'AR-VLA: True Autoregressive Action Expert for Vision-Language-Action Models'
-date: '2026-07-24T14:00:00.000Z'
+date: '2026-03-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: ar-vla-true-autoregressive-action-expert-for-vision-language-action-models
 legacyPath: /paper shorts/2026/07/24/ar-vla-true-autoregressive-action-expert-for-vision-language-action-models.html

--- a/src/content/posts/are-vlms-ready-for-autonomous-driving-drivebench.md
+++ b/src/content/posts/are-vlms-ready-for-autonomous-driving-drivebench.md
@@ -1,6 +1,6 @@
 ---
 title: 'Are VLMs Ready for Autonomous Driving?'
-date: '2025-01-01T05:00:00.000Z'
+date: '2025-01-07T00:00:00.000Z'
 section: paper-shorts
 postSlug: are-vlms-ready-for-autonomous-driving-drivebench
 legacyPath: /paper shorts/2025/01/01/are-vlms-ready-for-autonomous-driving-drivebench.html

--- a/src/content/posts/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.md
+++ b/src/content/posts/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'AsyncDriver: Asynchronous Large Language Model Enhanced Planner for Autonomous Driving'
-date: '2024-06-01T04:00:00.000Z'
+date: '2024-06-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving
 legacyPath: /paper shorts/2024/06/01/asyncdriver-asynchronous-llm-enhanced-planner-for-autonomous-driving.html

--- a/src/content/posts/attention-is-all-you-need.mdx
+++ b/src/content/posts/attention-is-all-you-need.mdx
@@ -1,6 +1,6 @@
 ---
 title: Attention Is All You Need
-date: '2017-06-01T04:00:00.000Z'
+date: '2017-06-12T00:00:00.000Z'
 section: paper-shorts
 postSlug: attention-is-all-you-need
 legacyPath: /paper shorts/2017/06/01/attention-is-all-you-need.html

--- a/src/content/posts/auto-encoding-variational-bayes.md
+++ b/src/content/posts/auto-encoding-variational-bayes.md
@@ -1,6 +1,6 @@
 ---
 title: Auto-Encoding Variational Bayes
-date: '2014-04-01T04:00:00.000Z'
+date: '2013-12-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: auto-encoding-variational-bayes
 legacyPath: /paper shorts/2014/04/01/auto-encoding-variational-bayes.html

--- a/src/content/posts/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.md
+++ b/src/content/posts/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'AutoTrust: Benchmarking Trustworthiness in Large Vision Language Models for Autonomous Driving'
-date: '2024-12-01T05:00:00.000Z'
+date: '2024-12-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving
 legacyPath: /paper shorts/2024/12/01/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.html

--- a/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
+++ b/src/content/posts/bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.mdx
@@ -2,7 +2,7 @@
 title: >-
   BERT: Pre-training of Deep Bidirectional Transformers for Language
   Understanding
-date: '2019-06-01T04:00:00.000Z'
+date: '2018-10-11T00:00:00.000Z'
 section: paper-shorts
 postSlug: >-
   bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding

--- a/src/content/posts/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.md
+++ b/src/content/posts/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.md
@@ -1,6 +1,6 @@
 ---
 title: 'BEVDepth: Acquisition of Reliable Depth for Multi-View 3D Object Detection'
-date: '2022-06-21T04:00:00.000Z'
+date: '2022-06-21T00:00:00.000Z'
 section: paper-shorts
 postSlug: bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection
 legacyPath: /paper shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html

--- a/src/content/posts/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.md
+++ b/src/content/posts/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.md
@@ -1,6 +1,6 @@
 ---
 title: "BEVFormer: Learning Bird's-Eye-View Representation from Multi-Camera Images via Spatiotemporal Transformers"
-date: '2022-03-31T04:00:00.000Z'
+date: '2022-03-31T00:00:00.000Z'
 section: paper-shorts
 postSlug: bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers
 legacyPath: /paper shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html

--- a/src/content/posts/bevfusion-multi-task-multi-sensor-unified-bev.md
+++ b/src/content/posts/bevfusion-multi-task-multi-sensor-unified-bev.md
@@ -1,6 +1,6 @@
 ---
 title: "BEVFusion: Multi-Task Multi-Sensor Fusion with Unified Bird's-Eye View Representation"
-date: '2022-05-26T04:00:00.000Z'
+date: '2022-05-26T00:00:00.000Z'
 section: paper-shorts
 postSlug: bevfusion-multi-task-multi-sensor-unified-bev
 legacyPath: /paper shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html

--- a/src/content/posts/cambrian-1-vision-centric-exploration-of-multimodal-llms.md
+++ b/src/content/posts/cambrian-1-vision-centric-exploration-of-multimodal-llms.md
@@ -1,6 +1,6 @@
 ---
 title: 'Cambrian-1: A Fully Open, Vision-Centric Exploration of Multimodal LLMs'
-date: '2024-06-01T04:00:00.000Z'
+date: '2024-06-24T00:00:00.000Z'
 section: paper-shorts
 postSlug: cambrian-1-vision-centric-exploration-of-multimodal-llms
 legacyPath: /paper shorts/2024/06/01/cambrian-1-vision-centric-exploration-of-multimodal-llms.html

--- a/src/content/posts/can-lvlms-obtain-a-drivers-license-idkb.md
+++ b/src/content/posts/can-lvlms-obtain-a-drivers-license-idkb.md
@@ -1,6 +1,6 @@
 ---
 title: "Can LVLMs Obtain a Driver's License?"
-date: '2024-09-01T04:00:00.000Z'
+date: '2024-09-04T00:00:00.000Z'
 section: paper-shorts
 postSlug: can-lvlms-obtain-a-drivers-license-idkb
 legacyPath: /paper shorts/2024/09/01/can-lvlms-obtain-a-drivers-license-idkb.html

--- a/src/content/posts/chameleon-mixed-modal-early-fusion-foundation-models.md
+++ b/src/content/posts/chameleon-mixed-modal-early-fusion-foundation-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'Chameleon: Mixed-Modal Early-Fusion Foundation Models'
-date: '2024-05-16T09:00:00.000Z'
+date: '2024-05-16T00:00:00.000Z'
 section: paper-shorts
 postSlug: chameleon-mixed-modal-early-fusion-foundation-models
 legacyPath: /paper shorts/2024/05/16/chameleon-mixed-modal-early-fusion-foundation-models.html

--- a/src/content/posts/constitutional-ai-harmlessness-from-ai-feedback.md
+++ b/src/content/posts/constitutional-ai-harmlessness-from-ai-feedback.md
@@ -1,6 +1,6 @@
 ---
 title: 'Constitutional AI: Harmlessness from AI Feedback'
-date: '2022-12-15T09:00:00.000Z'
+date: '2022-12-15T00:00:00.000Z'
 section: paper-shorts
 postSlug: constitutional-ai-harmlessness-from-ai-feedback
 legacyPath: /paper shorts/2022/12/15/constitutional-ai-harmlessness-from-ai-feedback.html

--- a/src/content/posts/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.md
+++ b/src/content/posts/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.md
@@ -1,6 +1,6 @@
 ---
 title: 'DAgger: A Reduction of Imitation Learning to No-Regret Online Learning'
-date: '2011-04-11T09:00:00.000Z'
+date: '2011-06-14T00:00:00.000Z'
 section: paper-shorts
 postSlug: dagger-reduction-of-imitation-learning-to-no-regret-online-learning
 legacyPath: /paper shorts/2011/04/11/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.html

--- a/src/content/posts/deep-residual-learning-for-image-recognition.md
+++ b/src/content/posts/deep-residual-learning-for-image-recognition.md
@@ -1,6 +1,6 @@
 ---
 title: Deep Residual Learning for Image Recognition
-date: '2015-12-01T05:00:00.000Z'
+date: '2015-12-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: deep-residual-learning-for-image-recognition
 legacyPath: /paper shorts/2015/12/01/deep-residual-learning-for-image-recognition.html

--- a/src/content/posts/deepinteraction-3d-object-detection-via-modality-interaction.md
+++ b/src/content/posts/deepinteraction-3d-object-detection-via-modality-interaction.md
@@ -1,6 +1,6 @@
 ---
 title: 'DeepInteraction: 3D Object Detection via Modality Interaction'
-date: '2022-08-23T04:00:00.000Z'
+date: '2022-08-23T00:00:00.000Z'
 section: paper-shorts
 postSlug: deepinteraction-3d-object-detection-via-modality-interaction
 legacyPath: /paper shorts/2022/08/23/deepinteraction-3d-object-detection-via-modality-interaction.html

--- a/src/content/posts/deepseek-v4-flash-0731-efficient-million-token-intelligence.md
+++ b/src/content/posts/deepseek-v4-flash-0731-efficient-million-token-intelligence.md
@@ -1,6 +1,6 @@
 ---
 title: 'DeepSeek-V4-Flash-0731: Efficient Million-Token Intelligence after Post-Training'
-date: '2026-07-31T12:00:00.000Z'
+date: '2026-04-26T00:00:00.000Z'
 section: paper-shorts
 postSlug: deepseek-v4-flash-0731-efficient-million-token-intelligence
 legacyPath: /paper shorts/2026/07/31/deepseek-v4-flash-0731-efficient-million-token-intelligence.html

--- a/src/content/posts/deepseek-vl2-mixture-of-experts-vision-language-models.md
+++ b/src/content/posts/deepseek-vl2-mixture-of-experts-vision-language-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'DeepSeek-VL2: Mixture-of-Experts Vision-Language Models for Advanced Multimodal Understanding'
-date: '2024-12-01T05:00:00.000Z'
+date: '2024-12-13T00:00:00.000Z'
 section: paper-shorts
 postSlug: deepseek-vl2-mixture-of-experts-vision-language-models
 legacyPath: /paper shorts/2024/12/01/deepseek-vl2-mixture-of-experts-vision-language-models.html

--- a/src/content/posts/deepseekmath-group-relative-policy-optimization-grpo.md
+++ b/src/content/posts/deepseekmath-group-relative-policy-optimization-grpo.md
@@ -1,6 +1,6 @@
 ---
 title: 'DeepSeekMath: Group Relative Policy Optimization (GRPO)'
-date: '2024-02-05T18:55:32.000Z'
+date: '2024-02-05T00:00:00.000Z'
 section: paper-shorts
 postSlug: deepseekmath-group-relative-policy-optimization-grpo
 legacyPath: /paper shorts/2024/02/05/deepseekmath-group-relative-policy-optimization-grpo.html

--- a/src/content/posts/denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/denoising-diffusion-probabilistic-models.md
@@ -1,6 +1,6 @@
 ---
 title: Denoising Diffusion Probabilistic Models
-date: '2020-06-01T04:00:00.000Z'
+date: '2020-06-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: denoising-diffusion-probabilistic-models
 legacyPath: /paper shorts/2020/06/01/denoising-diffusion-probabilistic-models.html

--- a/src/content/posts/densetnt-end-to-end-trajectory-prediction-from-dense-goal-sets.md
+++ b/src/content/posts/densetnt-end-to-end-trajectory-prediction-from-dense-goal-sets.md
@@ -1,6 +1,6 @@
 ---
 title: 'DenseTNT: End-to-End Trajectory Prediction from Dense Goal Sets'
-date: '2021-08-22T04:00:00.000Z'
+date: '2021-08-22T00:00:00.000Z'
 section: paper-shorts
 postSlug: densetnt-end-to-end-trajectory-prediction-from-dense-goal-sets
 legacyPath: /paper shorts/2021/08/22/densetnt-end-to-end-trajectory-prediction-from-dense-goal-sets.html

--- a/src/content/posts/dexvla-vision-language-model-with-plug-in-diffusion-expert.md
+++ b/src/content/posts/dexvla-vision-language-model-with-plug-in-diffusion-expert.md
@@ -1,6 +1,6 @@
 ---
 title: 'DexVLA: Vision-Language Model with Plug-In Diffusion Expert for General Robot Control'
-date: '2025-02-01T05:00:00.000Z'
+date: '2025-02-09T00:00:00.000Z'
 section: paper-shorts
 postSlug: dexvla-vision-language-model-with-plug-in-diffusion-expert
 legacyPath: /paper shorts/2025/02/01/dexvla-vision-language-model-with-plug-in-diffusion-expert.html

--- a/src/content/posts/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.md
+++ b/src/content/posts/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.md
@@ -1,6 +1,6 @@
 ---
 title: 'Diffusion Policy: Visuomotor Policy Learning via Action Diffusion'
-date: '2023-03-07T09:00:00.000Z'
+date: '2023-03-07T00:00:00.000Z'
 section: paper-shorts
 postSlug: diffusion-policy-visuomotor-policy-learning-via-action-diffusion
 legacyPath: /paper shorts/2023/03/07/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.html

--- a/src/content/posts/diffvla-vision-language-guided-diffusion-planning-for-autonomous-driving.md
+++ b/src/content/posts/diffvla-vision-language-guided-diffusion-planning-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'DiffVLA: Vision-Language Guided Diffusion Planning for Autonomous Driving'
-date: '2025-05-26T04:00:00.000Z'
+date: '2025-05-26T00:00:00.000Z'
 section: paper-shorts
 postSlug: diffvla-vision-language-guided-diffusion-planning-for-autonomous-driving
 legacyPath: /paper shorts/2025/05/26/diffvla-vision-language-guided-diffusion-planning-for-autonomous-driving.html

--- a/src/content/posts/dinov2-learning-robust-visual-features-without-supervision.md
+++ b/src/content/posts/dinov2-learning-robust-visual-features-without-supervision.md
@@ -1,6 +1,6 @@
 ---
 title: 'DINOv2: Learning Robust Visual Features without Supervision'
-date: '2023-04-14T15:12:19.000Z'
+date: '2023-04-14T00:00:00.000Z'
 section: paper-shorts
 postSlug: dinov2-learning-robust-visual-features-without-supervision
 legacyPath: /paper shorts/2023/04/14/dinov2-learning-robust-visual-features-without-supervision.html

--- a/src/content/posts/dinov2-meets-text-dino-txt.md
+++ b/src/content/posts/dinov2-meets-text-dino-txt.md
@@ -1,6 +1,6 @@
 ---
 title: 'DINOv2 Meets Text: dino.txt'
-date: '2024-12-20T20:46:48.000Z'
+date: '2024-12-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: dinov2-meets-text-dino-txt
 legacyPath: /paper shorts/2024/12/20/dinov2-meets-text-dino-txt.html

--- a/src/content/posts/dinov3.md
+++ b/src/content/posts/dinov3.md
@@ -1,6 +1,6 @@
 ---
 title: 'DINOv3'
-date: '2025-08-13T18:00:55.000Z'
+date: '2025-08-13T00:00:00.000Z'
 section: paper-shorts
 postSlug: dinov3
 legacyPath: /paper shorts/2025/08/13/dinov3.html

--- a/src/content/posts/direct-preference-optimization-dpo.md
+++ b/src/content/posts/direct-preference-optimization-dpo.md
@@ -1,6 +1,6 @@
 ---
 title: 'Direct Preference Optimization'
-date: '2023-05-29T21:55:10.000Z'
+date: '2023-05-29T00:00:00.000Z'
 section: paper-shorts
 postSlug: direct-preference-optimization-dpo
 legacyPath: /paper shorts/2023/05/01/direct-preference-optimization-dpo.html

--- a/src/content/posts/distilling-multimodal-large-language-models-for-autonomous-driving.md
+++ b/src/content/posts/distilling-multimodal-large-language-models-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'Distilling Multi-modal Large Language Models for Autonomous Driving'
-date: '2025-01-01T05:00:00.000Z'
+date: '2025-01-16T00:00:00.000Z'
 section: paper-shorts
 postSlug: distilling-multimodal-large-language-models-for-autonomous-driving
 legacyPath: /paper shorts/2025/01/01/distilling-multimodal-large-language-models-for-autonomous-driving.html

--- a/src/content/posts/dppo-diffusion-policy-policy-optimization.md
+++ b/src/content/posts/dppo-diffusion-policy-policy-optimization.md
@@ -1,6 +1,6 @@
 ---
 title: 'DPPO: Diffusion Policy Policy Optimization'
-date: '2024-09-01T09:00:00.000Z'
+date: '2024-09-01T00:00:00.000Z'
 section: paper-shorts
 postSlug: dppo-diffusion-policy-policy-optimization
 legacyPath: /paper shorts/2024/09/01/dppo-diffusion-policy-policy-optimization.html

--- a/src/content/posts/drivelm-driving-with-graph-visual-question-answering.md
+++ b/src/content/posts/drivelm-driving-with-graph-visual-question-answering.md
@@ -1,6 +1,6 @@
 ---
 title: 'DriveLM: Driving with Graph Visual Question Answering'
-date: '2023-12-21T05:00:00.000Z'
+date: '2023-12-21T00:00:00.000Z'
 section: paper-shorts
 postSlug: drivelm-driving-with-graph-visual-question-answering
 legacyPath: /paper shorts/2023/12/21/drivelm-driving-with-graph-visual-question-answering.html

--- a/src/content/posts/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.md
+++ b/src/content/posts/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'DriveMM: All-in-One Large Multimodal Model for Autonomous Driving'
-date: '2024-12-01T05:00:00.000Z'
+date: '2024-12-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: drivemm-all-in-one-large-multimodal-model-for-autonomous-driving
 legacyPath: /paper shorts/2024/12/01/drivemm-all-in-one-large-multimodal-model-for-autonomous-driving.html

--- a/src/content/posts/drivevla-w0-world-models-amplify-data-scaling-law-in-autonomous-driving.md
+++ b/src/content/posts/drivevla-w0-world-models-amplify-data-scaling-law-in-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'DriveVLA-W0: World Models Amplify Data Scaling Law in Autonomous Driving'
-date: '2025-10-14T04:00:00.000Z'
+date: '2025-10-14T00:00:00.000Z'
 section: paper-shorts
 postSlug: drivevla-w0-world-models-amplify-data-scaling-law-in-autonomous-driving
 legacyPath: /paper shorts/2025/10/14/drivevla-w0-world-models-amplify-data-scaling-law-in-autonomous-driving.html

--- a/src/content/posts/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.md
+++ b/src/content/posts/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'DriveVLM: The Convergence of Autonomous Driving and Large Vision-Language Models'
-date: '2024-02-01T05:00:00.000Z'
+date: '2024-02-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models
 legacyPath: /paper shorts/2024/02/01/drivevlm-convergence-of-autonomous-driving-and-large-vision-language-models.html

--- a/src/content/posts/driving-with-llms-fusing-object-level-vector-modality.md
+++ b/src/content/posts/driving-with-llms-fusing-object-level-vector-modality.md
@@ -1,6 +1,6 @@
 ---
 title: 'Driving with LLMs: Fusing Object-Level Vector Modality for Explainable Autonomous Driving'
-date: '2023-10-01T04:00:00.000Z'
+date: '2023-10-03T00:00:00.000Z'
 section: paper-shorts
 postSlug: driving-with-llms-fusing-object-level-vector-modality
 legacyPath: /paper shorts/2023/10/01/driving-with-llms-fusing-object-level-vector-modality.html

--- a/src/content/posts/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.md
+++ b/src/content/posts/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'Eagle 2: Building Post-Training Data Strategies from Scratch for Frontier Vision-Language Models'
-date: '2025-01-01T05:00:00.000Z'
+date: '2025-01-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: eagle-2-post-training-data-strategies-for-frontier-vision-language-models
 legacyPath: /paper shorts/2025/01/01/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.html

--- a/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
+++ b/src/content/posts/efficientdet-scalable-and-efficient-object-detection.md
@@ -1,6 +1,6 @@
 ---
 title: 'EfficientDet: Scalable and Efficient Object Detection'
-date: '2020-04-01T04:00:00.000Z'
+date: '2019-11-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: efficientdet-scalable-and-efficient-object-detection
 legacyPath: >-

--- a/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
+++ b/src/content/posts/efficientnet-rethinking-model-scaling-for-convnets.md
@@ -1,6 +1,6 @@
 ---
 title: EfficientNet — Rethinking Model Scaling for ConvNets
-date: '2019-05-01T04:00:00.000Z'
+date: '2019-05-28T00:00:00.000Z'
 section: paper-shorts
 postSlug: efficientnet-rethinking-model-scaling-for-convnets
 legacyPath: >-

--- a/src/content/posts/emerging-properties-self-supervised-vision-transformers-dino.md
+++ b/src/content/posts/emerging-properties-self-supervised-vision-transformers-dino.md
@@ -1,6 +1,6 @@
 ---
 title: 'DINO: Emerging Properties in Self-Supervised Vision Transformers'
-date: '2021-04-29T12:28:51.000Z'
+date: '2021-04-29T00:00:00.000Z'
 section: paper-shorts
 postSlug: emerging-properties-self-supervised-vision-transformers-dino
 legacyPath: /paper shorts/2021/04/29/emerging-properties-self-supervised-vision-transformers-dino.html

--- a/src/content/posts/emma-end-to-end-multimodal-model-for-autonomous-driving.md
+++ b/src/content/posts/emma-end-to-end-multimodal-model-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'EMMA: End-to-End Multimodal Model for Autonomous Driving'
-date: '2024-10-01T04:00:00.000Z'
+date: '2024-10-30T00:00:00.000Z'
 section: paper-shorts
 postSlug: emma-end-to-end-multimodal-model-for-autonomous-driving
 legacyPath: /paper shorts/2024/10/01/emma-end-to-end-multimodal-model-for-autonomous-driving.html

--- a/src/content/posts/expertise-need-not-monopolize-action-specialized-mixture-of-experts-for-vision-language-action-learning.md
+++ b/src/content/posts/expertise-need-not-monopolize-action-specialized-mixture-of-experts-for-vision-language-action-learning.md
@@ -1,6 +1,6 @@
 ---
 title: 'Expertise Need Not Monopolize: Action-Specialized Mixture of Experts for Vision-Language-Action Learning'
-date: '2026-07-24T14:05:00.000Z'
+date: '2025-10-16T00:00:00.000Z'
 section: paper-shorts
 postSlug: expertise-need-not-monopolize-action-specialized-mixture-of-experts-for-vision-language-action-learning
 legacyPath: /paper shorts/2026/07/24/expertise-need-not-monopolize-action-specialized-mixture-of-experts-for-vision-language-action-learning.html

--- a/src/content/posts/fast-efficient-action-tokenization-for-vision-language-action-models.md
+++ b/src/content/posts/fast-efficient-action-tokenization-for-vision-language-action-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'FAST: Efficient Action Tokenization for Vision-Language-Action Models'
-date: '2025-01-01T05:00:00.000Z'
+date: '2025-01-16T00:00:00.000Z'
 section: paper-shorts
 postSlug: fast-efficient-action-tokenization-for-vision-language-action-models
 legacyPath: /paper shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html

--- a/src/content/posts/fourier-features-let-networks-learn-high-frequency-functions-in-low-dimensional-domains.md
+++ b/src/content/posts/fourier-features-let-networks-learn-high-frequency-functions-in-low-dimensional-domains.md
@@ -1,6 +1,6 @@
 ---
 title: 'Fourier Features Let Networks Learn High Frequency Functions in Low Dimensional Domains'
-date: '2020-06-18T04:00:00.000Z'
+date: '2020-06-18T00:00:00.000Z'
 section: paper-shorts
 postSlug: fourier-features-let-networks-learn-high-frequency-functions-in-low-dimensional-domains
 legacyPath: /paper shorts/2020/06/18/fourier-features-let-networks-learn-high-frequency-functions-in-low-dimensional-domains.html

--- a/src/content/posts/futr3d-unified-sensor-fusion-framework-for-3d-detection.md
+++ b/src/content/posts/futr3d-unified-sensor-fusion-framework-for-3d-detection.md
@@ -1,6 +1,6 @@
 ---
 title: 'FUTR3D: A Unified Sensor Fusion Framework for 3D Detection'
-date: '2022-03-20T04:00:00.000Z'
+date: '2022-03-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: futr3d-unified-sensor-fusion-framework-for-3d-detection
 legacyPath: /paper shorts/2022/03/20/futr3d-unified-sensor-fusion-framework-for-3d-detection.html

--- a/src/content/posts/generative-adversarial-networks.md
+++ b/src/content/posts/generative-adversarial-networks.md
@@ -1,6 +1,6 @@
 ---
 title: Generative Adversarial Networks
-date: '2014-06-01T04:00:00.000Z'
+date: '2014-06-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: generative-adversarial-networks
 legacyPath: /paper shorts/2014/06/01/generative-adversarial-networks.html

--- a/src/content/posts/genie-generative-interactive-environments.md
+++ b/src/content/posts/genie-generative-interactive-environments.md
@@ -1,6 +1,6 @@
 ---
 title: 'Genie: Generative Interactive Environments'
-date: '2024-02-23T09:00:00.000Z'
+date: '2024-02-23T00:00:00.000Z'
 section: paper-shorts
 postSlug: genie-generative-interactive-environments
 legacyPath: /paper shorts/2024/02/23/genie-generative-interactive-environments.html

--- a/src/content/posts/gpt-driver-learning-to-drive-with-gpt.md
+++ b/src/content/posts/gpt-driver-learning-to-drive-with-gpt.md
@@ -1,6 +1,6 @@
 ---
 title: 'GPT-Driver: Learning to Drive with GPT'
-date: '2023-10-01T04:00:00.000Z'
+date: '2023-10-02T00:00:00.000Z'
 section: paper-shorts
 postSlug: gpt-driver-learning-to-drive-with-gpt
 legacyPath: /paper shorts/2023/10/01/gpt-driver-learning-to-drive-with-gpt.html

--- a/src/content/posts/himoe-vla-hierarchical-mixture-of-experts-for-generalist-vision-language-action-policies.md
+++ b/src/content/posts/himoe-vla-hierarchical-mixture-of-experts-for-generalist-vision-language-action-policies.md
@@ -1,6 +1,6 @@
 ---
 title: 'HiMoE-VLA: Hierarchical Mixture-of-Experts for Generalist Vision-Language-Action Policies'
-date: '2026-07-24T14:10:00.000Z'
+date: '2025-12-05T00:00:00.000Z'
 section: paper-shorts
 postSlug: himoe-vla-hierarchical-mixture-of-experts-for-generalist-vision-language-action-policies
 legacyPath: /paper shorts/2026/07/24/himoe-vla-hierarchical-mixture-of-experts-for-generalist-vision-language-action-policies.html

--- a/src/content/posts/how-much-do-language-models-memorize.md
+++ b/src/content/posts/how-much-do-language-models-memorize.md
@@ -1,6 +1,6 @@
 ---
 title: 'How Much Do Language Models Memorize?'
-date: '2025-05-30T04:00:00.000Z'
+date: '2025-05-30T00:00:00.000Z'
 section: paper-shorts
 postSlug: how-much-do-language-models-memorize
 legacyPath: /paper shorts/2025/05/30/how-much-do-language-models-memorize.html

--- a/src/content/posts/hyworldvla-a-vision-language-action-model-with-hybrid-world-modeling-for-autonomous-driving.md
+++ b/src/content/posts/hyworldvla-a-vision-language-action-model-with-hybrid-world-modeling-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'HyWorldVLA: A Vision-Language-Action Model with Hybrid World Modeling for Autonomous Driving'
-date: '2026-07-24T14:20:00.000Z'
+date: '2026-07-23T00:00:00.000Z'
 section: paper-shorts
 postSlug: hyworldvla-a-vision-language-action-model-with-hybrid-world-modeling-for-autonomous-driving
 legacyPath: /paper shorts/2026/07/24/hyworldvla-a-vision-language-action-model-with-hybrid-world-modeling-for-autonomous-driving.html

--- a/src/content/posts/ibot-image-bert-pre-training-with-online-tokenizer.md
+++ b/src/content/posts/ibot-image-bert-pre-training-with-online-tokenizer.md
@@ -1,6 +1,6 @@
 ---
 title: 'iBOT: Image BERT Pre-Training with Online Tokenizer'
-date: '2021-11-15T15:18:05.000Z'
+date: '2021-11-15T00:00:00.000Z'
 section: paper-shorts
 postSlug: ibot-image-bert-pre-training-with-online-tokenizer
 legacyPath: /paper shorts/2021/11/15/ibot-image-bert-pre-training-with-online-tokenizer.html

--- a/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
+++ b/src/content/posts/improved-denoising-diffusion-probabilistic-models.md
@@ -1,6 +1,6 @@
 ---
 title: Improved Denoising Diffusion Probabilistic Models
-date: '2021-06-01T04:00:00.000Z'
+date: '2021-02-18T00:00:00.000Z'
 section: paper-shorts
 postSlug: improved-denoising-diffusion-probabilistic-models
 legacyPath: >-

--- a/src/content/posts/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.md
+++ b/src/content/posts/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'InternVL 2.5: Expanding Performance Boundaries of Open-Source Multimodal Models'
-date: '2024-12-01T05:00:00.000Z'
+date: '2024-12-06T00:00:00.000Z'
 section: paper-shorts
 postSlug: internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models
 legacyPath: /paper shorts/2024/12/01/internvl-2-5-expanding-performance-boundaries-of-open-source-multimodal-models.html

--- a/src/content/posts/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.md
+++ b/src/content/posts/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.md
@@ -1,6 +1,6 @@
 ---
 title: 'Janus: Decoupling Visual Encoding for Unified Multimodal Understanding and Generation'
-date: '2024-10-17T09:00:00.000Z'
+date: '2024-10-17T00:00:00.000Z'
 section: paper-shorts
 postSlug: janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation
 legacyPath: /paper shorts/2024/10/17/janus-decoupling-visual-encoding-for-unified-multimodal-understanding-and-generation.html

--- a/src/content/posts/kto-model-alignment-as-prospect-theoretic-optimization.md
+++ b/src/content/posts/kto-model-alignment-as-prospect-theoretic-optimization.md
@@ -1,6 +1,6 @@
 ---
 title: 'KTO: Model Alignment as Prospect Theoretic Optimization'
-date: '2024-02-02T09:00:00.000Z'
+date: '2024-02-02T00:00:00.000Z'
 section: paper-shorts
 postSlug: kto-model-alignment-as-prospect-theoretic-optimization
 legacyPath: /paper shorts/2024/02/02/kto-model-alignment-as-prospect-theoretic-optimization.html

--- a/src/content/posts/lanegcn-learning-lane-graph-representations-for-motion-forecasting.md
+++ b/src/content/posts/lanegcn-learning-lane-graph-representations-for-motion-forecasting.md
@@ -1,6 +1,6 @@
 ---
 title: 'LaneGCN: Learning Lane Graph Representations for Motion Forecasting'
-date: '2020-07-27T04:00:00.000Z'
+date: '2020-07-27T00:00:00.000Z'
 section: paper-shorts
 postSlug: lanegcn-learning-lane-graph-representations-for-motion-forecasting
 legacyPath: /paper shorts/2020/07/27/lanegcn-learning-lane-graph-representations-for-motion-forecasting.html

--- a/src/content/posts/language-models-are-few-shot-learners.md
+++ b/src/content/posts/language-models-are-few-shot-learners.md
@@ -1,6 +1,6 @@
 ---
 title: Language Models are Few-Shot Learners
-date: '2020-05-01T04:00:00.000Z'
+date: '2020-05-28T00:00:00.000Z'
 section: paper-shorts
 postSlug: language-models-are-few-shot-learners
 legacyPath: /paper shorts/2020/05/01/language-models-are-few-shot-learners.html

--- a/src/content/posts/learning-transferable-visual-models-from-natural-language-supervision.md
+++ b/src/content/posts/learning-transferable-visual-models-from-natural-language-supervision.md
@@ -1,6 +1,6 @@
 ---
 title: Learning Transferable Visual Models From Natural Language Supervision
-date: '2021-03-01T04:00:00.000Z'
+date: '2021-02-26T00:00:00.000Z'
 section: paper-shorts
 postSlug: learning-transferable-visual-models-from-natural-language-supervision
 legacyPath: >-

--- a/src/content/posts/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.md
+++ b/src/content/posts/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.md
@@ -1,6 +1,6 @@
 ---
 title: 'LIBERO: Benchmarking Knowledge Transfer for Lifelong Robot Learning'
-date: '2023-06-05T09:00:00.000Z'
+date: '2023-06-05T00:00:00.000Z'
 section: paper-shorts
 postSlug: libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning
 legacyPath: /paper shorts/2023/06/05/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.html

--- a/src/content/posts/libero-para-paraphrase-robustness-in-vla-models.md
+++ b/src/content/posts/libero-para-paraphrase-robustness-in-vla-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'LIBERO-Para: A Diagnostic Benchmark for Paraphrase Robustness in VLA Models'
-date: '2026-03-30T09:00:00.000Z'
+date: '2026-03-30T00:00:00.000Z'
 section: paper-shorts
 postSlug: libero-para-paraphrase-robustness-in-vla-models
 legacyPath: /paper shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html

--- a/src/content/posts/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.md
+++ b/src/content/posts/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.md
@@ -1,6 +1,6 @@
 ---
 title: 'Lift, Splat, Shoot: Encoding Images from Arbitrary Camera Rigs by Implicitly Unprojecting to 3D'
-date: '2020-08-13T04:00:00.000Z'
+date: '2020-08-13T00:00:00.000Z'
 section: paper-shorts
 postSlug: lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs
 legacyPath: /paper shorts/2020/08/13/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.html

--- a/src/content/posts/lmt-net-lane-model-transformer-network-for-automated-hd-mapping-from-sparse-vehicle-observations.md
+++ b/src/content/posts/lmt-net-lane-model-transformer-network-for-automated-hd-mapping-from-sparse-vehicle-observations.md
@@ -1,6 +1,6 @@
 ---
 title: 'LMT-Net: Lane Model Transformer Network for Automated HD Mapping from Sparse Vehicle Observations'
-date: '2024-09-19T04:00:00.000Z'
+date: '2024-09-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: lmt-net-lane-model-transformer-network-for-automated-hd-mapping-from-sparse-vehicle-observations
 legacyPath: /paper shorts/2024/09/19/lmt-net-lane-model-transformer-network-for-automated-hd-mapping-from-sparse-vehicle-observations.html

--- a/src/content/posts/locca-visual-pretraining-with-location-aware-captioners.md
+++ b/src/content/posts/locca-visual-pretraining-with-location-aware-captioners.md
@@ -1,6 +1,6 @@
 ---
 title: 'LocCa: Visual Pretraining with Location-aware Captioners'
-date: '2024-03-28T04:00:00.000Z'
+date: '2024-03-28T00:00:00.000Z'
 section: paper-shorts
 postSlug: locca-visual-pretraining-with-location-aware-captioners
 legacyPath: /paper shorts/2024/03/28/locca-visual-pretraining-with-location-aware-captioners.html

--- a/src/content/posts/maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-construction.md
+++ b/src/content/posts/maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-construction.md
@@ -1,6 +1,6 @@
 ---
 title: 'MapTR: Structured Modeling and Learning for Online Vectorized HD Map Construction'
-date: '2022-08-30T04:00:00.000Z'
+date: '2022-08-30T00:00:00.000Z'
 section: paper-shorts
 postSlug: maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-construction
 legacyPath: /paper shorts/2022/08/30/maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-construction.html

--- a/src/content/posts/maptrv2-an-end-to-end-framework-for-online-vectorized-hd-map-construction.md
+++ b/src/content/posts/maptrv2-an-end-to-end-framework-for-online-vectorized-hd-map-construction.md
@@ -1,6 +1,6 @@
 ---
 title: 'MapTRv2: An End-to-End Framework for Online Vectorized HD Map Construction'
-date: '2023-08-10T04:00:00.000Z'
+date: '2023-08-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: maptrv2-an-end-to-end-framework-for-online-vectorized-hd-map-construction
 legacyPath: /paper shorts/2023/08/10/maptrv2-an-end-to-end-framework-for-online-vectorized-hd-map-construction.html

--- a/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
+++ b/src/content/posts/mastering-atari-go-chess-shogi-muzero.md
@@ -1,6 +1,6 @@
 ---
 title: 'Mastering Atari, Go, Chess & Shogi by Planning with a Learned Model'
-date: '2019-11-01T05:00:00.000Z'
+date: '2019-11-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: mastering-atari-go-chess-shogi-muzero
 legacyPath: /paper shorts/2019/11/01/mastering-atari-go-chess-shogi-muzero.html

--- a/src/content/posts/metabev-solving-sensor-failures-for-bev-perception.md
+++ b/src/content/posts/metabev-solving-sensor-failures-for-bev-perception.md
@@ -1,6 +1,6 @@
 ---
 title: 'MetaBEV: Solving Sensor Failures for BEV Detection and Map Segmentation'
-date: '2023-04-19T04:00:00.000Z'
+date: '2023-04-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: metabev-solving-sensor-failures-for-bev-perception
 legacyPath: /paper shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html

--- a/src/content/posts/mgmap-mask-guided-learning-for-online-vectorized-hd-map-construction.md
+++ b/src/content/posts/mgmap-mask-guided-learning-for-online-vectorized-hd-map-construction.md
@@ -1,6 +1,6 @@
 ---
 title: 'MGMap: Mask-Guided Learning for Online Vectorized HD Map Construction'
-date: '2024-04-01T04:00:00.000Z'
+date: '2024-04-01T00:00:00.000Z'
 section: paper-shorts
 postSlug: mgmap-mask-guided-learning-for-online-vectorized-hd-map-construction
 legacyPath: /paper shorts/2024/04/01/mgmap-mask-guided-learning-for-online-vectorized-hd-map-construction.html

--- a/src/content/posts/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.md
+++ b/src/content/posts/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.md
@@ -1,6 +1,6 @@
 ---
 title: 'MM1: Methods, Analysis & Insights from Multimodal LLM Pre-training'
-date: '2024-03-14T09:00:00.000Z'
+date: '2024-03-14T00:00:00.000Z'
 section: paper-shorts
 postSlug: mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training
 legacyPath: /paper shorts/2024/03/14/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.html

--- a/src/content/posts/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.md
+++ b/src/content/posts/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'Molmo and PixMo: Open Weights and Open Data for State-of-the-Art Vision-Language Models'
-date: '2024-09-01T04:00:00.000Z'
+date: '2024-09-25T00:00:00.000Z'
 section: paper-shorts
 postSlug: molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models
 legacyPath: /paper shorts/2024/09/01/molmo-and-pixmo-open-weights-and-open-data-for-state-of-the-art-vision-language-models.html

--- a/src/content/posts/motionlm-multi-agent-motion-forecasting-as-language-modeling.md
+++ b/src/content/posts/motionlm-multi-agent-motion-forecasting-as-language-modeling.md
@@ -1,6 +1,6 @@
 ---
 title: 'MotionLM: Multi-Agent Motion Forecasting as Language Modeling'
-date: '2023-09-28T04:00:00.000Z'
+date: '2023-09-28T00:00:00.000Z'
 section: paper-shorts
 postSlug: motionlm-multi-agent-motion-forecasting-as-language-modeling
 legacyPath: /paper shorts/2023/09/28/motionlm-multi-agent-motion-forecasting-as-language-modeling.html

--- a/src/content/posts/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.md
+++ b/src/content/posts/msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft.md
@@ -1,6 +1,6 @@
 ---
 title: 'mSFT: Addressing Dataset Mixtures Overfitting Heterogeneously in Multi-task SFT'
-date: '2026-03-23T04:00:00.000Z'
+date: '2026-03-23T00:00:00.000Z'
 section: paper-shorts
 postSlug: msft-addressing-dataset-mixtures-overfitting-heterogeneously-in-multitask-sft
 legacyPath: >-

--- a/src/content/posts/octo-an-open-source-generalist-robot-policy.md
+++ b/src/content/posts/octo-an-open-source-generalist-robot-policy.md
@@ -1,6 +1,6 @@
 ---
 title: 'Octo: An Open-Source Generalist Robot Policy'
-date: '2024-05-20T09:00:00.000Z'
+date: '2024-05-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: octo-an-open-source-generalist-robot-policy
 legacyPath: /paper shorts/2024/05/20/octo-an-open-source-generalist-robot-policy.html

--- a/src/content/posts/on-policy-distillation-language-models-gkd.md
+++ b/src/content/posts/on-policy-distillation-language-models-gkd.md
@@ -1,6 +1,6 @@
 ---
 title: 'On-Policy Distillation of Language Models: GKD'
-date: '2023-06-23T17:56:26.000Z'
+date: '2023-06-23T00:00:00.000Z'
 section: paper-shorts
 postSlug: on-policy-distillation-language-models-gkd
 legacyPath: /paper shorts/2023/06/23/on-policy-distillation-language-models-gkd.html

--- a/src/content/posts/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.md
+++ b/src/content/posts/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'Open X-Embodiment: Robotic Learning Datasets and RT-X Models'
-date: '2023-10-13T09:00:00.000Z'
+date: '2023-10-13T00:00:00.000Z'
 section: paper-shorts
 postSlug: open-x-embodiment-robotic-learning-datasets-and-rt-x-models
 legacyPath: /paper shorts/2023/10/13/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.html

--- a/src/content/posts/opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-language-action-model.md
+++ b/src/content/posts/opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-language-action-model.md
@@ -1,6 +1,6 @@
 ---
 title: 'OpenDriveVLA: Towards End-to-end Autonomous Driving with Large Vision Language Action Model'
-date: '2025-03-30T04:00:00.000Z'
+date: '2025-03-30T00:00:00.000Z'
 section: paper-shorts
 postSlug: opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-language-action-model
 legacyPath: /paper shorts/2025/03/30/opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-language-action-model.html

--- a/src/content/posts/openvla-oft-optimizing-speed-and-success.md
+++ b/src/content/posts/openvla-oft-optimizing-speed-and-success.md
@@ -1,6 +1,6 @@
 ---
 title: 'Fine-Tuning Vision-Language-Action Models: Optimizing Speed and Success (OpenVLA-OFT)'
-date: '2025-02-27T09:00:00.000Z'
+date: '2025-02-27T00:00:00.000Z'
 section: paper-shorts
 postSlug: openvla-oft-optimizing-speed-and-success
 legacyPath: /paper shorts/2025/02/27/openvla-oft-optimizing-speed-and-success.html

--- a/src/content/posts/openvla-open-source-vision-language-action-model.md
+++ b/src/content/posts/openvla-open-source-vision-language-action-model.md
@@ -1,6 +1,6 @@
 ---
 title: 'OpenVLA: An Open-Source Vision-Language-Action Model'
-date: '2024-06-01T04:00:00.000Z'
+date: '2024-06-13T00:00:00.000Z'
 section: paper-shorts
 postSlug: openvla-open-source-vision-language-action-model
 legacyPath: /paper shorts/2024/06/01/openvla-open-source-vision-language-action-model.html

--- a/src/content/posts/paligemma-a-versatile-3b-vlm-for-transfer.md
+++ b/src/content/posts/paligemma-a-versatile-3b-vlm-for-transfer.md
@@ -1,6 +1,6 @@
 ---
 title: 'PaliGemma: A Versatile 3B VLM for Transfer'
-date: '2024-07-10T04:00:00.000Z'
+date: '2024-07-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: paligemma-a-versatile-3b-vlm-for-transfer
 legacyPath: /paper shorts/2024/07/10/paligemma-a-versatile-3b-vlm-for-transfer.html

--- a/src/content/posts/perceiver-io-a-general-architecture-for-structured-inputs-and-outputs.md
+++ b/src/content/posts/perceiver-io-a-general-architecture-for-structured-inputs-and-outputs.md
@@ -1,6 +1,6 @@
 ---
 title: 'Perceiver IO: A General Architecture for Structured Inputs & Outputs'
-date: '2021-07-30T04:00:00.000Z'
+date: '2021-07-30T00:00:00.000Z'
 section: paper-shorts
 postSlug: perceiver-io-a-general-architecture-for-structured-inputs-and-outputs
 legacyPath: /paper shorts/2021/07/30/perceiver-io-a-general-architecture-for-structured-inputs-and-outputs.html

--- a/src/content/posts/perceptdrive-perception-prior-world-action-modeling-with-adaptive-expert-routing-for-end-to-end-autonomous-driving.md
+++ b/src/content/posts/perceptdrive-perception-prior-world-action-modeling-with-adaptive-expert-routing-for-end-to-end-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'PerceptDrive: Perception Prior World-Action Modeling with Adaptive Expert Routing for End-to-End Autonomous Driving'
-date: '2026-07-24T14:30:00.000Z'
+date: '2026-07-22T00:00:00.000Z'
 section: paper-shorts
 postSlug: perceptdrive-perception-prior-world-action-modeling-with-adaptive-expert-routing-for-end-to-end-autonomous-driving
 legacyPath: /paper shorts/2026/07/24/perceptdrive-perception-prior-world-action-modeling-with-adaptive-expert-routing-for-end-to-end-autonomous-driving.html

--- a/src/content/posts/pi0-5-vision-language-action-model-with-open-world-generalization.md
+++ b/src/content/posts/pi0-5-vision-language-action-model-with-open-world-generalization.md
@@ -1,6 +1,6 @@
 ---
 title: 'Pi0.5: A Vision-Language-Action Model with Open-World Generalization'
-date: '2025-04-22T09:00:00.000Z'
+date: '2025-04-22T00:00:00.000Z'
 section: paper-shorts
 postSlug: pi0-5-vision-language-action-model-with-open-world-generalization
 legacyPath: /paper shorts/2025/04/22/pi0-5-vision-language-action-model-with-open-world-generalization.html

--- a/src/content/posts/pi0-vision-language-action-flow-model-for-general-robot-control.md
+++ b/src/content/posts/pi0-vision-language-action-flow-model-for-general-robot-control.md
@@ -1,6 +1,6 @@
 ---
 title: 'Pi0: A Vision-Language-Action Flow Model for General Robot Control'
-date: '2024-10-01T04:00:00.000Z'
+date: '2024-10-31T00:00:00.000Z'
 section: paper-shorts
 postSlug: pi0-vision-language-action-flow-model-for-general-robot-control
 legacyPath: /paper shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html

--- a/src/content/posts/playing-atari-with-dqn.md
+++ b/src/content/posts/playing-atari-with-dqn.md
@@ -1,6 +1,6 @@
 ---
 title: Playing Atari with Deep Reinforcement Learning
-date: '2013-12-01T05:00:00.000Z'
+date: '2013-12-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: playing-atari-with-dqn
 legacyPath: /paper shorts/2013/12/01/playing-atari-with-dqn.html

--- a/src/content/posts/proximal-policy-optimization-ppo.mdx
+++ b/src/content/posts/proximal-policy-optimization-ppo.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Proximal Policy Optimization Algorithms (PPO)'
-date: '2017-07-20T17:26:19.000Z'
+date: '2017-07-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: proximal-policy-optimization-ppo
 legacyPath: /paper shorts/2017/07/01/proximal-policy-optimization-ppo.html

--- a/src/content/posts/qwen-robotworld-unifying-embodied-world-modeling-through-language-conditioned-video-generation.md
+++ b/src/content/posts/qwen-robotworld-unifying-embodied-world-modeling-through-language-conditioned-video-generation.md
@@ -1,6 +1,6 @@
 ---
 title: 'Qwen-RobotWorld: Unifying Embodied World Modeling through Language-Conditioned Video Generation'
-date: '2026-07-24T13:00:00.000Z'
+date: '2026-06-15T00:00:00.000Z'
 section: paper-shorts
 postSlug: qwen-robotworld-unifying-embodied-world-modeling-through-language-conditioned-video-generation
 legacyPath: /paper shorts/2026/07/24/qwen-robotworld-unifying-embodied-world-modeling-through-language-conditioned-video-generation.html

--- a/src/content/posts/qwen-vla-unifying-vision-language-action-modeling-across-tasks-environments-and-robot-embodiments.md
+++ b/src/content/posts/qwen-vla-unifying-vision-language-action-modeling-across-tasks-environments-and-robot-embodiments.md
@@ -1,6 +1,6 @@
 ---
 title: 'Qwen-VLA: Unifying Vision-Language-Action Modeling across Tasks, Environments, and Robot Embodiments'
-date: '2026-05-28T04:00:00.000Z'
+date: '2026-05-28T00:00:00.000Z'
 section: paper-shorts
 postSlug: qwen-vla-unifying-vision-language-action-modeling-across-tasks-environments-and-robot-embodiments
 legacyPath: /paper shorts/2026/05/28/qwen-vla-unifying-vision-language-action-modeling-across-tasks-environments-and-robot-embodiments.html

--- a/src/content/posts/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.md
+++ b/src/content/posts/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.md
@@ -1,6 +1,6 @@
 ---
 title: "Qwen2-VL: Enhancing Vision-Language Model's Perception of the World at Any Resolution"
-date: '2024-09-01T04:00:00.000Z'
+date: '2024-09-18T00:00:00.000Z'
 section: paper-shorts
 postSlug: qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution
 legacyPath: /paper shorts/2024/09/01/qwen2-vl-enhancing-vision-language-model-perception-of-the-world-at-any-resolution.html

--- a/src/content/posts/rcbevdet-radar-camera-fusion-in-bev.md
+++ b/src/content/posts/rcbevdet-radar-camera-fusion-in-bev.md
@@ -1,6 +1,6 @@
 ---
 title: "RCBEVDet: Radar-Camera Fusion in Bird's-Eye View for 3D Object Detection"
-date: '2024-03-25T04:00:00.000Z'
+date: '2024-03-25T00:00:00.000Z'
 section: paper-shorts
 postSlug: rcbevdet-radar-camera-fusion-in-bev
 legacyPath: /paper shorts/2024/03/25/rcbevdet-radar-camera-fusion-in-bev.html

--- a/src/content/posts/reward-model-ensembles-help-mitigate-overoptimization.md
+++ b/src/content/posts/reward-model-ensembles-help-mitigate-overoptimization.md
@@ -1,6 +1,6 @@
 ---
 title: 'Reward Model Ensembles Help Mitigate Overoptimization'
-date: '2023-10-04T09:00:00.000Z'
+date: '2023-10-04T00:00:00.000Z'
 section: paper-shorts
 postSlug: reward-model-ensembles-help-mitigate-overoptimization
 legacyPath: /paper shorts/2023/10/04/reward-model-ensembles-help-mitigate-overoptimization.html

--- a/src/content/posts/ript-vla-interactive-post-training-for-vision-language-action-models.md
+++ b/src/content/posts/ript-vla-interactive-post-training-for-vision-language-action-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'RIPT-VLA: Interactive Post-Training for Vision-Language-Action Models'
-date: '2025-05-22T09:00:00.000Z'
+date: '2025-05-22T00:00:00.000Z'
 section: paper-shorts
 postSlug: ript-vla-interactive-post-training-for-vision-language-action-models
 legacyPath: /paper shorts/2025/05/22/ript-vla-interactive-post-training-for-vision-language-action-models.html

--- a/src/content/posts/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.md
+++ b/src/content/posts/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.md
@@ -1,6 +1,6 @@
 ---
 title: 'RLDG: Robotic Generalist Policy Distillation via Reinforcement Learning'
-date: '2024-12-13T09:00:00.000Z'
+date: '2024-12-13T00:00:00.000Z'
 section: paper-shorts
 postSlug: rldg-robotic-generalist-policy-distillation-via-reinforcement-learning
 legacyPath: /paper shorts/2024/12/13/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.html

--- a/src/content/posts/robotwin-2-scalable-data-generator-and-benchmark.md
+++ b/src/content/posts/robotwin-2-scalable-data-generator-and-benchmark.md
@@ -1,6 +1,6 @@
 ---
 title: 'RoboTwin 2.0: A Scalable Data Generator and Benchmark for Bimanual Manipulation'
-date: '2025-06-20T09:00:00.000Z'
+date: '2025-06-22T00:00:00.000Z'
 section: paper-shorts
 postSlug: robotwin-2-scalable-data-generator-and-benchmark
 legacyPath: /paper shorts/2025/06/20/robotwin-2-scalable-data-generator-and-benchmark.html

--- a/src/content/posts/robust-autonomy-emerges-from-self-play.md
+++ b/src/content/posts/robust-autonomy-emerges-from-self-play.md
@@ -1,6 +1,6 @@
 ---
 title: 'Robust Autonomy Emerges from Self-Play'
-date: '2026-07-24T13:00:00.000Z'
+date: '2025-02-05T00:00:00.000Z'
 section: paper-shorts
 postSlug: robust-autonomy-emerges-from-self-play
 legacyPath: /paper shorts/2026/07/24/robust-autonomy-emerges-from-self-play.html

--- a/src/content/posts/robustvla-robustness-aware-reinforcement-post-training.md
+++ b/src/content/posts/robustvla-robustness-aware-reinforcement-post-training.md
@@ -1,6 +1,6 @@
 ---
 title: 'RobustVLA: Robustness-Aware Reinforcement Post-Training for Vision-Language-Action Models'
-date: '2025-11-03T09:00:00.000Z'
+date: '2025-11-03T00:00:00.000Z'
 section: paper-shorts
 postSlug: robustvla-robustness-aware-reinforcement-post-training
 legacyPath: /paper shorts/2025/11/03/robustvla-robustness-aware-reinforcement-post-training.html

--- a/src/content/posts/rt-1-robotics-transformer-for-real-world-control-at-scale.md
+++ b/src/content/posts/rt-1-robotics-transformer-for-real-world-control-at-scale.md
@@ -1,6 +1,6 @@
 ---
 title: 'RT-1: Robotics Transformer for Real-World Control at Scale'
-date: '2022-12-13T09:00:00.000Z'
+date: '2022-12-13T00:00:00.000Z'
 section: paper-shorts
 postSlug: rt-1-robotics-transformer-for-real-world-control-at-scale
 legacyPath: /paper shorts/2022/12/13/rt-1-robotics-transformer-for-real-world-control-at-scale.html

--- a/src/content/posts/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.md
+++ b/src/content/posts/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.md
@@ -1,6 +1,6 @@
 ---
 title: 'RT-2: Vision-Language-Action Models Transfer Web Knowledge to Robotic Control'
-date: '2023-07-28T09:00:00.000Z'
+date: '2023-07-28T00:00:00.000Z'
 section: paper-shorts
 postSlug: rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control
 legacyPath: /paper shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html

--- a/src/content/posts/rtmap-real-time-recursive-mapping-with-change-detection-and-localization.md
+++ b/src/content/posts/rtmap-real-time-recursive-mapping-with-change-detection-and-localization.md
@@ -1,6 +1,6 @@
 ---
 title: 'RTMap: Real-Time Recursive Mapping with Change Detection and Localization'
-date: '2025-07-01T04:00:00.000Z'
+date: '2025-07-01T00:00:00.000Z'
 section: paper-shorts
 postSlug: rtmap-real-time-recursive-mapping-with-change-detection-and-localization
 legacyPath: /paper shorts/2025/07/01/rtmap-real-time-recursive-mapping-with-change-detection-and-localization.html

--- a/src/content/posts/scaling-laws-for-generative-mixed-modal-language-models.md
+++ b/src/content/posts/scaling-laws-for-generative-mixed-modal-language-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scaling Laws for Generative Mixed-Modal Language Models'
-date: '2023-01-10T09:00:00.000Z'
+date: '2023-01-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: scaling-laws-for-generative-mixed-modal-language-models
 legacyPath: /paper shorts/2023/01/10/scaling-laws-for-generative-mixed-modal-language-models.html

--- a/src/content/posts/scaling-laws-for-native-multimodal-models.md
+++ b/src/content/posts/scaling-laws-for-native-multimodal-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scaling Laws for Native Multimodal Models'
-date: '2025-04-10T09:00:00.000Z'
+date: '2025-04-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: scaling-laws-for-native-multimodal-models
 legacyPath: /paper shorts/2025/04/10/scaling-laws-for-native-multimodal-models.html

--- a/src/content/posts/scaling-laws-for-optimal-data-mixtures.md
+++ b/src/content/posts/scaling-laws-for-optimal-data-mixtures.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scaling Laws for Optimal Data Mixtures'
-date: '2025-07-12T09:00:00.000Z'
+date: '2025-07-12T00:00:00.000Z'
 section: paper-shorts
 postSlug: scaling-laws-for-optimal-data-mixtures
 legacyPath: /paper shorts/2025/07/12/scaling-laws-for-optimal-data-mixtures.html

--- a/src/content/posts/scaling-laws-for-reward-model-overoptimization.md
+++ b/src/content/posts/scaling-laws-for-reward-model-overoptimization.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scaling Laws for Reward Model Overoptimization'
-date: '2022-10-19T09:00:00.000Z'
+date: '2022-10-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: scaling-laws-for-reward-model-overoptimization
 legacyPath: /paper shorts/2022/10/19/scaling-laws-for-reward-model-overoptimization.html

--- a/src/content/posts/scaling-laws-of-motion-forecasting-and-planning.md
+++ b/src/content/posts/scaling-laws-of-motion-forecasting-and-planning.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scaling Laws of Motion Forecasting and Planning'
-date: '2025-06-09T04:00:00.000Z'
+date: '2025-06-09T00:00:00.000Z'
 section: paper-shorts
 postSlug: scaling-laws-of-motion-forecasting-and-planning
 legacyPath: /paper shorts/2025/06/09/scaling-laws-of-motion-forecasting-and-planning.html

--- a/src/content/posts/scaling-motion-forecasting-models-with-ensemble-distillation.md
+++ b/src/content/posts/scaling-motion-forecasting-models-with-ensemble-distillation.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scaling Motion Forecasting Models with Ensemble Distillation'
-date: '2024-04-05T04:00:00.000Z'
+date: '2024-04-05T00:00:00.000Z'
 section: paper-shorts
 postSlug: scaling-motion-forecasting-models-with-ensemble-distillation
 legacyPath: /paper shorts/2024/04/05/scaling-motion-forecasting-models-with-ensemble-distillation.html

--- a/src/content/posts/scaling-self-play-for-end-to-end-driving.md
+++ b/src/content/posts/scaling-self-play-for-end-to-end-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scaling Self-Play for End-to-End Driving'
-date: '2026-07-24T13:00:00.000Z'
+date: '2026-06-17T00:00:00.000Z'
 section: paper-shorts
 postSlug: scaling-self-play-for-end-to-end-driving
 legacyPath: /paper shorts/2026/07/24/scaling-self-play-for-end-to-end-driving.html

--- a/src/content/posts/scene-reconstruction-as-mapping-priors-for-3d-detection.md
+++ b/src/content/posts/scene-reconstruction-as-mapping-priors-for-3d-detection.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scene Reconstruction as Mapping Priors for 3D Detection'
-date: '2026-05-21T04:00:00.000Z'
+date: '2026-05-21T00:00:00.000Z'
 section: paper-shorts
 postSlug: scene-reconstruction-as-mapping-priors-for-3d-detection
 legacyPath: /paper shorts/2026/05/21/scene-reconstruction-as-mapping-priors-for-3d-detection.html

--- a/src/content/posts/scene-transformer-a-unified-architecture-for-predicting-multiple-agent-trajectories.md
+++ b/src/content/posts/scene-transformer-a-unified-architecture-for-predicting-multiple-agent-trajectories.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scene Transformer: A Unified Architecture for Predicting Multiple Agent Trajectories'
-date: '2021-06-15T04:00:00.000Z'
+date: '2021-06-15T00:00:00.000Z'
 section: paper-shorts
 postSlug: scene-transformer-a-unified-architecture-for-predicting-multiple-agent-trajectories
 legacyPath: /paper shorts/2021/06/15/scene-transformer-a-unified-architecture-for-predicting-multiple-agent-trajectories.html

--- a/src/content/posts/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.md
+++ b/src/content/posts/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'SENNA: Bridging Large Vision-Language Models and End-to-End Autonomous Driving'
-date: '2024-10-01T04:00:00.000Z'
+date: '2024-10-29T00:00:00.000Z'
 section: paper-shorts
 postSlug: senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving
 legacyPath: /paper shorts/2024/10/01/senna-bridging-large-vision-language-models-and-end-to-end-autonomous-driving.html

--- a/src/content/posts/sequence-to-sequence-learning-with-neural-networks.md
+++ b/src/content/posts/sequence-to-sequence-learning-with-neural-networks.md
@@ -1,6 +1,6 @@
 ---
 title: Sequence to Sequence Learning with Neural Networks
-date: '2014-09-01T04:00:00.000Z'
+date: '2014-09-10T00:00:00.000Z'
 section: paper-shorts
 postSlug: sequence-to-sequence-learning-with-neural-networks
 legacyPath: >-

--- a/src/content/posts/sigmoid-loss-for-language-image-pre-training-siglip.md
+++ b/src/content/posts/sigmoid-loss-for-language-image-pre-training-siglip.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sigmoid Loss for Language-Image Pre-Training (SigLIP)'
-date: '2023-03-01T18:55:11.000Z'
+date: '2023-03-27T00:00:00.000Z'
 section: paper-shorts
 postSlug: sigmoid-loss-for-language-image-pre-training-siglip
 legacyPath: /paper shorts/2023/10/01/sigmoid-loss-for-language-image-pre-training-siglip.html

--- a/src/content/posts/simpler-evaluating-real-world-robot-policies-in-simulation.md
+++ b/src/content/posts/simpler-evaluating-real-world-robot-policies-in-simulation.md
@@ -1,6 +1,6 @@
 ---
 title: 'SIMPLER: Evaluating Real-World Robot Manipulation Policies in Simulation'
-date: '2024-05-09T09:00:00.000Z'
+date: '2024-05-09T00:00:00.000Z'
 section: paper-shorts
 postSlug: simpler-evaluating-real-world-robot-policies-in-simulation
 legacyPath: /paper shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html

--- a/src/content/posts/simplevla-rl-scaling-vla-training-via-reinforcement-learning.md
+++ b/src/content/posts/simplevla-rl-scaling-vla-training-via-reinforcement-learning.md
@@ -1,6 +1,6 @@
 ---
 title: 'SimpleVLA-RL: Scaling VLA Training via Reinforcement Learning'
-date: '2025-09-11T09:00:00.000Z'
+date: '2025-09-11T00:00:00.000Z'
 section: paper-shorts
 postSlug: simplevla-rl-scaling-vla-training-via-reinforcement-learning
 legacyPath: /paper shorts/2025/09/11/simplevla-rl-scaling-vla-training-via-reinforcement-learning.html

--- a/src/content/posts/sparse4d-multiview-3d-detection-with-sparse-spatiotemporal-fusion.md
+++ b/src/content/posts/sparse4d-multiview-3d-detection-with-sparse-spatiotemporal-fusion.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sparse4D: Multi-View 3D Object Detection with Sparse Spatial-Temporal Fusion'
-date: '2022-11-19T05:00:00.000Z'
+date: '2022-11-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: sparse4d-multiview-3d-detection-with-sparse-spatiotemporal-fusion
 legacyPath: /paper shorts/2022/11/19/sparse4d-multiview-3d-detection-with-sparse-spatiotemporal-fusion.html

--- a/src/content/posts/sparse4dv3-end-to-end-3d-detection-and-tracking.md
+++ b/src/content/posts/sparse4dv3-end-to-end-3d-detection-and-tracking.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sparse4D v3: Advancing End-to-End 3D Detection and Tracking'
-date: '2023-11-20T05:00:00.000Z'
+date: '2023-11-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: sparse4dv3-end-to-end-3d-detection-and-tracking
 legacyPath: /paper shorts/2023/11/20/sparse4dv3-end-to-end-3d-detection-and-tracking.html

--- a/src/content/posts/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.md
+++ b/src/content/posts/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.md
@@ -1,6 +1,6 @@
 ---
 title: 'SparseDrive: End-to-End Autonomous Driving via Sparse Scene Representation'
-date: '2024-05-30T04:00:00.000Z'
+date: '2024-05-30T00:00:00.000Z'
 section: paper-shorts
 postSlug: sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation
 legacyPath: /paper shorts/2024/05/30/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.html

--- a/src/content/posts/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.md
+++ b/src/content/posts/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.md
@@ -1,6 +1,6 @@
 ---
 title: 'StreamPETR: Object-Centric Temporal Modeling for Efficient Multi-View 3D Object Detection'
-date: '2023-03-21T04:00:00.000Z'
+date: '2023-03-21T00:00:00.000Z'
 section: paper-shorts
 postSlug: streampetr-object-centric-temporal-modeling-for-multiview-3d-detection
 legacyPath: /paper shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html

--- a/src/content/posts/talk2bev-language-enhanced-birds-eye-view-maps-for-autonomous-driving.md
+++ b/src/content/posts/talk2bev-language-enhanced-birds-eye-view-maps-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: "Talk2BEV: Language-enhanced Bird's-eye View Maps for Autonomous Driving"
-date: '2023-10-03T04:00:00.000Z'
+date: '2023-10-03T00:00:00.000Z'
 section: paper-shorts
 postSlug: talk2bev-language-enhanced-birds-eye-view-maps-for-autonomous-driving
 legacyPath: /paper shorts/2023/10/03/talk2bev-language-enhanced-birds-eye-view-maps-for-autonomous-driving.html

--- a/src/content/posts/think-at-5-hz-act-at-20-hz-asynchronous-fast-slow-vision-language-action-inference-for-closed-loop-d.md
+++ b/src/content/posts/think-at-5-hz-act-at-20-hz-asynchronous-fast-slow-vision-language-action-inference-for-closed-loop-d.md
@@ -1,6 +1,6 @@
 ---
 title: 'Think at 5 Hz, Act at 20 Hz: Asynchronous Fast-Slow Vision-Language-Action Inference for Closed-Loop Driving'
-date: '2026-07-17T09:00:00.000Z'
+date: '2026-07-17T00:00:00.000Z'
 section: paper-shorts
 postSlug: think-at-5-hz-act-at-20-hz-asynchronous-fast-slow-vision-language-action-inference-for-closed-loop-d
 legacyPath: /paper shorts/2026/07/17/think-at-5-hz-act-at-20-hz-asynchronous-fast-slow-vision-language-action-inference-for-closed-loop-d.html

--- a/src/content/posts/tnt-target-driven-trajectory-prediction.md
+++ b/src/content/posts/tnt-target-driven-trajectory-prediction.md
@@ -1,6 +1,6 @@
 ---
 title: 'TNT: Target-driveN Trajectory Prediction'
-date: '2020-08-19T04:00:00.000Z'
+date: '2020-08-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: tnt-target-driven-trajectory-prediction
 legacyPath: /paper shorts/2020/08/19/tnt-target-driven-trajectory-prediction.html

--- a/src/content/posts/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.md
+++ b/src/content/posts/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.md
@@ -1,6 +1,6 @@
 ---
 title: 'TOD3Cap: Towards 3D Dense Captioning in Outdoor Scenes'
-date: '2024-03-01T05:00:00.000Z'
+date: '2024-03-28T00:00:00.000Z'
 section: paper-shorts
 postSlug: tod3cap-towards-3d-dense-captioning-in-outdoor-scenes
 legacyPath: /paper shorts/2024/03/01/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.html

--- a/src/content/posts/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.md
+++ b/src/content/posts/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.md
@@ -1,6 +1,6 @@
 ---
 title: 'TokenFlow: Unified Image Tokenizer for Multimodal Understanding and Generation'
-date: '2024-12-04T09:00:00.000Z'
+date: '2024-12-04T00:00:00.000Z'
 section: paper-shorts
 postSlug: tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation
 legacyPath: /paper shorts/2024/12/04/tokenflow-unified-image-tokenizer-for-multimodal-understanding-and-generation.html

--- a/src/content/posts/toponet-graph-based-topology-reasoning-for-driving-scenes.md
+++ b/src/content/posts/toponet-graph-based-topology-reasoning-for-driving-scenes.md
@@ -1,6 +1,6 @@
 ---
 title: 'TopoNet: Graph-based Topology Reasoning for Driving Scenes'
-date: '2023-04-11T04:00:00.000Z'
+date: '2023-04-11T00:00:00.000Z'
 section: paper-shorts
 postSlug: toponet-graph-based-topology-reasoning-for-driving-scenes
 legacyPath: /paper shorts/2023/04/11/toponet-graph-based-topology-reasoning-for-driving-scenes.html

--- a/src/content/posts/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.md
+++ b/src/content/posts/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.md
@@ -1,6 +1,6 @@
 ---
 title: 'TorchTitan: One-stop PyTorch Native Solution for Production-ready LLM Pre-training'
-date: '2024-10-09T09:00:00.000Z'
+date: '2024-10-09T00:00:00.000Z'
 section: paper-shorts
 postSlug: torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training
 legacyPath: /paper shorts/2024/10/09/torchtitan-one-stop-pytorch-native-solution-for-production-ready-llm-pre-training.html

--- a/src/content/posts/training-language-models-to-follow-instructions-with-human-feedback.md
+++ b/src/content/posts/training-language-models-to-follow-instructions-with-human-feedback.md
@@ -1,6 +1,6 @@
 ---
 title: Training Language Models to Follow Instructions with Human Feedback
-date: '2022-03-01T04:00:00.000Z'
+date: '2022-03-04T00:00:00.000Z'
 section: paper-shorts
 postSlug: training-language-models-to-follow-instructions-with-human-feedback
 legacyPath: >-

--- a/src/content/posts/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.md
+++ b/src/content/posts/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.md
@@ -1,6 +1,6 @@
 ---
 title: 'Transfusion: Predict the Next Token and Diffuse Images with One Multi-Modal Model'
-date: '2024-08-20T09:00:00.000Z'
+date: '2024-08-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model
 legacyPath: /paper shorts/2024/08/20/transfusion-predict-the-next-token-and-diffuse-images-with-one-multimodal-model.html

--- a/src/content/posts/transfusion-robust-lidar-camera-fusion-with-transformers.md
+++ b/src/content/posts/transfusion-robust-lidar-camera-fusion-with-transformers.md
@@ -1,6 +1,6 @@
 ---
 title: 'TransFusion: Robust LiDAR-Camera Fusion for 3D Object Detection with Transformers'
-date: '2022-03-22T04:00:00.000Z'
+date: '2022-03-22T00:00:00.000Z'
 section: paper-shorts
 postSlug: transfusion-robust-lidar-camera-fusion-with-transformers
 legacyPath: /paper shorts/2022/03/22/transfusion-robust-lidar-camera-fusion-with-transformers.html

--- a/src/content/posts/understanding-reasoning-from-pretraining-to-post-training.md
+++ b/src/content/posts/understanding-reasoning-from-pretraining-to-post-training.md
@@ -1,6 +1,6 @@
 ---
 title: 'Understanding Reasoning from Pretraining to Post-Training'
-date: '2026-07-17T09:00:00.000Z'
+date: '2026-07-17T00:00:00.000Z'
 section: paper-shorts
 postSlug: understanding-reasoning-from-pretraining-to-post-training
 legacyPath: /paper shorts/2026/07/17/understanding-reasoning-from-pretraining-to-post-training.html

--- a/src/content/posts/uniad-planning-oriented-autonomous-driving.md
+++ b/src/content/posts/uniad-planning-oriented-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'UniAD: Planning-oriented Autonomous Driving'
-date: '2022-12-20T05:00:00.000Z'
+date: '2022-12-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: uniad-planning-oriented-autonomous-driving
 legacyPath: /paper shorts/2022/12/20/uniad-planning-oriented-autonomous-driving.html

--- a/src/content/posts/unidrivevla-unifying-understanding-perception-and-action-planning-for-autonomous-driving.md
+++ b/src/content/posts/unidrivevla-unifying-understanding-perception-and-action-planning-for-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'UniDriveVLA: Unifying Understanding, Perception, and Action Planning for Autonomous Driving'
-date: '2026-04-02T04:00:00.000Z'
+date: '2026-04-02T00:00:00.000Z'
 section: paper-shorts
 postSlug: unidrivevla-unifying-understanding-perception-and-action-planning-for-autonomous-driving
 legacyPath: /paper shorts/2026/04/02/unidrivevla-unifying-understanding-perception-and-action-planning-for-autonomous-driving.html

--- a/src/content/posts/unim2ae-multimodal-masked-autoencoders-with-unified-3d-representation.md
+++ b/src/content/posts/unim2ae-multimodal-masked-autoencoders-with-unified-3d-representation.md
@@ -1,6 +1,6 @@
 ---
 title: 'UniM²AE: Multi-Modal Masked Autoencoders with Unified 3D Representation for Autonomous Driving'
-date: '2023-08-21T04:00:00.000Z'
+date: '2023-08-21T00:00:00.000Z'
 section: paper-shorts
 postSlug: unim2ae-multimodal-masked-autoencoders-with-unified-3d-representation
 legacyPath: /paper shorts/2023/08/21/unim2ae-multimodal-masked-autoencoders-with-unified-3d-representation.html

--- a/src/content/posts/unitr-unified-efficient-multimodal-transformer-for-bev.md
+++ b/src/content/posts/unitr-unified-efficient-multimodal-transformer-for-bev.md
@@ -1,6 +1,6 @@
 ---
 title: "UniTR: A Unified and Efficient Multi-Modal Transformer for Bird's-Eye-View Representation"
-date: '2023-08-15T04:00:00.000Z'
+date: '2023-08-15T00:00:00.000Z'
 section: paper-shorts
 postSlug: unitr-unified-efficient-multimodal-transformer-for-bev
 legacyPath: /paper shorts/2023/08/15/unitr-unified-efficient-multimodal-transformer-for-bev.html

--- a/src/content/posts/vad-vectorized-scene-representation-for-efficient-autonomous-driving.md
+++ b/src/content/posts/vad-vectorized-scene-representation-for-efficient-autonomous-driving.md
@@ -1,6 +1,6 @@
 ---
 title: 'VAD: Vectorized Scene Representation for Efficient Autonomous Driving'
-date: '2023-03-21T04:00:00.000Z'
+date: '2023-03-21T00:00:00.000Z'
 section: paper-shorts
 postSlug: vad-vectorized-scene-representation-for-efficient-autonomous-driving
 legacyPath: /paper shorts/2023/03/21/vad-vectorized-scene-representation-for-efficient-autonomous-driving.html

--- a/src/content/posts/vectornet-encoding-hd-maps-and-agent-dynamics-from-vectorized-representation.md
+++ b/src/content/posts/vectornet-encoding-hd-maps-and-agent-dynamics-from-vectorized-representation.md
@@ -1,6 +1,6 @@
 ---
 title: 'VectorNet: Encoding HD Maps and Agent Dynamics from Vectorized Representation'
-date: '2020-05-08T04:00:00.000Z'
+date: '2020-05-08T00:00:00.000Z'
 section: paper-shorts
 postSlug: vectornet-encoding-hd-maps-and-agent-dynamics-from-vectorized-representation
 legacyPath: /paper shorts/2020/05/08/vectornet-encoding-hd-maps-and-agent-dynamics-from-vectorized-representation.html

--- a/src/content/posts/videollama-3-frontier-multimodal-foundation-models.md
+++ b/src/content/posts/videollama-3-frontier-multimodal-foundation-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'VideoLLaMA 3: Frontier Multimodal Foundation Models for Image and Video Understanding'
-date: '2025-01-01T05:00:00.000Z'
+date: '2025-01-22T00:00:00.000Z'
 section: paper-shorts
 postSlug: videollama-3-frontier-multimodal-foundation-models
 legacyPath: /paper shorts/2025/01/01/videollama-3-frontier-multimodal-foundation-models.html

--- a/src/content/posts/vision-language-action-models-for-autonomous-driving-past-present-and-future.md
+++ b/src/content/posts/vision-language-action-models-for-autonomous-driving-past-present-and-future.md
@@ -1,6 +1,6 @@
 ---
 title: 'Vision-Language-Action Models for Autonomous Driving: Past, Present, and Future'
-date: '2025-12-18T05:00:00.000Z'
+date: '2025-12-18T00:00:00.000Z'
 section: paper-shorts
 postSlug: vision-language-action-models-for-autonomous-driving-past-present-and-future
 legacyPath: /paper shorts/2025/12/18/vision-language-action-models-for-autonomous-driving-past-present-and-future.html

--- a/src/content/posts/visual-instruction-tuning-llava.md
+++ b/src/content/posts/visual-instruction-tuning-llava.md
@@ -1,6 +1,6 @@
 ---
 title: Visual Instruction Tuning (LLaVA)
-date: '2023-04-01T04:00:00.000Z'
+date: '2023-04-17T00:00:00.000Z'
 section: paper-shorts
 postSlug: visual-instruction-tuning-llava
 legacyPath: /paper shorts/2023/04/01/visual-instruction-tuning-llava.html

--- a/src/content/posts/visualprm-process-reward-model-for-multimodal-reasoning.md
+++ b/src/content/posts/visualprm-process-reward-model-for-multimodal-reasoning.md
@@ -1,6 +1,6 @@
 ---
 title: 'VisualPRM: An Effective Process Reward Model for Multimodal Reasoning'
-date: '2025-03-13T09:00:00.000Z'
+date: '2025-03-13T00:00:00.000Z'
 section: paper-shorts
 postSlug: visualprm-process-reward-model-for-multimodal-reasoning
 legacyPath: /paper shorts/2025/03/13/visualprm-process-reward-model-for-multimodal-reasoning.html

--- a/src/content/posts/vla-replica-low-cost-reproducible-real-world-evaluation.md
+++ b/src/content/posts/vla-replica-low-cost-reproducible-real-world-evaluation.md
@@ -1,6 +1,6 @@
 ---
 title: 'VLA-REPLICA: A Low-Cost, Reproducible Benchmark for Real-World VLA Evaluation'
-date: '2026-05-20T09:00:00.000Z'
+date: '2026-05-20T00:00:00.000Z'
 section: paper-shorts
 postSlug: vla-replica-low-cost-reproducible-real-world-evaluation
 legacyPath: /paper shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html

--- a/src/content/posts/vlac-vision-language-action-critic-for-real-world-rl.md
+++ b/src/content/posts/vlac-vision-language-action-critic-for-real-world-rl.md
@@ -1,6 +1,6 @@
 ---
 title: 'VLAC: A Vision-Language-Action-Critic Model for Real-World Reinforcement Learning'
-date: '2025-09-19T09:00:00.000Z'
+date: '2025-09-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: vlac-vision-language-action-critic-for-real-world-rl
 legacyPath: /paper shorts/2025/09/19/vlac-vision-language-action-critic-for-real-world-rl.html

--- a/src/content/posts/vlm-ad-end-to-end-autonomous-driving-through-vision-language-model-supervision.md
+++ b/src/content/posts/vlm-ad-end-to-end-autonomous-driving-through-vision-language-model-supervision.md
@@ -1,6 +1,6 @@
 ---
 title: 'VLM-AD: End-to-End Autonomous Driving through Vision-Language Model Supervision'
-date: '2024-12-19T05:00:00.000Z'
+date: '2024-12-19T00:00:00.000Z'
 section: paper-shorts
 postSlug: vlm-ad-end-to-end-autonomous-driving-through-vision-language-model-supervision
 legacyPath: /paper shorts/2024/12/19/vlm-ad-end-to-end-autonomous-driving-through-vision-language-model-supervision.html

--- a/src/content/posts/voln-vision-only-long-horizon-navigation-paradigm-benchmark-and-method.md
+++ b/src/content/posts/voln-vision-only-long-horizon-navigation-paradigm-benchmark-and-method.md
@@ -1,6 +1,6 @@
 ---
 title: 'VoLN: Vision-Only Long-Horizon Navigation—Paradigm, Benchmark, and Method'
-date: '2026-07-24T14:25:00.000Z'
+date: '2026-07-23T00:00:00.000Z'
 section: paper-shorts
 postSlug: voln-vision-only-long-horizon-navigation-paradigm-benchmark-and-method
 legacyPath: /paper shorts/2026/07/24/voln-vision-only-long-horizon-navigation-paradigm-benchmark-and-method.html

--- a/src/content/posts/wan-open-and-advanced-large-scale-video-generative-models.md
+++ b/src/content/posts/wan-open-and-advanced-large-scale-video-generative-models.md
@@ -1,6 +1,6 @@
 ---
 title: 'Wan: Open and Advanced Large-Scale Video Generative Models'
-date: '2025-03-26T09:00:00.000Z'
+date: '2025-03-26T00:00:00.000Z'
 section: paper-shorts
 postSlug: wan-open-and-advanced-large-scale-video-generative-models
 legacyPath: /paper shorts/2025/03/26/wan-open-and-advanced-large-scale-video-generative-models.html

--- a/src/content/posts/wayformer-motion-forecasting-via-simple-and-efficient-attention-networks.md
+++ b/src/content/posts/wayformer-motion-forecasting-via-simple-and-efficient-attention-networks.md
@@ -1,6 +1,6 @@
 ---
 title: 'Wayformer: Motion Forecasting via Simple and Efficient Attention Networks'
-date: '2022-07-12T04:00:00.000Z'
+date: '2022-07-12T00:00:00.000Z'
 section: paper-shorts
 postSlug: wayformer-motion-forecasting-via-simple-and-efficient-attention-networks
 legacyPath: /paper shorts/2022/07/12/wayformer-motion-forecasting-via-simple-and-efficient-attention-networks.html

--- a/src/pages/paper_summaries_field.astro
+++ b/src/pages/paper_summaries_field.astro
@@ -133,6 +133,9 @@ const indexedPapers = papers.map((paper) => {
     field,
     topics: [...new Set([...inferredTopics, ...paper.data.topics])],
   };
+}).sort((left, right) => {
+  const byDate = right.date.getTime() - left.date.getTime();
+  return byDate || left.title.localeCompare(right.title);
 });
 
 const years = [...new Set(indexedPapers.map((paper) => paper.year))].sort((a, b) => b - a);
@@ -381,7 +384,7 @@ const formatDate = (date: Date) =>
           <p class="panel-kicker">Library</p>
           <h2>All paper notes</h2>
         </div>
-        <p><span data-visible-count>{indexedPapers.length}</span> results</p>
+        <p><span data-visible-count>{indexedPapers.length}</span> results · ordered by release date</p>
       </div>
 
       <div class="active-filter" data-active-filter hidden>


### PR DESCRIPTION
Use one date field for paper release dates across the full paper corpus, sort the research list by release date with title tie-breaking, and preserve legacy URLs. Tested with npm run ci.