### PR TITLE
Rewrite autonomous driving perception guide

### DIFF
--- a/src/content/posts/bev-mae-bird-eye-view-masked-autoencoders-for-point-cloud-pretraining.md
+++ b/src/content/posts/bev-mae-bird-eye-view-masked-autoencoders-for-point-cloud-pretraining.md
@@ -1,0 +1,43 @@
+---
+title: "BEV-MAE: Bird's-Eye-View Masked Autoencoders for Point-Cloud Pretraining"
+date: '2022-12-12T05:00:00.000Z'
+section: paper-shorts
+postSlug: bev-mae-bird-eye-view-masked-autoencoders-for-point-cloud-pretraining
+legacyPath: /paper shorts/2022/12/12/bev-mae-bird-eye-view-masked-autoencoders-for-point-cloud-pretraining.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: "2022 – BEV-MAE: Bird's-Eye-View Masked Autoencoders for Point-Cloud Pretraining"
+---
+## 2022 – BEV-MAE
+
+**arXiv:** [2212.05758](https://arxiv.org/abs/2212.05758)
+
+**Code:** [VDIGPKU/BEV-MAE](https://github.com/VDIGPKU/BEV-MAE)
+
+**Summary:** BEV-MAE pretrains a sparse LiDAR encoder by masking vertical BEV columns and predicting normalized point coordinates plus density inside the missing regions. A shared learnable token occupies each masked column so the encoder sees a receptive-field pattern closer to downstream fine-tuning.
+
+The objective is designed around outdoor LiDAR physics. Density falls with range and scan pattern, so reconstructing it forces the encoder to learn where a feature lives instead of only copying local appearance.
+
+## Paper Insights
+
+BEV-guided masking removes an entire vertical column rather than independent occupied voxels. That choice lets the model keep a sparse encoder and use a one-layer convolutional decoder. The coordinate target describes local geometry; density supplies a coarse location cue. On Waymo with 20% labeled fine-tuning data, the paper reports 1.42 mAP and 1.34 mAPH over training from scratch.
+
+| Pretraining design | L2 mAP | Memory | Training cost |
+| --- | ---: | ---: | ---: |
+| BEV-guided masking | 66.70 | 4.1 GB | $1\times$ |
+| Random occupied-voxel masking | 66.63 | 12.6 GB | $1.4\times$ |
+
+Using only 5% of Waymo labels, BEV-MAE improves L2 mAP from 44.41 to 51.63. With the full labeled set, the gain shrinks from 68.50 to 69.35, suggesting that downstream model capacity or supervised data eventually dominates initialization. Combining nuScenes and Waymo for pretraining improves transfer more than either source alone, but sensor-density differences still create a domain gap.
+
+The strongest modified nuScenes model reports 69.6 mAP and 73.6 NDS. That number combines pretraining with a changed encoder, so the cleaner evidence for the objective comes from the controlled data-efficiency and masking ablations.
+
+## Decision Lens
+
+BEV-MAE informs what a LiDAR foundation objective should reconstruct. Its atomic unit is a masked BEV column containing a set of points, not a generic voxel token. The encoder is the reusable asset; the small decoder and reconstruction targets are discarded after pretraining.
+
+The rejection test holds unlabeled frames, encoder, and fine-tuning budget fixed while comparing coordinate-density reconstruction with occupancy, contrastive, and future-geometry objectives. BEV-MAE loses if gains vanish with more diverse labeled data or fail across sensors with different beam patterns. At 10× pretraining scale, scenario redundancy and data I/O are likely to dominate before the small decoder does.
+
+**Context:** BEV-MAE is a LiDAR-only pretraining reference. UniM²AE adds camera-LiDAR masked reconstruction in a shared 3D volume; UniWorld, ViDAR, and DriveWorld add temporal prediction so the latent must retain persistence and motion.
+
+**Takeaway:** A useful driving pretext task reconstructs measurement geometry and range-dependent density, not an arbitrary token merely because it was masked.

--- a/src/content/posts/bevdet-high-performance-multicamera-3d-object-detection-in-bev.md
+++ b/src/content/posts/bevdet-high-performance-multicamera-3d-object-detection-in-bev.md
@@ -1,0 +1,45 @@
+---
+title: 'BEVDet: High-Performance Multi-Camera 3D Object Detection in Bird-Eye View'
+date: '2021-12-22T05:00:00.000Z'
+section: paper-shorts
+postSlug: bevdet-high-performance-multicamera-3d-object-detection-in-bev
+legacyPath: /paper shorts/2021/12/22/bevdet-high-performance-multicamera-3d-object-detection-in-bev.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2021 – BEVDet: High-Performance Multi-Camera 3D Object Detection in Bird-Eye View'
+---
+## 2021 – BEVDet
+
+**arXiv:** [2112.11790](https://arxiv.org/abs/2112.11790)
+
+**Code:** [HuangJunJie2017/BEVDet](https://github.com/HuangJunJie2017/BEVDet)
+
+**Summary:** BEVDet assembles an image backbone, Lift-Splat-style view transformer, BEV encoder, and CenterPoint-like head into a scalable camera-only detector. Its novelty is less a new mathematical operator than a careful argument that BEV needs its own augmentation, resolution, pooling, and suppression policies.
+
+The paper is valuable because it treats the view transform as a systems component. Camera resolution, BEV resolution, and pooling implementation determine different parts of the cost.
+
+## Paper Insights
+
+Image-space augmentation alone is insufficient because the detector's output lives in ego coordinates. BEVDet applies rotation, scaling, and flipping after view transformation, then uses a BEV encoder to build metric context. In the reported ablation, combining image and BEV augmentation raises peak mAP from 23.0 to 31.6 and largely removes late-training overfit.
+
+| Configuration | mAP | NDS | FPS | What changed |
+| --- | ---: | ---: | ---: | --- |
+| 704×256 images, 0.8 m BEV | 31.2 | 39.2 | 15.6 | Efficient baseline. |
+| 1056×384 images, 0.8 m BEV | 33.3 | 41.0 | 8.9 | More long-range image detail. |
+| 704×256 images, 0.4 m BEV | 31.5 | 41.0 | 10.0 | Finer metric grid. |
+| 1408×512 images, 0.4 m BEV | 36.0 | 43.8 | 5.0 | Accuracy bought on both axes. |
+
+The optimized pooling path precomputes fixed-rig indices and replaces accumulation with an indexed matrix reduction, reducing the paper's BEVDet-Tiny latency from 137 to 64 ms. That result makes a broader point: a view transform can dominate wall time even when its conceptual role is one arrow in a diagram.
+
+BEV improves translation, orientation, and velocity reasoning, but the paper reports weaker attribute prediction than image-view methods. Compressing appearance into BEV helps geometry and can weaken fine visual cues.
+
+## Decision Lens
+
+BEVDet informs when explicit BEV is worth its fixed spatial cost. Its atomic units change from pixels and depth bins to BEV cells. The image encoder is shared across cameras; geometry is shared through the vehicle-centered grid; the detector pays uniformly for the chosen range and resolution.
+
+The falsification compares dense BEV with query-based retrieval under equal input pixels, depth supervision, and optimized kernels. BEVDet loses if empty-cell processing dominates P99 latency or if attribute and small-object evidence is damaged by early pooling. At larger range, image resolution and BEV area grow on different axes and must be budgeted separately.
+
+**Context:** Lift, Splat, Shoot supplies the geometric primitive. BEVDet turns it into a tuned detector; BEVDet4D adds recurrent BEV, BEVDepth adds LiDAR-supervised depth, and SOLOFusion stretches the temporal stereo horizon.
+
+**Takeaway:** BEV performance comes from the whole representation contract—augmentation, resolution, pooling, and heads—not from the view-transform equation alone.

--- a/src/content/posts/craft-camera-radar-3d-object-detection-with-spatio-contextual-fusion-transformer.md
+++ b/src/content/posts/craft-camera-radar-3d-object-detection-with-spatio-contextual-fusion-transformer.md
@@ -1,0 +1,40 @@
+---
+title: 'CRAFT: Camera-Radar 3D Object Detection with Spatio-Contextual Fusion Transformer'
+date: '2022-09-14T04:00:00.000Z'
+section: paper-shorts
+postSlug: craft-camera-radar-3d-object-detection-with-spatio-contextual-fusion-transformer
+legacyPath: /paper shorts/2022/09/14/craft-camera-radar-3d-object-detection-with-spatio-contextual-fusion-transformer.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2022 – CRAFT: Camera-Radar 3D Object Detection with Spatio-Contextual Fusion Transformer'
+---
+## 2022 – CRAFT
+
+**arXiv:** [2209.06535](https://arxiv.org/abs/2209.06535)
+
+**Summary:** CRAFT starts from camera-generated 3D proposals, associates nearby radar returns in polar coordinates, and lets radar-to-image and image-to-radar cross-attention refine each proposal. The association is soft enough to tolerate image-depth and radar-angle uncertainty, but sparse enough to avoid letting every proposal attend to every return.
+
+The key modeling choice is coordinate-aware correspondence. Camera localization error is anisotropic: depth is much less certain than azimuth. Polar association expresses that structure more naturally than a Cartesian ball.
+
+## Paper Insights
+
+Soft Polar Association builds a proposal-specific radar set. A spatio-contextual fusion transformer then exchanges position and feature evidence between image tokens and radar returns. On nuScenes test, the paper reports 41.1 mAP and 52.3 NDS. Relative to its camera-only CRAFT-I baseline on validation, radar adds 7.9 mAP overall, with larger gains on reflective metal classes and distant objects.
+
+| Ablation | Car AP | Association recall | What it isolates |
+| --- | ---: | ---: | --- |
+| RoI pooling | 29.8 | 50.7 | Hard image regions miss valid returns under depth error. |
+| Cartesian ball query | 39.5 | 78.2 | Broad neighborhoods recover returns but include clutter. |
+| Soft Polar Association | 41.3 | 77.1 | Polar uncertainty improves the precision-recall tradeoff. |
+
+Replacing naive concatenation with the fusion transformer adds 2.4 car AP. Polar coordinates add 13.6 AP over the reported Cartesian setup and reduce both radial and azimuth error. For objects beyond 35 m, fusion yields a 32.2% relative improvement in the paper's analysis; with few or no valid radar points, the gain is much smaller.
+
+## Decision Lens
+
+CRAFT informs whether camera-radar fusion should occur around object proposals instead of a dense BEV. Its atomic unit is an image proposal paired with a variable radar set. The camera supplies semantics and an initial spatial hypothesis; radar is asked to correct range and motion where returns exist.
+
+The rejection test compares proposal fusion with radar-guided BEV lifting under the same camera detector, sweep count, range buckets, and corruption suite. CRAFT loses if proposal errors prevent the relevant radar return from entering the association set or if a dense radar representation recovers weak actors without camera proposals. At crowded range, proposal-return pairing and repeated cross-attention are the likely scaling bottlenecks.
+
+**Context:** PointPainting hard-projects semantics onto LiDAR points. CRAFT instead uses camera proposals as the sparse fusion unit. CRN and RCBEVDet later move camera-radar interaction into BEV and strengthen radar-specific encoding.
+
+**Takeaway:** Radar fusion improves when the association rule reflects how each sensor is uncertain, not merely where their nominal coordinates coincide.

--- a/src/content/posts/detr3d-multiview-images-via-3d-to-2d-queries.md
+++ b/src/content/posts/detr3d-multiview-images-via-3d-to-2d-queries.md
@@ -1,0 +1,43 @@
+---
+title: 'DETR3D: 3D Object Detection from Multi-View Images via 3D-to-2D Queries'
+date: '2021-10-14T04:00:00.000Z'
+section: paper-shorts
+postSlug: detr3d-multiview-images-via-3d-to-2d-queries
+legacyPath: /paper shorts/2021/10/14/detr3d-multiview-images-via-3d-to-2d-queries.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2021 – DETR3D: 3D Object Detection from Multi-View Images via 3D-to-2D Queries'
+---
+## 2021 – DETR3D
+
+**arXiv:** [2110.06922](https://arxiv.org/abs/2110.06922)
+
+**Code:** [WangYueFt/detr3d](https://github.com/WangYueFt/detr3d)
+
+**Summary:** DETR3D predicts a set of 3D boxes directly from multiview image features. Each object query carries a 3D reference point; calibration projects that point into every camera and feature level; sampled image evidence updates the query; and the decoder iteratively refines the reference point and box.
+
+The model avoids both a dense BEV view transform and per-camera boxes followed by global NMS. Geometry enters as a retrieval operation: a metric hypothesis asks where supporting pixels should appear.
+
+## Paper Insights
+
+DETR3D treats all cameras jointly, which is especially useful where an object crosses camera boundaries. On nuScenes validation, its CBGS configuration reports 34.9 mAP and 43.4 NDS. In overlap regions, the FCOS3D-initialized model reaches 26.8 mAP and 38.4 NDS versus 22.9 mAP and 32.9 NDS for the compared FCOS3D setup.
+
+| Queries | mAP | NDS | Consequence |
+| ---: | ---: | ---: | --- |
+| 100 | 31.3 | 40.8 | Too few hypotheses constrain recall. |
+| 600 | 34.7 | 42.0 | Most of the gain has arrived. |
+| 900 | 34.6 | 42.5 | NDS peaks in the reported sweep. |
+| 1500 | 34.6 | 42.0 | More queries no longer help. |
+
+The query count therefore acts as a capacity and recall budget, not a free scaling knob. The paper also reports higher translation error than explicit per-pixel depth methods and identifies single-point feature sampling as a limitation. A projected reference point can retrieve a local feature, but it does not model object extent or ray-depth ambiguity by itself.
+
+## Decision Lens
+
+DETR3D informs whether camera-only 3D detection needs a scene-wide BEV field. Its atomic unit is an object query with a metric reference point. The image backbone is dense and shared across views, while geometric and temporal cost after the backbone scales with the bounded query set rather than BEV area.
+
+The matched falsification compares query retrieval and dense BEV lifting with the same image pyramid, depth supervision, and P99 budget. DETR3D loses if missed query initialization or point sampling harms long-range recall, or if dense scene context materially improves births and free-space reasoning. At crowded scale, query count and self-attention replace grid area as the limiting resource.
+
+**Context:** DETR3D establishes 3D-to-2D query retrieval. PETR instead embeds 3D coordinates into every image feature before global attention; Sparse4D and SparseBEV make the query's sampled support larger and adaptive.
+
+**Takeaway:** A camera detector can reason in metric 3D without first materializing BEV, provided each hypothesis has a calibrated route back to image evidence.

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -11,290 +11,190 @@ tags:
 topics:
   - autonomy
   - multimodal
-summary: A mechanism-first guide to what modern driving models share across cameras, LiDAR, radar, time, and perception tasks—and what they deliberately keep separate.
+summary: How modern driving systems encode each sensor, fuse in metric space, train several tasks, use LiDAR supervision, and carry scene state through time.
 ---
 
 # Machine Learning for Autonomous Driving Perception
 
-A unified perception model is often drawn as three sensor arrows entering one box. That picture hides every expensive decision. Cameras produce dense semantics with uncertain depth. LiDAR produces sparse but accurate geometry. Radar adds range and radial velocity with different noise, multipath, and angular resolution. Detection wants compact object state; lane and free-space prediction need dense structure; tracking needs identity through time; planning cares about the consequence of an error, not whether every head improved its average benchmark.
+Modern driving perception is built around a simple split: **sensor-specific encoders at the input, a shared metric representation in the middle, and task-specific outputs at the end**. Cameras, LiDAR, and radar should not enter the network as interchangeable tensors. They measure different quantities and fail differently. They become useful to one another only after the model has preserved those differences and placed the evidence in a common 3D frame.
 
-The modern answer is therefore not “encode everything with one transformer.” State-of-the-art systems unify selected interfaces while preserving the distinctions that carry sensor physics or task contracts. They may share a vehicle-centered BEV, object queries, temporal memory, backbone weights, or a deployment graph. They usually retain modality-specific tokenization, calibration, uncertainty, and task heads. The architecture is defined by where that boundary sits.
+The same principle applies to tasks and time. Detection, occupancy, lanes, velocity, and tracking can reuse expensive scene reasoning, but they do not need the same output resolution or loss. Dense BEV features are good short-term memory for roads and free space; sparse object queries are better long-term memory for actors. LiDAR can supervise geometry during training even when the deployed model uses cameras alone.
 
-The implementation questions follow from that boundary: why each sensor needs its own encoder, where geometry becomes shared, how task losses are balanced, which temporal state survives, how privileged sensors supervise a cheaper runtime model, what pretraining target can use fleet-scale unlabeled logs, and where sparsity actually reduces onboard cost. Those are the questions this guide answers.
+This post explains those design choices and links each mechanism to an individual paper note.
 
-This guide follows that boundary through the literature. The evidence cutoff is July 31, 2026. I focus on onboard multi-camera, LiDAR, and radar perception, with detection, mapping, segmentation, state estimation, and the handoff toward prediction and planning. I exclude cooperative vehicle-to-vehicle fusion and language-first driving agents except where they clarify the consumer interface. Reported results come from the cited papers; the taxonomy and recommendations are my synthesis.
+## The system in one table
 
-## 1. “Unified” names five different bets
-
-The word _unified_ can describe at least five architectural choices. Papers that make different choices should not be placed on one leaderboard as if they solved the same problem.
-
-| Unification boundary | Shared object | Representative papers | Main question |
+| Stage | Representation | Share | Keep specialized |
 | --- | --- | --- | --- |
-| Coordinate | Dense ego-frame BEV | [LSS](/paper%20shorts/2020/08/13/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.html), [BEVFormer](/paper%20shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html) | Where should evidence from different views live? |
-| Fusion | Fused BEV or object queries | [BEVFusion](/paper%20shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html), [TransFusion](/paper%20shorts/2022/03/22/transfusion-robust-lidar-camera-fusion-with-transformers.html), [FUTR3D](/paper%20shorts/2022/03/20/futr3d-unified-sensor-fusion-framework-for-3d-detection.html) | At what granularity should sensors exchange evidence? |
-| Representation | Interaction protocol or shared backbone | [DeepInteraction](/paper%20shorts/2022/08/23/deepinteraction-3d-object-detection-via-modality-interaction.html), [UniTR](/paper%20shorts/2023/08/15/unitr-unified-efficient-multimodal-transformer-for-bev.html) | Which sensor-specific structure should survive sharing? |
-| Task | Shared scene state plus specialized heads or queries | BEVFusion, [MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html), [UniAD](/paper%20shorts/2022/12/20/uniad-planning-oriented-autonomous-driving.html) | Which outputs should shape one another? |
-| Operating mode | One model across sensor configurations and failures | FUTR3D, MetaBEV, [UniBEV](/paper%20shorts/2023/09/25/unibev-robust-multimodal-detection-with-uniform-bev-encoders.html), [Grace-BEV](/paper%20shorts/2026/05/29/grace-bev-graceful-degradation-under-sensor-failures.html) | What should the model do when a modality is weak or absent? |
+| Sensor encoding | Camera pyramids, LiDAR voxels, radar points or pillars | Backbone weights only when the input statistics match | Tokenization, calibration, timing, uncertainty |
+| Geometry | Dense BEV cells or sparse 3D queries | Vehicle-frame coordinates and cross-view reasoning | Height-sensitive and sensor-native side paths |
+| Temporal state | Short dense scene memory plus long sparse instance memory | Ego-motion compensation and interaction | Query birth, death, confidence, and task history |
+| Outputs | Detection, occupancy, lanes, velocity, tracking | Expensive upstream features | Resolution, decoder, loss units, safety thresholds |
 
-These boundaries form a dependency chain. Before sensors can share a representation, the model needs a spatial correspondence. Before tasks can share a trunk, that trunk must retain what each task needs. Before one network can replace fallback models, training and evaluation must cover degraded modes. “One model” is the end of the argument, not its starting point.
+The rest of the architecture follows from four questions: what measurement must survive the encoder, where it becomes metric, what state persists through time, and which tasks can safely update the same parameters.
 
-## 2. Sensor encoders should preserve measurement physics
+## Sensor encoders should preserve sensor physics
 
-A sensor encoder is not a generic adapter that makes tensors the same width. It decides which measurements survive long enough to become useful. Early fusion of raw channels is attractive because it appears maximally shared; in practice, camera pixels, LiDAR returns, and radar detections do not have compatible sampling, noise, units, or neighborhoods.
+### Camera
 
-### Camera: preserve semantics, scale, and viewpoint
+A surround-camera stack normally shares one CNN or vision transformer across views. Intrinsics, extrinsics, distortion, camera identity, and timestamps then tell the geometric layers how those views differ. Sharing the visual backbone saves compute and discourages the model from memorizing one camera position; omitting calibration forces the network to treat viewpoint changes as unexplained appearance variation.
 
-A surround-camera encoder is usually one CNN or vision transformer shared across views, followed by a multi-scale neck. Weight sharing is justified because every camera measures the same appearance statistics, while intrinsics, extrinsics, exposure, distortion, timestamp, and camera identity tell the geometric stages how that view differs. Separate encoders per camera multiply cost and can memorize a rig; one encoder without calibration treats different focal lengths and poses as unexplained domain shifts.
+Resolution is part of the sensor model. A distant motorcycle may occupy only a few pixels. Once a high-stride backbone removes it, neither BEV fusion nor a larger decoder can recover it. Multiscale camera features therefore preserve two things: semantic evidence about what is visible and spatial detail about where small or distant evidence remains.
 
-Resolution is a range allocation decision. Small distant actors may occupy a few pixels, so aggressive backbone stride creates an irreversible miss before fusion. Feature pyramids, high-resolution crops, or sparse high-resolution attention spend compute on those actors, but their benefit must be measured by distance and class. Camera encoders should emit both semantic context and the information needed to infer depth; a classification-pretrained feature can be semantically strong while discarding metric detail.
+### LiDAR
 
-### LiDAR: preserve sparsity, height, and measurement age
+LiDAR supplies direct range and height but samples only a small part of 3D space. Dense 3D convolution wastes most computation on empty voxels, so the main lineage is about where to exploit sparsity and when to compress height.
 
-LiDAR starts as an unordered set of returns with position, intensity, ring or beam identity, and timestamp. [VoxelNet](/paper%20shorts/2017/11/17/voxelnet-end-to-end-point-cloud-3d-detection.html) learns features inside 3D voxels; [PointPillars](/paper%20shorts/2018/12/14/pointpillars-fast-point-cloud-encoders.html) collapses height early for speed; sparse convolutions process only occupied voxels; [SST](/paper%20shorts/2021/12/13/sst-single-stride-sparse-transformer-for-3d-detection.html) and [DSVT](/paper%20shorts/2023/01/15/dsvt-dynamic-sparse-voxel-transformer.html) use local sparse attention to enlarge receptive fields without densifying the full volume. [CenterPoint](/paper%20shorts/2020/06/19/centerpoint-center-based-3d-detection-and-tracking.html) then shows how a BEV center representation can support both boxes and tracking.
+[VoxelNet](/paper%20shorts/2017/11/17/voxelnet-end-to-end-point-cloud-3d-detection.html) learns features inside voxels. [SECOND](/paper%20shorts/2018/10/06/second-sparsely-embedded-convolutional-detection.html) keeps the 3D middle encoder sparse before height compression, while [PointPillars](/paper%20shorts/2018/12/14/pointpillars-fast-point-cloud-encoders.html) collapses height early and does most work with fast 2D convolution. [VoTr](/paper%20shorts/2021/09/06/votr-voxel-transformer-for-3d-object-detection.html), [SST](/paper%20shorts/2021/12/13/sst-single-stride-sparse-transformer-for-3d-detection.html), and [DSVT](/paper%20shorts/2023/01/15/dsvt-dynamic-sparse-voxel-transformer.html) enlarge the receptive field with attention over occupied voxels. [VoxelNeXt](/paper%20shorts/2023/03/20/voxelnext-fully-sparse-voxelnet-for-3d-detection-and-tracking.html) stays sparse through the detection head instead of constructing a dense BEV heatmap.
 
-The encoder must also de-skew a scan collected while the vehicle moves. Treating all returns as simultaneous creates position error before fusion begins. Multi-sweep accumulation needs the age of each point, ego-pose interpolation, and a policy for dynamic objects that cannot be corrected by ego motion alone. Flattening to BEV is efficient for road scenes, but height-sensitive tasks should keep a 3D path or delay height compression.
+The trade-off is straightforward. Early height compression is efficient for mostly planar roads. Retaining sparse 3D structure helps with overpasses, stacked geometry, and occupancy. A useful LiDAR token should also carry intensity, acquisition time, and point age because a rotating scan is collected while the ego vehicle and other actors move.
 
-### Radar: preserve Doppler, uncertainty, and return structure
+### Radar
 
-Radar returns include range, azimuth, sometimes elevation, radial velocity, Radar Cross Section, and measurement uncertainty. A LiDAR voxelizer can ingest the coordinates, but it does not automatically exploit Doppler or model multipath and angular noise. [RCBEVDet](/paper%20shorts/2024/03/25/rcbevdet-radar-camera-fusion-in-bev.html) uses pointwise and transformer branches plus RCS-aware scattering; [CRN](/paper%20shorts/2023/04/03/crn-camera-radar-net-for-3d-perception.html) uses radar to guide camera lifting. Both approaches make radar affect geometry before a generic BEV encoder can wash out its distinctive signal.
+Radar is not low-resolution LiDAR. Its useful measurements are range, radial velocity, Radar Cross Section, return time, and uncertainty. Its characteristic errors are poor angular resolution, ambiguous elevation, multipath, and ghost returns. Rasterizing radar into a generic occupancy map too early can erase the velocity and confidence information that justified the sensor.
 
-This leads to a practical rule: share weights after each modality has constructed a physically meaningful token. Camera patches, LiDAR voxels, and radar returns can enter a shared interaction block, as [UniTR](/paper%20shorts/2023/08/15/unitr-unified-efficient-multimodal-transformer-for-bev.html) demonstrates, but their tokenizers, normalization, positional metadata, and health signals should remain explicit.
+[CRAFT](/paper%20shorts/2022/09/14/craft-camera-radar-3d-object-detection-with-spatio-contextual-fusion-transformer.html) associates radar returns with camera proposals in polar coordinates. [CRN](/paper%20shorts/2023/04/03/crn-camera-radar-net-for-3d-perception.html) instead uses radar to guide camera lifting and repair alignment with deformable attention. [RCBEVDet](/paper%20shorts/2024/03/25/rcbevdet-radar-camera-fusion-in-bev.html) gives radar both pointwise and transformer paths before BEV fusion. These choices preserve radar attributes until the model has used them to resolve camera depth or actor motion.
 
-## 3. BEV is a contract between sensing and autonomy
+## Put the sensors in a common metric frame
 
-Surround cameras observe perspective views; planners reason about where actors, lanes, and free space sit around the ego vehicle. [Lift, Splat, Shoot](/paper%20shorts/2020/08/13/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.html) made this mismatch explicit. Each pixel predicts context and a depth distribution, is lifted into a camera frustum, transformed by calibration, and pooled into an ego-frame grid. Camera count and pose become inputs to the view transform rather than assumptions baked into the task head.
+Cameras observe rays; driving tasks reason in meters. The central camera-perception problem is therefore the view transform: where along each ray should an image feature be placed in 3D?
 
-![Figure 1 from Lift, Splat, Shoot, showing multi-camera evidence represented in vehicle-centered BEV](/assets/images/lift-splat-shoot-paper-figure-1.png)
-_LSS establishes the first durable interface: arbitrary camera views in, one metric scene map out. Source note: [Lift, Splat, Shoot](/paper%20shorts/2020/08/13/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.html), Figure 1._
+[Lift, Splat, Shoot](/paper%20shorts/2020/08/13/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.html) predicts a categorical depth distribution for each image location, lifts image features along the ray, transforms them with camera calibration, and pools them into bird's-eye view. [BEVDet](/paper%20shorts/2021/12/22/bevdet-high-performance-multicamera-3d-object-detection-in-bev.html) turns that representation into a detector. [BEVDepth](/paper%20shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html) adds explicit LiDAR-derived depth supervision.
 
-The BEV grid earns its cost because several consumers need the same geometry. Object detection needs centers, extents, and orientation. Map segmentation needs lane and road layout. Occupancy needs free and occupied cells. Tracking and prediction need ego-motion-compensated history. A vehicle-centered grid makes these outputs comparable and lets convolution or attention move information across camera boundaries.
+![Figure 1 from Lift, Splat, Shoot, showing multiview evidence represented in vehicle-centered BEV](/assets/images/lift-splat-shoot-paper-figure-1.png)
+_LSS places perspective features in one vehicle-centered metric grid. Source: [Lift, Splat, Shoot](/paper%20shorts/2020/08/13/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.html), Figure 1._
 
-BEV also commits the model to a compression. Camera depth hypotheses and vertical structure are collapsed into cells; LiDAR voxels are often flattened along height; resolution and spatial extent set memory before the scene is known. Long range demands many mostly empty cells. A dense grid is therefore a strong default for scene-level tasks, not a universal answer.
+A dense BEV grid is useful because detection, occupancy, lanes, maps, and free space all need aligned geometry. Its cost, however, is fixed by range and resolution rather than scene content. Doubling both horizontal dimensions roughly quadruples the number of cells, and storing several frames multiplies the memory again.
 
-[BEVFormer](/paper%20shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html) replaces explicit depth splatting with learned BEV queries that sample projected image features, and it carries the grid through time with temporal self-attention. The contrast with LSS is useful: LSS places uncertainty in a depth distribution before pooling; BEVFormer places it in learned attention from metric queries. Both build the same downstream contract, but they spend compute and absorb calibration error differently.
+Query-based models avoid materializing every cell. [DETR3D](/paper%20shorts/2021/10/14/detr3d-multiview-images-via-3d-to-2d-queries.html) projects 3D object queries into multiscale image features. [PETR](/paper%20shorts/2022/03/10/petr-position-embedding-transformation-for-multiview-3d-object-detection.html) embeds possible 3D coordinates into perspective features before attention. [PETRv2](/paper%20shorts/2022/06/02/petrv2-unified-3d-perception-from-multicamera-images.html) aligns those features over time and gives detection, lanes, and segmentation different query geometries. [BEVFormer](/paper%20shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html) sits between the two approaches: it stores a dense field of learned BEV queries but retrieves evidence through projected attention.
 
-## 4. Depth has three different jobs
+The choice should follow the output:
 
-“Use LiDAR for depth” can describe three systems with different runtime contracts.
-
-| Depth problem | Runtime inputs | Output or training role | Representative work |
+| Representation | Best suited to | Main cost | Main failure |
 | --- | --- | --- | --- |
-| Monocular depth estimation | RGB only | Dense or categorical depth from appearance | [CaDDN](/paper%20shorts/2021/03/01/caddn-categorical-depth-for-monocular-3d-detection.html), [BEVDepth](/paper%20shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html) at inference |
-| Depth completion | RGB plus sparse runtime depth | Dense depth that retains measured ranges | [Sparse-to-Dense](/paper%20shorts/2017/09/21/sparse-to-dense-depth-prediction-from-sparse-depth-and-rgb.html), [DeepLiDAR](/paper%20shorts/2018/12/02/deeplidar-surface-normal-guided-depth-completion.html), [GuideFormer](/paper%20shorts/2022/06/19/guideformer-transformers-for-image-guided-depth-completion.html) |
-| Privileged depth supervision | RGB at runtime; LiDAR or offline geometry only during training | Teaches lifting, occupancy, features, or pseudo-labels | BEVDepth, [CRKD](/paper%20shorts/2024/06/17/crkd-camera-radar-distillation-from-lidar-camera.html), [UniWorld](/paper%20shorts/2023/08/14/uniworld-autonomous-driving-pretraining-via-world-models.html) |
+| Dense BEV | Occupancy, roads, maps, weak scene evidence | Area × resolution | Depth errors are committed to cells |
+| Object queries | Detection, tracking, motion | Queries × sampled views | Missed or poorly initialized queries |
+| Sensor-native features | Fine appearance or geometry | Repeated projection and sampling | Harder cross-sensor alignment |
 
-Depth completion is sensor fusion. A failed runtime LiDAR removes the sparse measurements the completion model expects. Privileged depth supervision is different: projected LiDAR points define a loss during training, while the deployed network predicts depth from cameras. Confusing the two leads to a fallback design that silently depends on a sensor the production bill of materials removed.
+Many strong systems use more than one representation: dense BEV proposes and describes the scene, while sparse queries carry actors.
 
-[BEVDepth](/paper%20shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html) provides the cleanest controlled case. It shows a large gap between learned and ground-truth depth inside a Lift-Splat detector, then supervises the categorical depth distribution with projected LiDAR, conditions the depth head on camera parameters, and refines the lifted volume. LiDAR supplies labels; the inference graph remains camera-only.
+## Fuse at the granularity required by the output
 
-![Figure 4 from BEVDepth, showing explicit depth supervision during training and camera-only BEV inference](/assets/images/bevdepth-paper-figure-4.png)
-_The red depth target can be generated by an instrumented training fleet without entering the deployed graph. Source note: [BEVDepth](/paper%20shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html), Figure 4._
+Sensor fusion differs mainly in where correspondence is imposed.
 
-Sparse LiDAR is not dense truth. Returns miss dark or distant surfaces, projected points can cross object boundaries when timestamps or calibration differ, and a rotating scanner samples dynamic objects at different times. Good target generation filters occlusions, models label confidence, keeps ignore regions, and separates direct measurements from offline densification. More labels do not help if the target-generation geometry is wrong.
+[PointPainting](/paper%20shorts/2019/11/22/pointpainting-sequential-fusion-for-3d-object-detection.html) projects camera class scores onto LiDAR points before voxelization. The operation is cheap and interpretable, but only pixels touched by LiDAR survive. A calibration error can also attach the wrong semantic score to a point.
 
-## 5. Fusion moved from calibrated points to shared spaces and queries
+[TransFusion](/paper%20shorts/2022/03/22/transfusion-robust-lidar-camera-fusion-with-transformers.html) uses LiDAR to propose object queries and lets each query attend to an image region. [FUTR3D](/paper%20shorts/2022/03/20/futr3d-unified-sensor-fusion-framework-for-3d-detection.html) projects a shared 3D reference point into camera, LiDAR, and radar feature spaces. Query fusion is a natural fit for actor detection because the output is already a sparse set.
 
-Early camera-LiDAR fusion often painted image features onto projected LiDAR points. The association is cheap and geometrically legible, but it uses LiDAR sampling density to decide which image information survives. A small calibration error can attach the wrong pixel; background semantics that matter to mapping never enter the representation.
-
-[TransFusion](/paper%20shorts/2022/03/22/transfusion-robust-lidar-camera-fusion-with-transformers.html) loosens that association. LiDAR proposes object queries, then each query attends to an image region. Calibration narrows the search without dictating one correspondence. This works well when the prediction unit is an object and when LiDAR should remain a usable fallback.
-
-[BEVFusion](/paper%20shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html) makes the opposite granularity choice. It independently converts camera and LiDAR features into dense BEV maps, concatenates them, and learns a BEV encoder before task heads. The shared grid preserves background semantics for segmentation and amortizes fusion across multiple tasks.
+[BEVFusion](/paper%20shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html) independently encodes camera and LiDAR, converts both to dense BEV, fuses them once, and shares the result across detection and mapping heads. This retains dense image semantics for scene-level outputs. [DeepInteraction](/paper%20shorts/2022/08/23/deepinteraction-3d-object-detection-via-modality-interaction.html) keeps the camera and LiDAR streams separate and lets them update one another, which preserves modality provenance. [UniTR](/paper%20shorts/2023/08/15/unitr-unified-efficient-multimodal-transformer-for-bev.html) shares transformer blocks after modality-specific token construction while retaining appropriate 2D and 3D neighborhoods.
 
 ![Figure 2 from BEVFusion, showing modality-specific encoders converging on a shared BEV and task-specific heads](/assets/images/bevfusion-unified-bev-paper-figure-2.png)
-_BEVFusion shares after geometry is normalized, then specializes at the output. Source note: [BEVFusion](/paper%20shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html), Figure 2._
+_BEVFusion specializes tokenization, shares metric scene processing, and separates the output heads. Source: [BEVFusion](/paper%20shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html), Figure 2._
 
-[FUTR3D](/paper%20shorts/2022/03/20/futr3d-unified-sensor-fusion-framework-for-3d-detection.html) avoids requiring every modality to become one dense map. A 3D object query samples camera, LiDAR, and radar features in their native representations. The same detector can accept different sensor configurations because availability changes the set of features sampled, not the shape of the detection interface.
+There is no single best fusion layer. Use point fusion when the association is reliable and the output follows points, query fusion for actors, and BEV fusion for dense scene structure. Keep a sensor-native path when downstream tasks still need precise appearance, height, Doppler, or uncertainty.
 
-The choice follows the output contract:
+## Multi-task learning: share the trunk, control the gradients
 
-- Use dense BEV fusion when several heads need complete scene context and the spatial envelope is bounded.
-- Use query fusion when object-centric outputs dominate, most of the scene is empty, or sensors should remain independently usable.
-- Use both when a dense scene memory serves mapping and occupancy while sparse queries carry actors, tracks, or plans.
+Detection, occupancy, lanes, velocity, and tracking all need semantic features, metric geometry, and ego motion. A shared trunk avoids recomputing those features and can make the outputs geometrically consistent. The heads should remain specialized because the tasks differ in resolution, label density, sensor affinity, and error tolerance.
 
-This hybrid is increasingly common because “dense versus sparse” is not a philosophical choice. It is a capacity allocation decision by output type.
+The practical default is a shared geometric trunk with task-specific decoders or adapters. [BEVFusion](/paper%20shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html) follows this pattern. [UniAD](/paper%20shorts/2022/12/20/uniad-planning-oriented-autonomous-driving.html) goes further: tracking and map queries become inputs to motion prediction, occupancy, and planning. That explicit task graph can improve consistency, but an upstream error now propagates into more consumers.
 
-## 6. Unification can destroy the evidence it meant to share
+Multi-task optimization has three distinct failure modes:
 
-A fused tensor is convenient, but convenience is not proof that the tensor retains sensor provenance or native structure. [DeepInteraction](/paper%20shorts/2022/08/23/deepinteraction-3d-object-detection-via-modality-interaction.html) makes this failure visible. It keeps the image feature map and LiDAR BEV alive, updates them bidirectionally, and lets object queries alternate between them. Camera features retain dense perspective neighborhoods; LiDAR retains metric sparsity. The shared object is an interaction protocol, not one representation.
-
-![DeepInteraction's comparison between feature collapse and retained modality streams](/assets/images/deepinteraction-paper-figure-1.png)
-_DeepInteraction asks whether a fused latent has discarded exactly the modality-specific evidence the detector needs. Source note: [DeepInteraction](/paper%20shorts/2022/08/23/deepinteraction-3d-object-detection-via-modality-interaction.html), Figure 1._
-
-[UniTR](/paper%20shorts/2023/08/15/unitr-unified-efficient-multimodal-transformer-for-bev.html) pushes in the other direction: share the expensive transformer weights across image patches and LiDAR voxels. It avoids pretending the tokens are identical. Modality-specific tokenizers construct them; intra-modal partitions respect native neighborhoods; cross-modal blocks build mixed 2D and 3D local sets. Weight sharing removes serial duplicate encoders while coordinate structure tells shared attention what locality means.
-
-These papers define the real test for a unified backbone. Parameter count and benchmark accuracy are insufficient. A matched study should ask:
-
-- Does sharing reduce latency after tokenization and view transforms are included?
-- Which rare classes or ranges improve, and which lose sensor-specific capacity?
-- Does the model remain calibrated when one modality degrades?
-- Can a consumer tell whether a state estimate was observed by camera, LiDAR, radar, or only propagated through time?
-- Does a larger separate-backbone control recover the same accuracy at equal compute?
-
-Without those controls, “shared representations improve collaboration” is a plausible interpretation, not an isolated result.
-
-## 7. Multi-task modeling needs capacity and loss accounting
-
-Detection, lanes, segmentation, velocity, and tracking do not merely require different labels. They use different spatial granularity and error tolerances. A detection head can tolerate smooth background features; lane topology cannot. Velocity may depend heavily on radar and time; semantic class may depend on camera texture. Sharing the trunk saves compute only if it preserves all of those contracts.
-
-BEVFusion uses a shared BEV encoder and independent task heads. That is the safe baseline: share geometry and expensive scene features, then keep losses and outputs explicit. [MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html) adds mixtures of experts to reduce detection/segmentation interference. The experts are a capacity valve: shared attention handles common structure, while routing lets tasks or modality states avoid one set of parameters doing incompatible work.
-
-[UniAD](/paper%20shorts/2022/12/20/uniad-planning-oriented-autonomous-driving.html) changes the task graph. Tracking, mapping, motion, occupancy, and planning are not parallel heads attached to one trunk. Their queries pass structured state forward, and planning is the organizing objective. This exposes a distinction that multi-task benchmarks often miss: two outputs can be individually accurate yet mutually inconsistent or poorly timed for planning.
-
-The first optimization problem is scale. A box regression loss measured in meters, a cross-entropy segmentation loss summed over thousands of pixels, and a velocity loss do not arrive with comparable magnitudes. [Kendall, Gal, and Cipolla](/paper%20shorts/2017/05/19/multi-task-learning-using-homoscedastic-uncertainty.html) derive homoscedastic uncertainty weighting. For regression tasks, the useful form is
-
-$$
-\mathcal{L}_{\text{total}}=\sum_i \left(\frac{1}{2\sigma_i^2}\mathcal{L}_i+\log \sigma_i\right),
-$$
-
-where each learned $\sigma_i$ acts as a task-level noise scale. The inverse variance downweights a noisy or large-scale objective; the log term prevents the model from sending every weight to zero. In practice, implementations optimize $s_i=\log \sigma_i^2$ for numerical stability. The method is attractive because the weights are learned with the network instead of swept by hand.
-
-Homoscedastic weighting solves neither of the other two multi-task problems. It does not measure whether two tasks ask shared parameters to move in opposite directions, and one global $\sigma_i$ cannot represent scenario-dependent reliability. [GradNorm](/paper%20shorts/2017/11/07/gradnorm-adaptive-loss-balancing.html) targets unequal learning rates by adapting weights from gradient norms. [PCGrad](/paper%20shorts/2020/01/19/pcgrad-gradient-surgery-for-multi-task-learning.html) projects away pairwise conflicting gradient components. Alternating batches, task-specific normalization, adapters, or mixture-of-experts allocate capacity when weighting alone cannot reconcile the objectives.
-
-A practical debug sequence is therefore:
-
-1. Normalize every loss by a meaningful unit: positives, valid pixels, anchors, or trajectories rather than raw tensor size.
-2. Log per-task loss, gradient norm, and pairwise gradient cosine at the shared trunk.
-3. Compare fixed weights, homoscedastic weighting, and one gradient-aware method under the same training budget.
-4. Freeze or split progressively deeper blocks to locate where transfer turns negative.
-5. Evaluate every head and the downstream planner; never select a checkpoint from the weighted scalar alone.
-
-If a 2% mAP gain creates more planner interventions through jitter, velocity error, or lane inconsistency, the unified model regressed where it matters. Loss balance is an optimization tool; the consumer contract remains the deployment criterion.
-
-## 8. Temporal modeling splits into dense BEV and sparse 4D state
-
-Temporal fusion adds evidence that no single frame contains: velocity, occlusion recovery, track continuity, and improved depth through ego motion. It also adds a new failure mode. Historical evidence was observed under an older pose, sensor state, and world state. “More frames” is not the architectural choice; the choice is what state represents those frames.
-
-[BEVDet4D](/paper%20shorts/2022/03/31/bevdet4d-temporal-cues-in-multicamera-3d-detection.html) is the dense baseline: ego-warp the previous camera BEV, concatenate it with the current BEV, and learn temporal fusion. [BEVFormer](/paper%20shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html) uses temporal attention over the persistent grid. Dense recurrence preserves road, free-space, and background evidence, but history length multiplies a representation whose cost is fixed by spatial extent.
-
-[Sparse4D](/paper%20shorts/2022/11/19/sparse4d-multiview-3d-detection-with-sparse-spatiotemporal-fusion.html) follows 3D anchors instead. Multiple keypoints around each anchor are projected into every camera, scale, and timestamp; only those features are sampled and fused. [StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html) stores a FIFO memory of foreground object queries, compensates them with ego pose, and updates them against the current images. [Sparse4D v3](/paper%20shorts/2023/11/20/sparse4dv3-end-to-end-3d-detection-and-tracking.html) adds temporal denoising and quality estimation, then uses recurrent instances directly as tracks.
-
-![Figure 3 from StreamPETR, showing a recurrent queue of object queries updated by current multi-view images](/assets/images/streampetr-paper-figure-3.png)
-_StreamPETR's top-k query memory makes long history cheap by discarding most scene state. Source note: [StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html), Figure 3._
-
-| Temporal state | Compute scales with | Strongest use | Blind spot |
-| --- | --- | --- | --- |
-| Dense BEV memory | Spatial cells × history | Static context, lanes, occupancy, uncommitted evidence | Long-range empty space and long histories are expensive. |
-| Multi-frame perspective features | Cameras × scales × history | Deferred geometry and rich image evidence | Repeated projection and sampling. |
-| Sparse 4D anchors or queries | Instances × keypoints × history | Actors, tracking, long object histories | Misses state that never became a query. |
-| Hybrid dense + sparse | Short BEV plus long instance memory | Full scene plus actors | Two memories must remain consistent. |
-
-A production model often benefits from the hybrid: a short high-resolution BEV memory for static context and a longer compressed object memory for actors. [SparseDrive](/paper%20shorts/2024/05/30/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.html) pushes the sparse state beyond detection into map and motion instances used by planning.
-
-The maximum history should be selected by task and failure slice, not by available VRAM. Longer memory can recover an occluded vehicle but also preserve an actor that left the scene. Ego warping aligns static structure; it does not align independently moving objects. Pose error accumulates, and rolling-shutter or timestamp mismatch can make nominal calibration wrong for a moving platform.
-
-A useful temporal evaluation therefore measures jitter, track continuity, stale false positives, latency-adjusted accuracy, and re-observation behavior. Frame-level mAP cannot tell whether the model is stable, fresh, or merely slow.
-
-## 9. Missing sensors are training distributions, not zero tensors
-
-Most fusion models are trained on healthy sensors and evaluated on healthy sensors. Zeroing a failed feature tensor at deployment does not create a principled fallback. Normalization statistics, attention weights, and task heads were optimized for a different joint distribution.
-
-[MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html) samples full and missing modalities during training, uses dense queries that can attend to camera, LiDAR, or both, and routes through modality-specific experts. [UniBEV](/paper%20shorts/2023/09/25/unibev-robust-multimodal-detection-with-uniform-bev-encoders.html) studies uniform BEV encoders, shared queries, and normalized weighted fusion so the detector can run on camera plus LiDAR, camera only, or LiDAR only without retraining. The 2026 [Grace-BEV](/paper%20shorts/2026/05/29/grace-bev-graceful-degradation-under-sensor-failures.html) goes beyond a binary modality mask and explicitly estimates reliability before recalibrating fusion.
-
-![Figure 3 from MetaBEV, showing an evolving BEV query attending to available sensor features](/assets/images/metabev-paper-figure-3.png)
-_MetaBEV turns modality availability into an explicit input to fusion and routing. Source note: [MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html), Figure 3._
-
-The progression is from availability to health. “Camera present” is not enough when glare saturates one view, radar multipath creates ghosts, LiDAR returns thin out in weather, or calibration drifts gradually. A deployable interface should carry sensor-health indicators, masks, timestamps, calibration confidence, and uncertainty. Training should include camera dropout, partial field-of-view loss, timestamp jitter, calibration perturbations, structured corruption, and transitions into and out of each mode.
-
-One conditional model is not automatically safer than separate fallbacks. It reduces memory and versioning cost, but it expands the validation matrix. The decisive comparison is against specialist models under the same total onboard budget, including uncertainty calibration and worst-case latency.
-
-## 10. Radar must keep the properties that cameras do not have
-
-Radar is attractive because it supplies direct range and radial velocity, works at long range, and degrades differently from cameras. It is difficult because returns are sparse, angular resolution is weaker, elevation may be ambiguous, multipath creates false structure, and Radar Cross Section depends on object and aspect.
-
-[CRN](/paper%20shorts/2023/04/03/crn-camera-radar-net-for-3d-perception.html) uses radar to guide camera lifting and deformable attention to reconcile camera-radar misalignment. [RCBEVDet](/paper%20shorts/2024/03/25/rcbevdet-radar-camera-fusion-in-bev.html) gives radar a dual point/transformer encoder, RCS-aware scattering, and cross-attention alignment in BEV. [CRKD](/paper%20shorts/2024/06/17/crkd-camera-radar-distillation-from-lidar-camera.html) uses a camera-LiDAR teacher to improve a cheaper camera-radar student at training time. The 2026 [RPGFusion](/paper%20shorts/2026/06/01/rpgfusion-4d-radar-prior-guided-fusion.html) uses 4D-radar priors to guide image BEV queries and densify radar features.
-
-The sequence shows two current recipes. One builds a strong radar representation and fuses it with camera BEV. The other uses radar geometry to decide how camera evidence is lifted or queried. Both retain radar attributes until after they have influenced geometry; simply rasterizing returns as occupancy throws away much of the reason to carry radar.
-
-Weather robustness still needs direct evidence. A nuScenes aggregate gain or random sensor-dropout test is not a substitute for rain, fog, snow, glare, distance, actor class, and transition slices with calibrated confidence.
-
-## 11. Training-time sensors can be richer than runtime sensors
-
-Production hardware does not have to define the supervision ceiling. A LiDAR-equipped development fleet can train a camera-radar model through depth targets, occupancy labels, BEV feature distillation, pseudo-labels, or a privileged teacher. CRKD makes this design explicit: the camera-radar student learns from a stronger camera-LiDAR teacher while retaining its cheaper runtime sensor set.
-
-[BEVDepth](/paper%20shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html) uses the same lifecycle for a camera-only student: projected LiDAR supervises depth during training, but images and calibration are the only inference inputs. [UniWorld](/paper%20shorts/2023/08/14/uniworld-autonomous-driving-pretraining-via-world-models.html) pretrains camera features by predicting 4D occupancy from large image-LiDAR pairs. A richer offline teacher can also combine future frames, multiple passes, expensive models, map priors, or human review; none needs to fit the onboard deadline if its output becomes a versioned target rather than a runtime dependency.
-
-The distinction prevents a common architecture mistake. A LiDAR-derived target is privileged supervision; a LiDAR-dependent view transform is a runtime dependency. The former can disappear after training. The latter cannot. Every source of geometry should be labeled by lifecycle: needed to collect data, generate labels, train, calibrate, or run onboard.
-
-Privileged sensing also creates risks. Teacher errors become labels, the student may inherit a representation it cannot reconstruct from its inputs, and offline gains may concentrate in clear scenes where the teacher is already strongest. Distillation should be evaluated against direct supervision under the same student architecture, with uncertainty and adverse-condition slices.
-
-Tesla illustrates the deployment principle but should be described precisely. [Tesla's public AI material](https://www.tesla.com/AI) documents camera-based onboard inference, multi-camera video-to-BEV networks, and ground-truth generation that combines vehicle sensors across space and time; its [2021 AI Day presentation](https://www.youtube.com/watch?v=j0z4FweCy4M) also describes offline auto-labeling. Those sources do not establish the blanket claim that production Tesla networks are trained by a LiDAR teacher. The supported lesson is broader: expensive offline labeling and temporal reconstruction can supervise a cheaper camera-only inference graph. BEVDepth, CRKD, and UniWorld provide paper-level evidence for specific privileged-sensor versions of that idea.
-
-## 12. Pretraining at scale should predict geometry and change
-
-ImageNet initialization helps a camera encoder recognize objects, but it does not teach multi-camera geometry, sensor correspondence, ego motion, or which state persists. Driving pretraining must choose a target that makes unlabeled fleet logs carry those lessons.
-
-[UniM²AE](/paper%20shorts/2023/08/21/unim2ae-multimodal-masked-autoencoders-with-unified-3d-representation.html) masks camera patches and LiDAR voxels, projects visible features into a shared 3D volume, and reconstructs both modalities. It learns cross-modal completion from synchronized pairs. [UniWorld](/paper%20shorts/2023/08/14/uniworld-autonomous-driving-pretraining-via-world-models.html) predicts current and future 4D occupancy from image-LiDAR pairs. [ViDAR](/paper%20shorts/2023/12/29/vidar-visual-point-cloud-forecasting-for-autonomous-driving.html) predicts future point clouds from historical images, forcing a camera encoder to represent semantics, 3D geometry, and dynamics. [DriveWorld](/paper%20shorts/2024/05/07/driveworld-4d-pretrained-scene-understanding.html) pretrains a spatiotemporal latent with dynamic memory, static-scene propagation, and downstream task prompts.
-
-![Figure 2 from UniM²AE, showing masked camera and LiDAR tokens interacting in a shared 3D volume](/assets/images/unim2ae-paper-figure-2.png)
-_Masked reconstruction uses synchronized sensors to learn correspondence; future-geometry objectives add the requirement to model change. Source note: [UniM²AE](/paper%20shorts/2023/08/21/unim2ae-multimodal-masked-autoencoders-with-unified-3d-representation.html), Figure 2._
-
-The objectives teach different invariances:
-
-| Pretraining target | What the encoder must retain | Shortcut or cost |
+| Problem | Symptom | Useful response |
 | --- | --- | --- |
-| Masked image/LiDAR reconstruction | Cross-modal appearance and local geometry | Can copy correlated observations without learning dynamics. |
-| Current occupancy | Metric scene completion | Requires geometric targets and may average uncertainty. |
-| Future occupancy or point cloud | Geometry, motion, and persistence | Multi-modal futures make deterministic targets brittle. |
-| Teacher features or pseudo-labels | Task-relevant semantics and geometry | Inherits teacher bias and confidence errors. |
-| Ego-motion/photometric consistency | Video geometry without LiDAR labels | Breaks on dynamic objects, occlusion, and lighting change. |
+| Loss scale | Dense segmentation dominates sparse regression numerically | Normalize by valid cells, matched objects, lane points, or trajectories; then use learned weighting |
+| Learning speed | One task converges while another stalls | Track shared-layer gradient norms; consider [GradNorm](/paper%20shorts/2017/11/07/gradnorm-adaptive-loss-balancing.html) |
+| Gradient conflict | Tasks request opposing shared updates | Measure gradient cosine similarity; use adapters, partial splits, alternating updates, or [PCGrad](/paper%20shorts/2020/01/19/pcgrad-gradient-surgery-for-multi-task-learning.html) |
 
-Scaling data is not only adding clips. Mixtures change the gradient budget: common highway scenes can swamp rare construction, adverse weather, and near-collision events. A useful large-scale recipe deduplicates near-identical cruising, samples by scenario and sensor health, measures representation transfer by task, and retains held-out geographic and temporal slices. The pretraining unit—frame, synchronized sensor packet, clip, masked volume, or future interval—determines which correlations the model can learn.
+[Homoscedastic uncertainty weighting](/paper%20shorts/2017/05/19/multi-task-learning-using-homoscedastic-uncertainty.html) learns one scale per task:
 
-The expensive ablation holds encoder size and total tokens fixed while comparing more scenes, longer clips, and richer sensor supervision. Otherwise “scale” may mean only more redundant frames or more LiDAR-equipped miles.
+$$
+\mathcal{L}=\sum_i\left[\frac{1}{2\sigma_i^2}\mathcal{L}_i+\log\sigma_i\right].
+$$
 
-## 13. Sparse transformers move the budget from area to evidence
+The inverse variance changes the task weight and the logarithm prevents every weight from collapsing to zero. This is useful after each loss has a meaningful unit. It does not solve conflicting gradients or per-scene sensor reliability. If weighting fails, the shared representation may need separate normalization, adapters, or an earlier split.
 
-Sparsity appears at three different levels. Sparse LiDAR backbones process only occupied voxels. Sparse camera detectors sample image features around object hypotheses. Sparse end-to-end systems carry actor and map instances into prediction and planning. Each saves a different dimension of compute.
+## Use LiDAR during training without requiring it at inference
 
-For LiDAR, [SST](/paper%20shorts/2021/12/13/sst-single-stride-sparse-transformer-for-3d-detection.html) keeps a single high-resolution stride and applies attention inside non-empty windows, preserving small objects that downsampling can erase. [DSVT](/paper%20shorts/2023/01/15/dsvt-dynamic-sparse-voxel-transformer.html) partitions variable-density voxels into bounded local sets, rotates partitions between layers to exchange context, and avoids custom sparse-convolution operators in its transformer path. UniTR reuses DSVT-style blocks across camera and LiDAR tokens, making sparse local attention part of sensor unification.
+“Using LiDAR for depth” describes three different deployment contracts:
 
-For cameras, Sparse4D and StreamPETR do not make the image encoder sparse; they make fusion and memory sparse. The multi-view backbone still processes every image, often dominating latency. The saving comes after feature extraction: a bounded number of anchors or queries retrieve evidence instead of constructing and recurrently updating every BEV cell.
+| System | Runtime input | What LiDAR does |
+| --- | --- | --- |
+| Camera depth estimation | Cameras only | Supplies depth labels during training |
+| Depth completion | Cameras plus sparse runtime depth | Remains an inference input |
+| Teacher-student distillation | Cheaper sensor set | Supervises features, occupancy, or predictions offline |
 
-Sparse models therefore need four budgets reported separately: image-backbone FLOPs, number of active voxels or image tokens, number of queries/keypoints, and temporal memory size. A model can call itself sparse while carrying a dense high-resolution camera pyramid that dominates P99 latency.
+[BEVDepth](/paper%20shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html) is the clean first case. Projected LiDAR trains the camera depth distribution, but inference uses images and calibration. The camera model learns where image evidence should be lifted into BEV without carrying LiDAR hardware in the deployed graph.
 
-Sparsity also creates recall risk. Empty voxels cannot represent unobserved free space; a query detector cannot sample an object it never proposed; top-k temporal memory can evict a low-confidence hazard. Dense and sparse representations are complementary when the dense path retains safety-relevant scene context and the sparse path allocates long-horizon capacity to actors.
+Depth completion is different. [Sparse-to-Dense](/paper%20shorts/2017/09/21/sparse-to-dense-depth-prediction-from-sparse-depth-and-rgb.html), [DeepLiDAR](/paper%20shorts/2018/12/02/deeplidar-surface-normal-guided-depth-completion.html), [NLSPN](/paper%20shorts/2020/07/20/nlspn-non-local-spatial-propagation-network-for-depth-completion.html), and [GuideFormer](/paper%20shorts/2022/06/19/guideformer-transformers-for-image-guided-depth-completion.html) densify sparse depth that is still present at runtime. Removing that sensor changes the model input, not merely its supervision.
 
-## 14. SOTA is a recipe, not one winning block
+Distillation permits a larger sensor gap. [CRKD](/paper%20shorts/2024/06/17/crkd-camera-radar-distillation-from-lidar-camera.html) transfers feature, relation, and response knowledge from a camera-LiDAR teacher to a camera-radar student. [UniWorld](/paper%20shorts/2023/08/14/uniworld-autonomous-driving-pretraining-via-world-models.html) uses image-LiDAR sequences to create 4D occupancy supervision, then removes the pretraining decoder for downstream camera tasks.
 
-Recent leaderboard papers often refine one axis: [IS-Fusion](/paper%20shorts/2024/06/17/is-fusion-instance-scene-multimodal-fusion.html) combines scene- and instance-level fusion; [GAFusion](/paper%20shorts/2024/06/17/gafusion-adaptive-lidar-camera-fusion.html) adds LiDAR-guided depth, occupancy, global interaction, multi-scale processing, and temporal fusion; Sparse4D v3 strengthens sparse recurrent detection and tracking; UniM²AE pretrains camera and LiDAR encoders through masked reconstruction in a shared 3D volume. These are useful components, but a production SOTA system is assembled under a hardware and safety contract.
+The deployed graph and the label-generation graph should be documented separately. Offline labeling can use LiDAR, future frames, repeated passes, large models, and human review. Onboard inference can remain camera-only or camera-radar. Tesla's public [AI material](https://www.tesla.com/AI) and [2021 AI Day presentation](https://www.youtube.com/watch?v=j0z4FweCy4M) support this general separation between expensive offline labeling and camera-based onboard inference; they do not establish that every deployed network is distilled from a LiDAR teacher.
 
-The defensible current recipe is:
+Projected LiDAR is also imperfect supervision. Occlusion, timestamp mismatch, actor motion, and calibration error can move a return across an object boundary. Depth-label generation therefore needs visibility checks, pose interpolation, confidence, and ignore regions.
 
-1. Use modality-specific front ends to preserve sensor physics and calibration.
-2. Supervise or pretrain the camera geometry path explicitly; do not assume detection loss will discover reliable depth.
-3. Normalize geometry into BEV when dense scene tasks need a common canvas.
-4. Retain sparse object or track queries for actor-centric reasoning and long temporal horizons.
-5. Share the expensive trunk only where matched ablations show positive task and modality affinity.
-6. Normalize task losses, then measure gradient conflict before adding learned weights, surgery, adapters, or experts.
-7. Train nominal, degraded, and missing-sensor modes explicitly; pass health and age metadata into the model.
-8. Use privileged sensors and offline teachers when they improve a runtime-feasible student without becoming hidden dependencies.
-9. Pretrain on synchronized clips with geometry- or future-aware targets, not only 2D image semantics.
-10. Optimize the real execution graph—view transforms, token construction, memory movement, synchronization, and P99 latency—not FLOPs alone.
-11. Evaluate range, weather, calibration, temporal stability, sensor state, uncertainty, and planner impact alongside aggregate accuracy.
+## Temporal modeling: choose what persists
 
-No paper in this reading set demonstrates every item in one system. That gap matters. Academic comparisons usually hold the dataset fixed and vary a block; production must hold a behavior contract fixed while sensor health, weather, scene density, compute load, and task ownership change.
+A single frame does not provide stable velocity, identity through occlusion, or enough parallax for reliable depth. Temporal models differ in the state they retain.
 
-## 15. A cumulative reading path
+### Dense scene memory
 
-Read the papers in an order that produces an architectural artifact after each layer.
+[BEVDet4D](/paper%20shorts/2022/03/31/bevdet4d-temporal-cues-in-multicamera-3d-detection.html) warps the previous camera-BEV feature into the current ego frame and fuses it with the current feature. BEVFormer carries recurrent BEV queries. [SOLOFusion](/paper%20shorts/2022/10/05/solofusion-temporal-multiview-3d-object-detection.html) uses short high-resolution stereo for fine correspondence and a longer low-resolution BEV history for depth and velocity.
 
-| Layer | Read | Question | Artifact to produce |
-| --- | --- | --- | --- |
-| 1. Sensor encoding | [VoxelNet](/paper%20shorts/2017/11/17/voxelnet-end-to-end-point-cloud-3d-detection.html), [PointPillars](/paper%20shorts/2018/12/14/pointpillars-fast-point-cloud-encoders.html), [SST](/paper%20shorts/2021/12/13/sst-single-stride-sparse-transformer-for-3d-detection.html), [DSVT](/paper%20shorts/2023/01/15/dsvt-dynamic-sparse-voxel-transformer.html), [RCBEVDet](/paper%20shorts/2024/03/25/rcbevdet-radar-camera-fusion-in-bev.html) | Which measurement attributes and neighborhoods must survive? | Specify one token schema and health contract per sensor. |
-| 2. Coordinate and depth | [LSS](/paper%20shorts/2020/08/13/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.html), [BEVDepth](/paper%20shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html), [BEVFormer](/paper%20shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html) | How does uncertain perspective evidence enter metric space? | Draw the view transform and label train-only versus runtime geometry. |
-| 3. Fusion granularity | [TransFusion](/paper%20shorts/2022/03/22/transfusion-robust-lidar-camera-fusion-with-transformers.html), [BEVFusion](/paper%20shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html), [FUTR3D](/paper%20shorts/2022/03/20/futr3d-unified-sensor-fusion-framework-for-3d-detection.html) | Should evidence meet at points, cells, or queries? | Choose the fusion unit for objects, maps, and occupancy separately. |
-| 4. Sharing and tasks | [DeepInteraction](/paper%20shorts/2022/08/23/deepinteraction-3d-object-detection-via-modality-interaction.html), [UniTR](/paper%20shorts/2023/08/15/unitr-unified-efficient-multimodal-transformer-for-bev.html), [uncertainty weighting](/paper%20shorts/2017/05/19/multi-task-learning-using-homoscedastic-uncertainty.html), [GradNorm](/paper%20shorts/2017/11/07/gradnorm-adaptive-loss-balancing.html), [PCGrad](/paper%20shorts/2020/01/19/pcgrad-gradient-surgery-for-multi-task-learning.html) | What survives parameter sharing, and how are losses normalized? | Specify shared blocks, adapters, per-task loss units, and conflict diagnostics. |
-| 5. Temporal state | [BEVDet4D](/paper%20shorts/2022/03/31/bevdet4d-temporal-cues-in-multicamera-3d-detection.html), [Sparse4D](/paper%20shorts/2022/11/19/sparse4d-multiview-3d-detection-with-sparse-spatiotemporal-fusion.html), [StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html), [Sparse4D v3](/paper%20shorts/2023/11/20/sparse4dv3-end-to-end-3d-detection-and-tracking.html) | Which scene state must persist, and how does it age? | Budget dense cells, object queries, history length, and birth/death behavior. |
-| 6. Failure and radar | [MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html), [UniBEV](/paper%20shorts/2023/09/25/unibev-robust-multimodal-detection-with-uniform-bev-encoders.html), [CRN](/paper%20shorts/2023/04/03/crn-camera-radar-net-for-3d-perception.html), [RCBEVDet](/paper%20shorts/2024/03/25/rcbevdet-radar-camera-fusion-in-bev.html) | Does the model understand sensor availability and reliability? | Build a sensor-state matrix with required capability and uncertainty per mode. |
-| 7. Pretraining | [UniM²AE](/paper%20shorts/2023/08/21/unim2ae-multimodal-masked-autoencoders-with-unified-3d-representation.html), [UniWorld](/paper%20shorts/2023/08/14/uniworld-autonomous-driving-pretraining-via-world-models.html), [ViDAR](/paper%20shorts/2023/12/29/vidar-visual-point-cloud-forecasting-for-autonomous-driving.html), [DriveWorld](/paper%20shorts/2024/05/07/driveworld-4d-pretrained-scene-understanding.html) | Which unlabeled unit teaches geometry and dynamics? | Define the pretraining unit, target, data mixture, and matched transfer test. |
-| 8. Task graph | [UniAD](/paper%20shorts/2022/12/20/uniad-planning-oriented-autonomous-driving.html), [SparseDrive](/paper%20shorts/2024/05/30/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.html) | Are heads colocated, or does scene state serve planning? | Define consumer contracts and scenario-level regression gates. |
+Dense memory preserves roads, free space, background, and weak evidence that has not become an object. Its raw state grows approximately as $O(HWTD)$ for grid size $H\times W$, history $T$, and channel dimension $D$. Ego warping aligns static structure, but moving actors still need learned alignment.
 
-The final artifact should be a budgeted system proposal, not another architecture collage. For every shared block, name what it saves, which tasks and modalities update it, how failure is signaled, and which matched ablation would cause you to split it.
+### Sparse object memory
 
-## 16. The research test that would change my mind
+[Sparse4D](/paper%20shorts/2022/11/19/sparse4d-multiview-3d-detection-with-sparse-spatiotemporal-fusion.html) represents actors as 3D anchors. Each anchor predicts keypoints, projects them into cameras and timestamps, samples nearby image features, and refines the object state. Fusion cost moves from every BEV cell toward a bounded number of hypotheses.
 
-My current thesis is that the strongest unified driving model will be **shared in geometry and expensive scene computation, conditional in sensor availability, sparse in actor state, and specialized at physics-sensitive inputs and safety-sensitive outputs**. Full feature collapse is too lossy; fully separate stacks waste compute and create inconsistent state.
+[Sparse4D v2](/paper%20shorts/2023/05/23/sparse4dv2-recurrent-temporal-fusion-with-sparse-model.html) transforms previous instances into the current frame and reserves new anchors for births, so decoder cost no longer grows with nominal history length. [Sparse4D v3](/paper%20shorts/2023/11/20/sparse4dv3-end-to-end-3d-detection-and-tracking.html) adds temporal denoising, quality estimation, and recurrent tracking state. [StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html) stores a FIFO memory of high-confidence object queries, transforms their reference points with ego pose, and lets current queries attend to the compact history. [SparseBEV](/paper%20shorts/2023/08/18/sparsebev-high-performance-sparse-3d-object-detection.html) uses pillar queries that learn support points across cameras and timestamps without storing a dense BEV tensor.
 
-The thesis is falsifiable. Train three systems on the same data and augmentation: separate sensor/task specialists; a fully shared backbone and latent; and a structured hybrid with modality tokenizers, shared BEV or interaction blocks, task adapters, and explicit health conditioning. Match total parameters, training compute, onboard memory, and P99 latency. Evaluate nominal accuracy, calibration perturbation, partial and full sensor loss, weather, long range, temporal staleness, and planner interventions.
+![Figure 3 from StreamPETR, showing object queries propagated through a temporal memory queue](/assets/images/streampetr-paper-figure-3.png)
+_StreamPETR carries selected object state instead of a sequence of full scene grids. Source: [StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html), Figure 3._
 
-If the fully shared model matches the hybrid on every degraded slice and downstream metric while remaining easier to optimize and deploy, the extra structure is unnecessary. If specialists dominate within the same total budget, the shared scene representation is not carrying enough reusable information. Until that comparison exists, “unified” should describe an experimentally justified boundary—not a preference for fewer boxes in the diagram.
+Sparse memory is cheaper only after hypotheses exist. It can miss a new actor, evict a low-confidence hazard, or preserve a stale track. A production design therefore needs explicit query birth, death, age, confidence, and re-observation rules.
+
+The useful default is hybrid: short dense memory for road structure, free space, and query birth; longer sparse memory for actors and vectorized map elements. [SparseDrive](/paper%20shorts/2024/05/30/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.html) extends this object-and-map state into motion prediction and planning.
+
+## Sparse transformers reduce specific costs, not the whole system
+
+Sparse LiDAR encoders avoid processing empty 3D space. Sparse camera detectors avoid constructing or repeatedly updating every BEV cell. Both save work, but neither makes the full perception stack sparse.
+
+Surround-camera backbones still process every image, often at several scales. Sparse attention also introduces indexing, sorting, padding, and irregular memory access. Its real benefit depends on the accelerator and compiler, not only FLOPs. A useful latency profile separates image encoding, geometry, fusion, temporal memory, heads, and postprocessing.
+
+The key sparse-transformer papers change different terms. VoTr, SST, and DSVT bound attention among occupied LiDAR voxels. VoxelNeXt removes the dense LiDAR detection head. Sparse4D and StreamPETR bound object-level temporal memory. SparseBEV replaces a full camera-BEV grid with learned pillar support points. Those are complementary choices rather than one architecture family with a single efficiency claim.
+
+Measure end-to-end P95 and P99 latency, peak memory, and recall under dense scenes. Average FPS can hide synchronization, transfer, sparse-kernel overhead, and the rare frame in which many queries or voxels become active.
+
+## Pretraining should teach geometry and persistence
+
+Image-classification pretraining teaches appearance but not calibration, cross-view correspondence, metric depth, ego motion, or temporal persistence. Driving pretraining should use synchronized sensor packets or clips and a target that requires those relationships.
+
+[UniM²AE](/paper%20shorts/2023/08/21/unim2ae-multimodal-masked-autoencoders-with-unified-3d-representation.html) masks camera patches and LiDAR voxels, maps visible features into a shared 3D volume, and reconstructs both modalities. [BEV-MAE](/paper%20shorts/2022/12/12/bev-mae-bird-eye-view-masked-autoencoders-for-point-cloud-pretraining.html) masks vertical LiDAR columns and predicts normalized point coordinates and density, matching the structure of outdoor scans. Its reported improvement is larger in low-label regimes and narrows with the full Waymo training set.
+
+[UniWorld](/paper%20shorts/2023/08/14/uniworld-autonomous-driving-pretraining-via-world-models.html) predicts current and future 4D occupancy. [ViDAR](/paper%20shorts/2023/12/29/vidar-visual-point-cloud-forecasting-for-autonomous-driving.html) predicts future point clouds from historical images. [DriveWorld](/paper%20shorts/2024/05/07/driveworld-4d-pretrained-scene-understanding.html) separates dynamic memory from propagated static state and adapts the result to downstream tasks.
+
+| Pretraining target | What it teaches | Main limitation |
+| --- | --- | --- |
+| Masked camera and LiDAR reconstruction | Cross-modal correspondence | Local correlated evidence can make reconstruction easy |
+| Current occupancy | Metric scene structure | Requires geometric labels or a teacher |
+| Future occupancy or point clouds | Motion and persistence | A single future cannot represent every valid outcome |
+| Teacher features and pseudo-labels | Task-specific abstractions | Inherits teacher errors and blind spots |
+
+Scale should be measured in scenario diversity and useful temporal transitions, not only frame count. Repeated highway frames add less supervision than intersections, rare actors, adverse weather, calibration variation, and recoveries after occlusion. The strongest evidence for a pretrained representation is transfer across several tasks and label budgets, not a gain on one detector configuration.
+
+## Practical takeaways
+
+1. Encode each sensor around what it uniquely measures: camera semantics, LiDAR geometry, and radar velocity and uncertainty.
+2. Use vehicle-frame geometry as the shared interface. Choose dense BEV for scene fields and sparse queries for actors.
+3. Fuse at the output's natural granularity instead of forcing every modality into one tensor.
+4. Share expensive geometry across tasks, but keep task decoders, loss units, and safety thresholds explicit.
+5. Treat loss scale, learning speed, and gradient conflict as different multi-task problems.
+6. Separate training sensors from runtime sensors. LiDAR supervision can improve a camera model without entering its inference graph; depth completion cannot.
+7. Keep short dense temporal state for scene discovery and longer sparse state for tracked entities.
+8. Profile the executed system. Sparse fusion does not remove the cost of camera backbones or irregular memory access.
+9. Pretrain on geometry, correspondence, and future state, then verify transfer across tasks and data regimes.
+
+The core pattern is specialized sensing, shared geometry, and selective state. Most modern perception papers can be understood by asking which of those three boundaries they move.

--- a/src/content/posts/nlspn-non-local-spatial-propagation-network-for-depth-completion.md
+++ b/src/content/posts/nlspn-non-local-spatial-propagation-network-for-depth-completion.md
@@ -1,0 +1,45 @@
+---
+title: 'NLSPN: Non-Local Spatial Propagation Network for Depth Completion'
+date: '2020-07-20T04:00:00.000Z'
+section: paper-shorts
+postSlug: nlspn-non-local-spatial-propagation-network-for-depth-completion
+legacyPath: /paper shorts/2020/07/20/nlspn-non-local-spatial-propagation-network-for-depth-completion.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2020 – NLSPN: Non-Local Spatial Propagation Network for Depth Completion'
+---
+## 2020 – NLSPN
+
+**arXiv:** [2007.10042](https://arxiv.org/abs/2007.10042)
+
+**Code:** [zzangjinsun/NLSPN](https://github.com/zzangjinsun/NLSPN)
+
+**Summary:** NLSPN predicts an initial dense depth map, confidence, non-local neighbor offsets, and affinities. Iterative propagation then gathers depth from learned relevant locations rather than a fixed local window. Confidence enters the affinity normalization so noisy sparse-depth measurements do not spread indiscriminately.
+
+The method targets the mixed-depth problem: a local kernel near an object boundary often copies background depth into the foreground or the reverse.
+
+## Paper Insights
+
+Each pixel selects a small set of neighbors that can lie on the same object or plane even when they are not adjacent. Learnable normalization expands the feasible affinity space while maintaining stable iteration. Confidence jointly suppresses unreliable source pixels during propagation instead of masking them only after a dense estimate is formed.
+
+On KITTI Depth Completion test, NLSPN reports 741.68 mm RMSE and 199.59 mm MAE, compared with 758.38 and 226.50 for DeepLiDAR in the cited table. On NYU Depth V2, it reports 0.092 m RMSE. The ablation attributes the improvement to all three choices:
+
+| Propagation choice | KITTI validation RMSE |
+| --- | ---: |
+| Fixed local neighbors, no confidence | 908.4 mm |
+| Fixed local neighbors with confidence | 890.4 mm |
+| Non-local neighbors with learned affinity | 886.0 mm |
+| Non-local neighbors, learned normalization, confidence | 884.1 mm |
+
+The reported non-local neighbors have lower depth variance than fixed local ones, supporting the boundary argument. The method still assumes sparse depth is present at runtime and pays for iterative dense image-space refinement; it is not a recipe for removing LiDAR from deployment.
+
+## Decision Lens
+
+NLSPN informs whether depth completion should use a large feed-forward decoder or a learned propagation rule. Its atomic unit is a depth pixel, but the neighborhood graph is predicted from RGB and sparse depth. The expensive decision is iterative full-resolution propagation and its memory access pattern.
+
+The matched alternative compares non-local propagation with a transformer or convolutional decoder at equal resolution, iterations, and P99 latency, with boundary- and range-stratified errors. NLSPN loses if the learned offsets become unstable under domain shift or if a simpler local kernel matches boundary quality. At higher image resolution, the dense state and repeated gathers dominate.
+
+**Context:** Sparse-to-Dense regresses depth directly; DeepLiDAR injects surface normals; GuideFormer uses transformer guidance. NLSPN isolates learned propagation as a way to preserve boundaries around sparse measurements.
+
+**Takeaway:** Depth completion should move measurements along learned geometric neighborhoods, not assume the nearest pixels belong to the same surface.

--- a/src/content/posts/petr-position-embedding-transformation-for-multiview-3d-object-detection.md
+++ b/src/content/posts/petr-position-embedding-transformation-for-multiview-3d-object-detection.md
@@ -1,0 +1,44 @@
+---
+title: 'PETR: Position Embedding Transformation for Multi-View 3D Object Detection'
+date: '2022-03-10T05:00:00.000Z'
+section: paper-shorts
+postSlug: petr-position-embedding-transformation-for-multiview-3d-object-detection
+legacyPath: /paper shorts/2022/03/10/petr-position-embedding-transformation-for-multiview-3d-object-detection.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2022 – PETR: Position Embedding Transformation for Multi-View 3D Object Detection'
+---
+## 2022 – PETR
+
+**arXiv:** [2203.05625](https://arxiv.org/abs/2203.05625)
+
+**Code:** [megvii-research/PETR](https://github.com/megvii-research/PETR)
+
+**Summary:** PETR assigns each multiview image feature a 3D position embedding derived from the camera frustum and calibration. Object queries then use global transformer attention over image features that already encode possible world coordinates. Unlike DETR3D, the query does not project one reference point to sample a local image feature; the geometry is distributed across the feature map before decoding.
+
+This is a different answer to the camera-to-3D problem: make perspective features position-aware, then let attention learn the correspondence.
+
+## Paper Insights
+
+PETR discretizes points along each camera ray, transforms them into the ego frame, normalizes the resulting coordinates over a region of interest, and maps them through a small network into a positional tensor. Learnable 3D anchor points initialize the object queries.
+
+The central ablation is unusually clear. Standard 2D positional encoding reaches only 6.9 mAP; 3D positional encoding reaches 30.5 mAP in the same reported setup. A simple $1\times1$ position encoder raises mAP from 25.6 to 30.9, while $3\times3$ convolutions collapse training because they mix a feature with neighboring coordinates and break correspondence.
+
+| Geometry interface | Retrieval pattern | Main cost |
+| --- | --- | --- |
+| DETR3D | Project each 3D query into local image features | Sparse support can miss object extent. |
+| PETR | Embed 3D coordinates into all image tokens | Global query-image attention is dense. |
+| Dense BEV lifting | Pool ray hypotheses into metric cells | Cost follows BEV area and resolution. |
+
+PETR's strongest externally pretrained test model reports 44.1 mAP and 50.4 NDS on nuScenes. The paper also reports 10.7 FPS for a 1056×384 configuration, although device and implementation differences make cross-paper speed comparisons weak. PETR converges more slowly than DETR3D, consistent with learning global correspondence rather than receiving a local projection prior.
+
+## Decision Lens
+
+PETR informs where geometric coordinates should enter a camera transformer. Its atomic units are perspective features annotated with 3D positional hypotheses and object queries initialized by learned anchors. The architecture buys flexible global matching by paying attention over the whole multiview feature set.
+
+A matched test should compare PETR, DETR3D-style sampling, and BEV lifting at equal image tokens, queries, training length, and depth supervision. PETR loses if global attention's memory cost dominates or if its implicit ray matching remains less calibrated than explicit depth. At more cameras or higher resolution, query-image attention grows before object sparsity can help.
+
+**Context:** PETR follows DETR3D but moves geometry from the query projection into the image-token embedding. PETRv2 aligns those embeddings over time; StreamPETR converts the resulting queries into recurrent object memory.
+
+**Takeaway:** Position embeddings can turn perspective tokens into a metric search space, but global flexibility is purchased with dense attention and slower geometric learning.

--- a/src/content/posts/petrv2-unified-3d-perception-from-multicamera-images.md
+++ b/src/content/posts/petrv2-unified-3d-perception-from-multicamera-images.md
@@ -1,0 +1,42 @@
+---
+title: 'PETRv2: A Unified Framework for 3D Perception from Multi-Camera Images'
+date: '2022-06-02T04:00:00.000Z'
+section: paper-shorts
+postSlug: petrv2-unified-3d-perception-from-multicamera-images
+legacyPath: /paper shorts/2022/06/02/petrv2-unified-3d-perception-from-multicamera-images.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2022 – PETRv2: A Unified Framework for 3D Perception from Multi-Camera Images'
+---
+## 2022 – PETRv2
+
+**arXiv:** [2206.01256](https://arxiv.org/abs/2206.01256)
+
+**Code:** [megvii-research/PETR](https://github.com/megvii-research/PETR)
+
+**Summary:** PETRv2 extends PETR's 3D position-aware image tokens across time and tasks. Ego pose aligns historical 3D coordinates before their position embeddings meet current queries. Separate query families then use the same multiview features for object detection, BEV segmentation, and 3D lane detection.
+
+The paper unifies the interface, not the output representation. Boxes use sparse 3D detection queries, BEV segmentation uses patch queries, and lanes use ordered anchor-point queries.
+
+## Paper Insights
+
+Coordinate alignment gives historical features the position they occupy in the current ego frame. A feature-guided position encoder modulates geometric embeddings with appearance so the same nominal coordinate can carry different evidence. In the main nuScenes test configuration, PETRv2 reports 49.0 mAP and 58.2 NDS; its multiscale variant reaches 50.8 mAP and 59.1 NDS. Average velocity error drops from PETR's 0.808 m/s to 0.343 m/s.
+
+| Added component | Validation effect | Interpretation |
+| --- | --- | --- |
+| Temporal frames without coordinate alignment | +2.7 NDS, +0.5 mAP | History helps, but unaligned geometry limits it. |
+| Coordinate alignment | Further +2.1 NDS, +0.9 mAP | Ego-frame consistency carries most temporal value. |
+| Feature-guided position encoding | Final 49.6 NDS, 40.1 mAP | Appearance adapts the geometric prior. |
+
+The robustness study is as important as the leaderboard. Extrinsic noise degrades every variant; feature-guided encoding reduces but does not remove the loss. Dropping one camera reduces mAP, especially the wide rear camera. A delay of roughly 83 ms lowers mAP by 3.19 points, and delays above 0.3 s produce a much larger collapse. Temporal modeling does not substitute for sensor synchronization.
+
+## Decision Lens
+
+PETRv2 informs how one camera representation can support detection, mapping, and lanes without forcing one query geometry on all three. The shared object is a set of calibrated, position-aware image features. Task capacity stays explicit through query initialization and heads; temporal sharing occurs through aligned coordinates.
+
+The rejection test compares this task-query design with a dense BEV trunk at matched resolution and latency, including extrinsic noise, camera loss, and timestamp jitter. PETRv2 loses if global attention or position encoding becomes brittle under real calibration drift, or if dense BEV gives stronger task consistency. At more tasks, query families and their competing gradients become the likely capacity bottleneck.
+
+**Context:** PETR establishes 3D position embeddings; PETRv2 makes them temporal and multi-task. StreamPETR later retains selected PETR queries as recurrent object state instead of replaying the historical token set.
+
+**Takeaway:** A unified camera model can share calibrated evidence while giving boxes, maps, and lanes different query contracts—and synchronization remains part of the model.

--- a/src/content/posts/pointpainting-sequential-fusion-for-3d-object-detection.md
+++ b/src/content/posts/pointpainting-sequential-fusion-for-3d-object-detection.md
@@ -1,0 +1,41 @@
+---
+title: 'PointPainting: Sequential Fusion for 3D Object Detection'
+date: '2019-11-22T05:00:00.000Z'
+section: paper-shorts
+postSlug: pointpainting-sequential-fusion-for-3d-object-detection
+legacyPath: /paper shorts/2019/11/22/pointpainting-sequential-fusion-for-3d-object-detection.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2019 – PointPainting: Sequential Fusion for 3D Object Detection'
+---
+## 2019 – PointPainting
+
+**arXiv:** [1911.10150](https://arxiv.org/abs/1911.10150)
+
+**Summary:** PointPainting runs image semantic segmentation first, projects every LiDAR point into the camera output, appends the class-probability vector to the point, and then feeds the enriched cloud to an otherwise standard LiDAR detector. Fusion happens before voxelization, but after the camera has compressed RGB into semantics.
+
+Its appeal is modularity. The LiDAR model receives explicit semantic evidence without learning a large joint feature space. The same choice also defines its ceiling: image information can survive only where LiDAR produced a point and only in the form the segmentation model emitted.
+
+## Paper Insights
+
+The paper paints PointPillars, VoxelNet, and PointRCNN and reports gains across 24 of 27 KITTI validation comparisons. On nuScenes test, its strengthened PointPillars+ baseline rises from 40.1 to 46.4 mAP and from 55.0 to 58.1 NDS after painting. Every nuScenes class improves, with especially large gains for traffic cones, whose sparse LiDAR returns benefit from image semantics.
+
+| What PointPainting preserves | What it discards |
+| --- | --- |
+| Per-point geometry and LiDAR intensity | Image features between projected LiDAR samples |
+| Camera class probabilities | Texture and geometry not expressible as semantic classes |
+| Existing LiDAR detector interface | Joint adaptation of the camera network to 3D errors |
+| Sensor provenance at each point | Soft correspondence when calibration is uncertain |
+
+The segmentation-quality ablation shows detection improving with segmentation mIoU, while qualitative failures show a sharper boundary: incorrect semantic painting can create false classes. Pipelining reduces latency because segmentation and LiDAR processing can overlap, but that systems result assumes synchronization and a known dependency graph.
+
+## Decision Lens
+
+PointPainting informs whether sensor fusion needs an end-to-end joint model. Its atomic unit is a LiDAR point augmented with a semantic vector. The camera and LiDAR networks remain independently interpretable; the projection is the only shared interface. This makes the design easy to retrofit and test, but gives LiDAR sampling control over camera recall.
+
+The matched alternative is a learned point- or query-level fusion model using the same image backbone, LiDAR detector, and latency budget. Painting should be rejected if learned retrieval recovers small and distant actors from image regions without points, or if calibration perturbations cause the hard projection to fail abruptly. At scale, the separate segmentation model and duplicated camera computation can dominate the efficiency argument.
+
+**Context:** PointPainting is a clean early-fusion reference. TransFusion relaxes hard point-pixel correspondence with object-query attention; BEVFusion preserves dense camera context by meeting LiDAR only after both reach BEV.
+
+**Takeaway:** Early fusion can be simple and effective, but the sensor chosen as the carrier decides which evidence the other sensor is allowed to contribute.

--- a/src/content/posts/second-sparsely-embedded-convolutional-detection.md
+++ b/src/content/posts/second-sparsely-embedded-convolutional-detection.md
@@ -1,0 +1,43 @@
+---
+title: 'SECOND: Sparsely Embedded Convolutional Detection'
+date: '2018-10-06T04:00:00.000Z'
+section: paper-shorts
+postSlug: second-sparsely-embedded-convolutional-detection
+legacyPath: /paper shorts/2018/10/06/second-sparsely-embedded-convolutional-detection.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2018 – SECOND: Sparsely Embedded Convolutional Detection'
+---
+## 2018 – SECOND
+
+**Paper:** [Sensors 18(10), 3337](https://doi.org/10.3390/s18103337)
+
+**Summary:** SECOND turns VoxelNet's dense 3D middle encoder into a sparse one. It computes only around occupied voxels, then densifies after the vertical dimension has been compressed enough for a 2D proposal network. The paper also contributes ground-truth database sampling and an orientation loss that respects the fact that boxes separated by $\pi$ can describe the same footprint.
+
+The lasting contribution is the execution rule: preserve 3D structure while it is informative, but do not convolve over empty road volume. That rule became a foundation for later LiDAR detectors and sparse voxel transformers.
+
+## Paper Insights
+
+SECOND begins with voxel feature encoding, applies a sparse 3D convolutional middle network, converts the result to a dense BEV feature map, and predicts boxes with an RPN. Its GPU rule-generation step builds the active input-output pairs needed by each sparse convolution. On KITTI, the paper reports roughly $3\times$ faster inference than the dense counterpart; the small model runs at about 40 FPS and the larger model at 20 FPS on a GTX 1080 Ti.
+
+Two details matter beyond speed. Database sampling inserts complete labeled objects and their points into training scenes, reducing foreground imbalance and accelerating convergence. The angle objective separates overlap from direction: sine-based regression avoids a large penalty for geometrically equivalent headings, while an auxiliary classifier recovers the discrete direction.
+
+| Decision | SECOND choice | Boundary |
+| --- | --- | --- |
+| 3D computation | Sparse convolution on active voxels | Rule generation and irregular memory access remain real costs. |
+| Height compression | Densify after sparse 3D encoding | Later BEV stages no longer retain full vertical structure. |
+| Long-tail training | Sample labeled objects into scenes | Inserted objects must remain physically and contextually plausible. |
+| Orientation | Periodic regression plus direction class | Symmetric geometry and semantic heading are handled separately. |
+
+The paper reports lower pedestrian and cyclist performance than for cars and identifies camera fusion as future work. Its evidence also comes from KITTI's relatively small range and class set, so the exact speed and accuracy numbers should not be transferred directly to a modern surround-sensor stack.
+
+## Decision Lens
+
+SECOND informs where a LiDAR model should first become dense. Its atomic unit is an occupied voxel; parameter sharing occurs through sparse kernels over a coordinate map. The expensive decision is not whether the mathematical tensor is sparse, but whether the target accelerator can generate and traverse active rules cheaply enough to beat dense kernels at the observed occupancy.
+
+A matched test should compare sparse and dense 3D middle encoders with the same voxel size, receptive field, BEV head, and P99 latency measurement. The sparse design loses if indexing and memory movement erase its arithmetic savings or if early BEV conversion preserves the same detection quality more cheaply. At larger range and finer voxels, active-set bookkeeping and the final dense BEV map become the likely bottlenecks.
+
+**Context:** VoxelNet established learned voxel features; SECOND made sparse 3D convolution practical for detection. VoTr and DSVT later replace parts of the convolutional neighborhood with bounded attention, while VoxelNeXt removes the dense prediction head as well.
+
+**Takeaway:** Sparse LiDAR modeling starts by refusing to compute over empty volume, but the real system boundary is where sparse indexing stops paying for itself.

--- a/src/content/posts/solofusion-temporal-multiview-3d-object-detection.md
+++ b/src/content/posts/solofusion-temporal-multiview-3d-object-detection.md
@@ -1,0 +1,45 @@
+---
+title: 'SOLOFusion: Time Will Tell for Temporal Multi-View 3D Object Detection'
+date: '2022-10-05T04:00:00.000Z'
+section: paper-shorts
+postSlug: solofusion-temporal-multiview-3d-object-detection
+legacyPath: /paper shorts/2022/10/05/solofusion-temporal-multiview-3d-object-detection.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2022 – Time Will Tell: New Outlooks and a Baseline for Temporal Multi-View 3D Object Detection (SOLOFusion)'
+---
+## 2022 – SOLOFusion
+
+**arXiv:** [2210.02443](https://arxiv.org/abs/2210.02443)
+
+**Code:** [Divadi/SOLOFusion](https://github.com/Divadi/SOLOFusion)
+
+**Summary:** SOLOFusion frames temporal camera detection as stereo with a moving baseline. Short, high-resolution history resolves fine correspondence; long, low-resolution history supplies larger baselines that make distant depth easier to observe. The model combines both rather than spending high resolution over the full temporal window.
+
+Its central insight is a budget trade: temporal baseline and feature resolution can compensate for each other, but neither should be maximized uniformly.
+
+## Paper Insights
+
+The long-term path warps a running sequence of low-resolution BEV features into the present frame and builds a cost volume. The short-term path performs higher-resolution stereo around a few depth hypotheses chosen from the monocular depth distribution. Gaussian-spaced top-k sampling concentrates compute near likely depth while retaining nearby alternatives.
+
+| Temporal design | FPS | Memory | mAP | NDS |
+| --- | ---: | ---: | ---: | ---: |
+| Single-frame BEVDepth | 17.6 | 3.3 GB | 32.1 | 34.9 |
+| Short high-resolution only | 12.2 | 3.3 GB | 34.3 | 38.9 |
+| Long low-resolution only | 15.9 | 3.6 GB | 38.6 | 47.9 |
+| Both paths | 11.4 | 3.6 GB | 40.4 | 49.5 |
+
+History length matters nonlinearly. Moving from one to sixteen previous frames raises mAP from 31.6 to 37.7 and improves translation error from 0.734 to 0.655; 41 frames no longer helps. Matching every one of 112 depth hypotheses falls to 2.9 FPS and 8.5 GB, while seven guided hypotheses keep the memory at 3.3 GB.
+
+On nuScenes validation, the ResNet-50 model reports 42.7 mAP and 53.4 NDS. The larger test model reaches 54.0 mAP and 61.9 NDS. These results support the representation trade, but the pipeline still carries dense BEV state and its history depends on ego-motion alignment.
+
+## Decision Lens
+
+SOLOFusion informs how to spend a fixed temporal budget between spatial detail and baseline diversity. Its atomic units are depth hypotheses and aligned BEV cells. The short path buys local precision; the long path buys observability and velocity without replaying high-resolution images at every timestamp.
+
+The matched experiment should sweep resolution, frame spacing, and history under one latency and memory envelope, with range-bucketed depth and actor recall. SOLOFusion loses if a sparse recurrent query model matches long-range localization with less dense state, or if pose drift makes long baselines unreliable. At 10× history, stored BEV features and warp bandwidth become the limits even when each frame is coarse.
+
+**Context:** BEVDet4D uses a short recurrent BEV. SOLOFusion explains why long temporal baselines help camera depth; Sparse4D v2 and StreamPETR instead compress long history into recurrent instances.
+
+**Takeaway:** Long history is most useful when it changes depth observability; the efficient design spends detail on the short baseline and duration on the coarse one.

--- a/src/content/posts/sparse4dv2-recurrent-temporal-fusion-with-sparse-model.md
+++ b/src/content/posts/sparse4dv2-recurrent-temporal-fusion-with-sparse-model.md
@@ -1,0 +1,43 @@
+---
+title: 'Sparse4D v2: Recurrent Temporal Fusion with a Sparse Model'
+date: '2023-05-23T04:00:00.000Z'
+section: paper-shorts
+postSlug: sparse4dv2-recurrent-temporal-fusion-with-sparse-model
+legacyPath: /paper shorts/2023/05/23/sparse4dv2-recurrent-temporal-fusion-with-sparse-model.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2023 – Sparse4D v2: Recurrent Temporal Fusion with a Sparse Model'
+---
+## 2023 – Sparse4D v2
+
+**arXiv:** [2305.14018](https://arxiv.org/abs/2305.14018)
+
+**Code:** [linxuewu/Sparse4D](https://github.com/linxuewu/Sparse4D)
+
+**Summary:** Sparse4D v2 changes the first Sparse4D from explicit multi-frame image sampling into a recurrent instance model. Historical anchors and features are transformed into the current frame, merged with fresh single-frame proposals, and refined again. Temporal decoder cost becomes independent of the nominal history length because only the previous sparse state crosses the frame boundary.
+
+The architectural change is a memory decision: transmit structured hypotheses frame by frame instead of repeatedly reopening the video.
+
+## Paper Insights
+
+The decoder reserves one layer for fresh anchors and uses later layers for recurrent temporal instances. Camera-parameter encoding exposes calibration to the instance update. Dense LiDAR-derived depth supervision stabilizes the camera backbone during training but is absent from inference. Efficient Deformable Aggregation fuses sampling and weighted reduction into one operator.
+
+| Change | Reported effect | Why it matters |
+| --- | --- | --- |
+| Efficient aggregation | 6.3→3.1 GB train memory; 13.7→20.3 FPS | Sparse algorithms still need fused kernels. |
+| Recurrent temporal fusion | +9.8 mAP, +12.5 NDS over single-frame | Compact state retains useful history. |
+| Fresh single-frame layer | +3.5 mAP over all-temporal decoder | A recurrent model still needs query birth. |
+| Dense depth supervision | Prevents a reported training collapse | Train-time geometry can stabilize a camera-only graph. |
+
+The low-resolution ResNet-50 model reports 43.9 mAP and 53.9 NDS at 20.3 FPS. The pretrained high-resolution configuration reaches 50.5 mAP and 59.4 NDS at 8.4 FPS. The paper notes that its head cost does not grow with image resolution, although the dense camera backbone still does.
+
+## Decision Lens
+
+Sparse4D v2 informs when temporal compression should occur. Its atomic unit is a recurrent 3D instance rather than a frame, pixel, or BEV cell. The expensive image backbone remains dense; savings arrive in evidence retrieval, temporal storage, and decoder reuse.
+
+The rejection test compares recurrent instances with fixed-window resampling at the same history information, image backbone, and P99 latency. The recurrent design loses if old errors accumulate, new-object recall falls, or dense weak evidence is needed before a query is born. At 10× actors, instance count, duplicate resolution, and self-attention replace history length as the bottleneck.
+
+**Context:** Sparse4D v1 samples several timestamps explicitly. v2 makes the anchors recurrent; v3 adds stronger denoising, quality estimation, and tracking supervision to keep those instances reliable.
+
+**Takeaway:** Temporal cost becomes bounded when the model carries forward a scene hypothesis rather than a stack of observations—but query birth and state quality become first-class problems.

--- a/src/content/posts/sparsebev-high-performance-sparse-3d-object-detection.md
+++ b/src/content/posts/sparsebev-high-performance-sparse-3d-object-detection.md
@@ -1,0 +1,42 @@
+---
+title: 'SparseBEV: High-Performance Sparse 3D Object Detection from Multi-Camera Videos'
+date: '2023-08-18T04:00:00.000Z'
+section: paper-shorts
+postSlug: sparsebev-high-performance-sparse-3d-object-detection
+legacyPath: /paper shorts/2023/08/18/sparsebev-high-performance-sparse-3d-object-detection.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2023 – SparseBEV: High-Performance Sparse 3D Object Detection from Multi-Camera Videos'
+---
+## 2023 – SparseBEV
+
+**arXiv:** [2308.09244](https://arxiv.org/abs/2308.09244)
+
+**Code:** [MCG-NJU/SparseBEV](https://github.com/MCG-NJU/SparseBEV)
+
+**Summary:** SparseBEV keeps the BEV prior without building a dense BEV map. Pillar-shaped queries interact through scale-adaptive self-attention, predict several spatiotemporal sample points, retrieve multiscale camera features at those points, and decode them with query-conditioned channel and point mixing.
+
+The paper argues that sparse camera detectors lagged dense ones because their retrieval and mixing were too rigid, not because sparsity itself was the wrong representation.
+
+## Paper Insights
+
+Scale-adaptive attention gives each query head a learned BEV receptive field. Large classes learn broader neighborhoods. Adaptive sampling predicts support around the query, projects it across eight timestamps and visible cameras, and weights feature scales. Dynamic mixing lets the query decide how sampled points and channels should interact.
+
+| Component | mAP | NDS | Contribution |
+| --- | ---: | ---: | --- |
+| Baseline without mixing | 38.6 | 49.1 | Sparse sampled features with fixed aggregation. |
+| Static channel→point mixing | 41.9 | 51.8 | Better decoding without query-conditioned weights. |
+| Adaptive channel→point mixing | 45.4 | 55.6 | Query-specific decoding of support and semantics. |
+
+Pillar queries add 1.4 mAP over 3D points. Scale-adaptive attention adds 4.0 mAP over vanilla query self-attention. Aligning ego motion raises NDS by about ten points; adding a constant-velocity object correction raises it further to 55.6. The ResNet-50 configuration reports 44.8 mAP and 55.8 NDS at 23.5 FPS. The paper's 67.5 NDS test result uses future frames and should not be compared with causal online systems.
+
+## Decision Lens
+
+SparseBEV informs whether a camera detector can retain metric BEV structure as a query prior instead of a dense field. Its atomic unit is a BEV pillar query with adaptive spatial extent. Capacity scales with queries, sample points, feature levels, and timestamps rather than the full metric area.
+
+The rejection test compares SparseBEV with a dense BEV model under causal frames, the same backbone, and corrupted ego pose. SparseBEV loses if pose noise destroys temporal support, if query initialization misses weak actors, or if its nominally sparse gathers compile poorly. The paper also notes that latency still grows linearly with frames because sampled features are stacked across time.
+
+**Context:** DETR3D samples one projected query point; Sparse4D samples structured 3D keypoints; SparseBEV adds adaptive BEV receptive fields and query-conditioned mixing. Each expands sparse support without materializing the full grid.
+
+**Takeaway:** Sparse camera detection becomes competitive when the query can adapt where it looks, how much context it uses, and how it mixes the evidence.

--- a/src/content/posts/votr-voxel-transformer-for-3d-object-detection.md
+++ b/src/content/posts/votr-voxel-transformer-for-3d-object-detection.md
@@ -1,0 +1,43 @@
+---
+title: 'VoTr: Voxel Transformer for 3D Object Detection'
+date: '2021-09-06T04:00:00.000Z'
+section: paper-shorts
+postSlug: votr-voxel-transformer-for-3d-object-detection
+legacyPath: /paper shorts/2021/09/06/votr-voxel-transformer-for-3d-object-detection.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2021 – VoTr: Voxel Transformer for 3D Object Detection'
+---
+## 2021 – VoTr
+
+**arXiv:** [2109.02497](https://arxiv.org/abs/2109.02497)
+
+**Summary:** VoTr replaces a sparse-convolutional LiDAR backbone with attention over occupied voxels. Local attention supplies dense nearby context; dilated attention samples a much larger spatial region; and Fast Voxel Query retrieves those neighbors without scanning the full voxel grid.
+
+The paper's useful question is narrower than “should LiDAR use transformers?” It asks when content-dependent long-range retrieval is worth the indexing and latency that convolution avoids.
+
+## Paper Insights
+
+VoTr has sparse voxel modules that may create features at new active positions and submanifold modules that update only existing positions. Each query attends to a fixed-size set of local or dilated occupied voxels. The fixed budget keeps attention bounded even when the scene contains tens of thousands of active voxels.
+
+Replacing SECOND's convolutional backbone with VoTr improves Waymo Level-1 vehicle mAP by 1.05 points. The gains grow with range: 1.42 points at 30–50 m and 1.72 beyond 50 m. On KITTI, adding dilated attention raises moderate car AP from 75.48 to 78.27. Increasing attended voxels from 24 to 48 adds 1.19 AP, which makes the accuracy-cost relationship explicit.
+
+| Backbone | KITTI speed | Moderate car AP | Interpretation |
+| --- | ---: | ---: | --- |
+| SECOND | 20.73 Hz | 76.48 | Fast local convolutional context. |
+| VoTr-SSD | 14.65 Hz | 78.27 | Larger adaptive context for about 20 ms extra latency. |
+| PV-RCNN | 9.25 Hz | 83.69 | Stronger two-stage baseline at lower throughput. |
+| VoTr-TSD | 7.17 Hz | 84.04 | Transformer context inside a heavier two-stage detector. |
+
+These rows use the paper's KITTI validation setup and are not an accelerator-independent ranking. The important result is that long-range context helps sparse, distant objects, while the attention implementation is slower than the convolutional backbone it replaces.
+
+## Decision Lens
+
+VoTr informs whether to buy LiDAR receptive field through deeper sparse convolution or explicit voxel attention. Its atomic unit is an occupied voxel, but capacity is allocated through a bounded neighbor list. Local and dilated attention share weights across voxels; the coordinate query policy determines which evidence each token can reach.
+
+The decisive control matches receptive field, parameter count, active voxels, and deployed-kernel quality. VoTr should be rejected if large-kernel or multi-stage sparse convolution matches far-range recall at lower P99 latency. At 10× active voxels, neighbor lookup and irregular gathers are more likely to fail first than the attention matrix itself.
+
+**Context:** SECOND established sparse convolution for voxel detection. VoTr introduced sparse voxel attention; SST and DSVT later use windowed or rotated-set designs that are easier to batch and deploy.
+
+**Takeaway:** Sparse attention earns its cost when distant, incomplete objects need context that a local voxel kernel cannot reach cheaply.

--- a/src/content/posts/voxelnext-fully-sparse-voxelnet-for-3d-detection-and-tracking.md
+++ b/src/content/posts/voxelnext-fully-sparse-voxelnet-for-3d-detection-and-tracking.md
@@ -1,0 +1,45 @@
+---
+title: 'VoxelNeXt: Fully Sparse VoxelNet for 3D Object Detection and Tracking'
+date: '2023-03-20T04:00:00.000Z'
+section: paper-shorts
+postSlug: voxelnext-fully-sparse-voxelnet-for-3d-detection-and-tracking
+legacyPath: /paper shorts/2023/03/20/voxelnext-fully-sparse-voxelnet-for-3d-detection-and-tracking.html
+tags:
+  - Other
+field: 'BEV Perception & Mapping'
+summary: '2023 – VoxelNeXt: Fully Sparse VoxelNet for 3D Object Detection and Tracking'
+---
+## 2023 – VoxelNeXt
+
+**arXiv:** [2303.11301](https://arxiv.org/abs/2303.11301)
+
+**Code:** [dvlab-research/VoxelNeXt](https://github.com/dvlab-research/VoxelNeXt)
+
+**Summary:** VoxelNeXt keeps LiDAR detection sparse through the prediction head. Instead of compressing sparse 3D features into a dense BEV heatmap and looking for hand-defined centers or anchors, it lets selected occupied voxels predict boxes directly. Sparse max pooling replaces dense heatmap peak extraction, and the predicting voxel can also support tracking association.
+
+The paper tests a stronger claim than sparse backbones: the output interface does not have to become dense merely because earlier detectors did.
+
+## Paper Insights
+
+Extra downsampling stages enlarge the sparse receptive field without filling the grid. Feature-magnitude pruning removes up to half of selected voxels with little validation loss in the reported setting. Sparse height compression then combines a 3D backbone with a 2D sparse head, retaining vertical reasoning early while avoiding an expensive 3D prediction stage.
+
+On nuScenes test, VoxelNeXt reports 64.5 mAP and 70.0 NDS at 66 ms; its double-flip variant reaches 66.2 mAP and 71.4 NDS. On tracking, the corresponding variants report 69.5 and 71.0 AMOTA. A controlled quarter-data comparison against CenterPoint improves mAP by 0.9 and NDS by 1.0.
+
+| Property | Reported evidence | Design consequence |
+| --- | --- | --- |
+| Direct voxel prediction | Most predicting voxels are not near box centers | A center proxy is convenient, not required. |
+| Spatial pruning | Up to 50% pruning has little reported decay | Sparse capacity can be allocated by learned feature strength. |
+| Postprocessing | Sparse max pool reaches 56.2 mAP without NMS | Peak selection can remain on the active set. |
+| Systems cost | 38.7G FLOPs versus CenterPoint's 186.6G | Wall-clock improvement is much smaller than the FLOP ratio. |
+
+The authors explicitly identify that final mismatch as a limitation: sparse operations depend heavily on implementation and hardware. Direct voxel predictions can also come from outside the box, which makes their provenance less geometrically intuitive than center-based detections.
+
+## Decision Lens
+
+VoxelNeXt informs whether a sparse LiDAR stack should densify for detection and tracking. Its atomic unit remains the occupied voxel from input through output. The expensive architectural decision is the sparse runtime itself: coordinate maps, pruning, pooling, and gathers must all remain efficient on the deployed accelerator.
+
+A matched rejection test compares VoxelNeXt and CenterPoint with equal backbone capacity, range, voxel resolution, and compiler effort. The fully sparse head loses if dense heatmaps give better small-object recall or comparable latency, or if pruning destabilizes degraded and crowded scenes. At larger range, the active voxel count and sparse-kernel memory traffic become the likely limits.
+
+**Context:** SECOND makes the 3D backbone sparse; CenterPoint densifies into BEV for prediction. VoxelNeXt removes that final dense proxy and links the predicting voxel to tracking.
+
+**Takeaway:** A sparse backbone is only half a sparse detector; VoxelNeXt asks the prediction head and tracker to operate on the active set too.


### PR DESCRIPTION
## What changed
- rewrote the autonomous-driving perception survey into a concise mechanism-first guide
- added 14 source-grounded Arxiv Notes covering sparse LiDAR, camera geometry, fusion, temporal modeling, depth completion, and pretraining
- linked each new note from the relevant technical section

## Why
The previous survey repeated its thesis and mixed implementation guidance with speculative sections. This version keeps the concrete architecture and training decisions readers can use.

## Validation
- git diff --check
- npm run ci
- desktop and 390 px rendered QA
- verified images, math, tables, internal routes, and clean browser console