### PR TITLE
Add unified perception architecture graphic

### DIFF
--- a/public/assets/images/autonomous-driving-perception-system.svg
+++ b/public/assets/images/autonomous-driving-perception-system.svg
@@ -1,0 +1,157 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
+  <title id="title">High-level autonomous-driving perception architecture</title>
+  <desc id="desc">Camera, LiDAR, and radar pass through sensor-specific encoders into metric fusion. The shared scene state contains dense BEV and sparse queries, which feed detection, occupancy, mapping, and planning. LiDAR, future frames, and teacher models can provide training-only supervision.</desc>
+
+  <defs>
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 10 5 0 10Z" fill="#2f67d8"/>
+    </marker>
+    <marker id="arrow-teal" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 10 5 0 10Z" fill="#0b8f8a"/>
+    </marker>
+    <marker id="arrow-amber" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 10 5 0 10Z" fill="#bd741e"/>
+    </marker>
+    <pattern id="grid" width="18" height="18" patternUnits="userSpaceOnUse">
+      <path d="M18 0H0V18" fill="none" stroke="#91afe8" stroke-width="1"/>
+    </pattern>
+    <style>
+      text { font-family: Inter, "Avenir Next", Arial, sans-serif; fill: #17202b; }
+      .title { font-size: 34px; font-weight: 700; letter-spacing: -0.6px; }
+      .kicker { font-size: 16px; font-weight: 700; letter-spacing: 1.8px; fill: #66717f; }
+      .label { font-size: 22px; font-weight: 680; }
+      .runtime { fill: none; stroke: #2f67d8; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow-blue); }
+      .runtime-line { fill: none; stroke: #2f67d8; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; }
+      .memory { fill: none; stroke: #0b8f8a; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow-teal); }
+      .training { fill: none; stroke: #bd741e; stroke-width: 2.5; stroke-dasharray: 9 8; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow-amber); }
+      .blue-icon { fill: none; stroke: #2f67d8; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; }
+      .teal-icon { fill: none; stroke: #0b8f8a; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="1600" height="760" fill="#fbfbf8"/>
+  <text x="56" y="60" class="title">Unified perception system</text>
+  <line x1="56" y1="90" x2="1544" y2="90" stroke="#d7dce2" stroke-width="1.5"/>
+
+  <text x="56" y="132" class="kicker">SENSORS</text>
+  <text x="352" y="132" class="kicker">ENCODERS</text>
+  <text x="708" y="132" class="kicker">GEOMETRY</text>
+  <text x="1012" y="132" class="kicker">SCENE STATE</text>
+  <text x="1350" y="132" class="kicker">OUTPUTS</text>
+
+  <!-- Sensors -->
+  <g>
+    <rect x="56" y="166" width="220" height="104" rx="12" fill="#ffffff" stroke="#cbd2da" stroke-width="1.5"/>
+    <g transform="translate(80 193)">
+      <rect x="0" y="7" width="46" height="32" rx="5" class="blue-icon"/>
+      <circle cx="23" cy="23" r="9" class="blue-icon"/>
+      <path d="M46 14 59 9V37L46 32" class="blue-icon"/>
+    </g>
+    <text x="160" y="226" class="label">Camera</text>
+
+    <rect x="56" y="310" width="220" height="104" rx="12" fill="#ffffff" stroke="#cbd2da" stroke-width="1.5"/>
+    <g transform="translate(80 329)">
+      <rect x="14" y="31" width="40" height="22" rx="4" class="blue-icon"/>
+      <path d="M34 31V13M21 23Q34 9 47 23M11 16Q34-6 57 16" class="blue-icon"/>
+      <circle cx="34" cy="42" r="3" fill="#2f67d8"/>
+    </g>
+    <text x="160" y="370" class="label">LiDAR</text>
+
+    <rect x="56" y="454" width="220" height="104" rx="12" fill="#ffffff" stroke="#cbd2da" stroke-width="1.5"/>
+    <g transform="translate(84 477)">
+      <circle cx="15" cy="25" r="7" class="blue-icon"/>
+      <path d="M26 14Q39 25 26 36M35 7Q57 25 35 43M45 0Q74 25 45 50" class="blue-icon"/>
+    </g>
+    <text x="160" y="514" class="label">Radar</text>
+  </g>
+
+  <!-- Sensor-specific encoders -->
+  <rect x="352" y="166" width="260" height="392" rx="14" fill="#f4f7fd" stroke="#8eace4" stroke-width="1.5"/>
+  <text x="386" y="208" class="label">Sensor-specific</text>
+  <text x="386" y="236" class="label">encoders</text>
+  <line x1="376" y1="270" x2="588" y2="270" stroke="#c3d1ea" stroke-width="1.5"/>
+  <line x1="376" y1="414" x2="588" y2="414" stroke="#c3d1ea" stroke-width="1.5"/>
+  <g transform="translate(405 306)">
+    <rect width="48" height="48" rx="5" class="blue-icon"/>
+    <path d="M9 13H39M9 24H39M9 35H39" class="blue-icon"/>
+    <rect x="76" y="0" width="48" height="48" rx="5" class="blue-icon" opacity=".55"/>
+    <path d="M85 13H115M85 24H115M85 35H115" class="blue-icon" opacity=".55"/>
+  </g>
+  <g transform="translate(413 458)" fill="#2f67d8">
+    <rect x="0" y="0" width="13" height="13"/><rect x="23" y="7" width="13" height="13"/><rect x="47" y="0" width="13" height="13"/>
+    <rect x="8" y="28" width="13" height="13"/><rect x="34" y="35" width="13" height="13"/><rect x="67" y="23" width="13" height="13"/>
+  </g>
+  <path d="M522 462 540 492 559 465 578 500" class="blue-icon"/>
+
+  <path d="M276 218H324V334H352" class="runtime"/>
+  <path d="M276 362H352" class="runtime"/>
+  <path d="M276 506H324V390H352" class="runtime"/>
+
+  <!-- Metric fusion -->
+  <rect x="708" y="254" width="220" height="216" rx="14" fill="#ffffff" stroke="#17202b" stroke-width="2"/>
+  <g transform="translate(770 288)">
+    <path d="M0 68V0M0 68H68M0 68 48 20" class="blue-icon"/>
+    <circle cx="0" cy="68" r="5" fill="#2f67d8"/>
+    <path d="m47 20-2 12 12-4" class="blue-icon"/>
+  </g>
+  <text x="751" y="422" class="label">Metric fusion</text>
+  <path d="M612 362H708" class="runtime"/>
+
+  <!-- Persistent scene state -->
+  <rect x="1012" y="166" width="258" height="392" rx="14" fill="#ffffff" stroke="#17202b" stroke-width="2"/>
+  <rect x="1038" y="196" width="206" height="144" rx="10" fill="#edf3ff" stroke="#7298df" stroke-width="1.5"/>
+  <rect x="1062" y="222" width="68" height="68" rx="5" fill="url(#grid)" stroke="#2f67d8" stroke-width="2"/>
+  <rect x="1084" y="244" width="24" height="24" rx="3" fill="#2f67d8" opacity=".82"/>
+  <text x="1150" y="265" class="label">Dense</text>
+  <text x="1150" y="293" class="label">BEV</text>
+
+  <rect x="1038" y="376" width="206" height="152" rx="10" fill="#edf8f6" stroke="#63aaa6" stroke-width="1.5"/>
+  <g transform="translate(1060 413)">
+    <path d="M8 8 49 22 19 58 63 64" class="teal-icon"/>
+    <circle cx="8" cy="8" r="7" fill="#fbfbf8" stroke="#0b8f8a" stroke-width="3"/>
+    <circle cx="49" cy="22" r="7" fill="#fbfbf8" stroke="#0b8f8a" stroke-width="3"/>
+    <circle cx="19" cy="58" r="7" fill="#fbfbf8" stroke="#0b8f8a" stroke-width="3"/>
+    <circle cx="63" cy="64" r="7" fill="#fbfbf8" stroke="#0b8f8a" stroke-width="3"/>
+  </g>
+  <text x="1150" y="445" class="label">Sparse</text>
+  <text x="1150" y="473" class="label">queries</text>
+
+  <path d="M928 362H976V268H1038" class="runtime"/>
+  <path d="M976 362V452H1038" class="memory"/>
+  <circle cx="976" cy="362" r="5" fill="#2f67d8"/>
+
+  <!-- Outputs -->
+  <path d="M1244 268H1310V218H1344" class="runtime"/>
+  <path d="M1244 268H1310V314H1344" class="runtime"/>
+  <path d="M1244 268H1310V410H1344" class="runtime"/>
+  <path d="M1244 452H1310V506H1344" class="memory"/>
+
+  <g>
+    <circle cx="1378" cy="218" r="32" fill="#ffffff" stroke="#2f67d8" stroke-width="2"/>
+    <path d="M1365 208H1390V227H1365ZM1369 204 1394 210V230" class="blue-icon"/>
+    <text x="1426" y="225" class="label">Detect</text>
+
+    <circle cx="1378" cy="314" r="32" fill="#ffffff" stroke="#2f67d8" stroke-width="2"/>
+    <g transform="translate(1362 298)" fill="#2f67d8">
+      <rect width="9" height="9"/><rect x="12" width="9" height="9" opacity=".35"/><rect x="24" width="9" height="9"/>
+      <rect y="12" width="9" height="9" opacity=".35"/><rect x="12" y="12" width="9" height="9"/><rect x="24" y="12" width="9" height="9" opacity=".35"/>
+      <rect y="24" width="9" height="9"/><rect x="12" y="24" width="9" height="9" opacity=".35"/><rect x="24" y="24" width="9" height="9"/>
+    </g>
+    <text x="1426" y="321" class="label">Occupancy</text>
+
+    <circle cx="1378" cy="410" r="32" fill="#ffffff" stroke="#2f67d8" stroke-width="2"/>
+    <path d="M1362 428Q1371 408 1367 391M1394 428Q1385 408 1389 391M1378 425V394" class="blue-icon"/>
+    <text x="1426" y="417" class="label">Map</text>
+
+    <circle cx="1378" cy="506" r="32" fill="#ffffff" stroke="#0b8f8a" stroke-width="2"/>
+    <path d="M1360 516C1366 491 1379 524 1396 486M1387 490l9-4-1 10" class="teal-icon"/>
+    <text x="1426" y="513" class="label">Plan</text>
+  </g>
+
+  <!-- Training-only inputs -->
+  <line x1="56" y1="614" x2="1544" y2="614" stroke="#d7dce2" stroke-width="1.5"/>
+  <text x="56" y="665" class="kicker" fill="#9a631f">TRAINING ONLY</text>
+  <rect x="226" y="636" width="400" height="58" rx="29" fill="#fff7ea" stroke="#bd741e" stroke-width="1.5"/>
+  <text x="264" y="673" class="label" fill="#8b571a">LiDAR • future frames • teacher</text>
+  <path d="M626 665H818V470" class="training"/>
+</svg>

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -22,14 +22,12 @@ The same principle applies to tasks and time. Detection, occupancy, lanes, veloc
 
 This post explains those design choices and links each mechanism to an individual paper note.
 
-## The system in one table
+## The system in one graphic
 
-| Stage | Representation | Share | Keep specialized |
-| --- | --- | --- | --- |
-| Sensor encoding | Camera pyramids, LiDAR voxels, radar points or pillars | Backbone weights only when the input statistics match | Tokenization, calibration, timing, uncertainty |
-| Geometry | Dense BEV cells or sparse 3D queries | Vehicle-frame coordinates and cross-view reasoning | Height-sensitive and sensor-native side paths |
-| Temporal state | Short dense scene memory plus long sparse instance memory | Ego-motion compensation and interaction | Query birth, death, confidence, and task history |
-| Outputs | Detection, occupancy, lanes, velocity, tracking | Expensive upstream features | Resolution, decoder, loss units, safety thresholds |
+At runtime, sensor-specific encoders feed metric fusion, persistent scene state, and task-specific outputs. The dashed path exists only during training.
+
+[![Unified autonomous-driving perception system with sensor-specific encoders, shared metric geometry, dense and sparse temporal memory, task heads, and training-only supervision](/assets/images/autonomous-driving-perception-system.svg)](/assets/images/autonomous-driving-perception-system.svg)
+_A high-level architecture synthesized from the linked literature._
 
 The rest of the architecture follows from four questions: what measurement must survive the encoder, where it becomes metric, what state persists through time, and which tasks can safely update the same parameters.
 
@@ -68,6 +66,8 @@ A dense BEV grid is useful because detection, occupancy, lanes, maps, and free s
 
 Query-based models avoid materializing every cell. [DETR3D](/paper%20shorts/2021/10/14/detr3d-multiview-images-via-3d-to-2d-queries.html) projects 3D object queries into multiscale image features. [PETR](/paper%20shorts/2022/03/10/petr-position-embedding-transformation-for-multiview-3d-object-detection.html) embeds possible 3D coordinates into perspective features before attention. [PETRv2](/paper%20shorts/2022/06/02/petrv2-unified-3d-perception-from-multicamera-images.html) aligns those features over time and gives detection, lanes, and segmentation different query geometries. [BEVFormer](/paper%20shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html) sits between the two approaches: it stores a dense field of learned BEV queries but retrieves evidence through projected attention.
 
+These methods place the irreversible step in different locations. LSS and BEVDepth assign image evidence to depth bins before BEV pooling; a wrong bin becomes a wrong cell. DETR3D and Sparse4D leave features in perspective space and use calibrated 3D queries to retrieve them, so geometric compute scales with queries and sampled points rather than BEV area—but evidence outside that support is never seen. BEVFormer pays for a dense metric state while keeping image retrieval sparse. The representation choice therefore determines both the compute term and where evidence can disappear.
+
 The choice should follow the output:
 
 | Representation | Best suited to | Main cost | Main failure |
@@ -92,6 +92,8 @@ Sensor fusion differs mainly in where correspondence is imposed.
 _BEVFusion specializes tokenization, shares metric scene processing, and separates the output heads. Source: [BEVFusion](/paper%20shorts/2022/05/26/bevfusion-multi-task-multi-sensor-unified-bev.html), Figure 2._
 
 There is no single best fusion layer. Use point fusion when the association is reliable and the output follows points, query fusion for actors, and BEV fusion for dense scene structure. Keep a sensor-native path when downstream tasks still need precise appearance, height, Doppler, or uncertainty.
+
+A fused model is not automatically a fallback model. [UniBEV](/paper%20shorts/2023/09/25/unibev-robust-multimodal-detection-with-uniform-bev-encoders.html) reports only 3.0 camera-only mAP when training always includes both sensors, versus 35.0 when modality dropout exposes the same network to missing-input modes and fusion is normalized over the streams that remain. [MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html) similarly lets BEV queries select whichever modality is available. [Grace-BEV](/paper%20shorts/2026/05/29/grace-bev-graceful-degradation-under-sensor-failures.html) handles the harder case in which a stream is present but unreliable. Sensor availability and health must condition fusion; replacing a failed sensor with zeros is not a calibrated fallback.
 
 ## Multi-task learning: share the trunk, control the gradients
 
@@ -149,12 +151,14 @@ Dense memory preserves roads, free space, background, and weak evidence that has
 
 [Sparse4D](/paper%20shorts/2022/11/19/sparse4d-multiview-3d-detection-with-sparse-spatiotemporal-fusion.html) represents actors as 3D anchors. Each anchor predicts keypoints, projects them into cameras and timestamps, samples nearby image features, and refines the object state. Fusion cost moves from every BEV cell toward a bounded number of hypotheses.
 
-[Sparse4D v2](/paper%20shorts/2023/05/23/sparse4dv2-recurrent-temporal-fusion-with-sparse-model.html) transforms previous instances into the current frame and reserves new anchors for births, so decoder cost no longer grows with nominal history length. [Sparse4D v3](/paper%20shorts/2023/11/20/sparse4dv3-end-to-end-3d-detection-and-tracking.html) adds temporal denoising, quality estimation, and recurrent tracking state. [StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html) stores a FIFO memory of high-confidence object queries, transforms their reference points with ego pose, and lets current queries attend to the compact history. [SparseBEV](/paper%20shorts/2023/08/18/sparsebev-high-performance-sparse-3d-object-detection.html) uses pillar queries that learn support points across cameras and timestamps without storing a dense BEV tensor.
+[Sparse4D v2](/paper%20shorts/2023/05/23/sparse4dv2-recurrent-temporal-fusion-with-sparse-model.html) transforms previous instances into the current frame and reserves new anchors for births. Only the prior sparse state crosses the frame boundary, reducing temporal decoder scaling from $O(T)$ to $O(1)$ in history length. [Sparse4D v3](/paper%20shorts/2023/11/20/sparse4dv3-end-to-end-3d-detection-and-tracking.html) adds temporal denoising and separate box-quality estimation so propagated queries learn to recover geometric error instead of treating class confidence as localization quality.
+
+[StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html) keeps a FIFO memory of top foreground queries, transforms their reference points with ego pose, and discards background queries. [SparseBEV](/paper%20shorts/2023/08/18/sparsebev-high-performance-sparse-3d-object-detection.html) instead reopens several timestamps through learned support points, so its retrieval cost still grows with the number of frames. Both are called sparse, but one compresses history into recurrent state while the other sparsifies access to stored observations.
 
 ![Figure 3 from StreamPETR, showing object queries propagated through a temporal memory queue](/assets/images/streampetr-paper-figure-3.png)
 _StreamPETR carries selected object state instead of a sequence of full scene grids. Source: [StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html), Figure 3._
 
-Sparse memory is cheaper only after hypotheses exist. It can miss a new actor, evict a low-confidence hazard, or preserve a stale track. A production design therefore needs explicit query birth, death, age, confidence, and re-observation rules.
+Sparse recurrence makes a missing frame computationally cheap, not semantically harmless. The model can continue from memory, but an unobserved actor state becomes stale while discarded background evidence cannot be recovered until a fresh query is born. A deployed state therefore needs age, observation freshness, confidence, birth, and reset rules; the papers establish learned recurrence, not a complete fallback policy.
 
 The useful default is hybrid: short dense memory for road structure, free space, and query birth; longer sparse memory for actors and vectorized map elements. [SparseDrive](/paper%20shorts/2024/05/30/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.html) extends this object-and-map state into motion prediction and planning.
 
@@ -183,7 +187,7 @@ Image-classification pretraining teaches appearance but not calibration, cross-v
 | Future occupancy or point clouds | Motion and persistence | A single future cannot represent every valid outcome |
 | Teacher features and pseudo-labels | Task-specific abstractions | Inherits teacher errors and blind spots |
 
-Scale should be measured in scenario diversity and useful temporal transitions, not only frame count. Repeated highway frames add less supervision than intersections, rare actors, adverse weather, calibration variation, and recoveries after occlusion. The strongest evidence for a pretrained representation is transfer across several tasks and label budgets, not a gain on one detector configuration.
+Longer pretraining targets are not automatically better. UniWorld reports that three target frames outperform five; multi-sweep occupancy becomes less reliable as motion, occlusion, pose error, and future ambiguity accumulate. Scale should therefore mean more distinct geometric and temporal situations, with transfer measured across tasks and label budgets, rather than a longer target horizon or a larger count of near-duplicate frames.
 
 ## Practical takeaways
 
@@ -192,8 +196,8 @@ Scale should be measured in scenario diversity and useful temporal transitions, 
 3. Fuse at the output's natural granularity instead of forcing every modality into one tensor.
 4. Share expensive geometry across tasks, but keep task decoders, loss units, and safety thresholds explicit.
 5. Treat loss scale, learning speed, and gradient conflict as different multi-task problems.
-6. Separate training sensors from runtime sensors. LiDAR supervision can improve a camera model without entering its inference graph; depth completion cannot.
-7. Keep short dense temporal state for scene discovery and longer sparse state for tracked entities.
+6. Separate the label-generation graph from runtime, and train every supported sensor configuration explicitly. Privileged LiDAR can supervise camera-only inference; depth completion cannot remove its sparse-depth input.
+7. Keep short dense temporal state for scene discovery and longer sparse state for tracked entities, but age or reset state when observations go missing.
 8. Profile the executed system. Sparse fusion does not remove the cost of camera backbones or irregular memory access.
 9. Pretrain on geometry, correspondence, and future state, then verify transfer across tasks and data regimes.
 


### PR DESCRIPTION
## What changed
- replace the opening architecture table with a clean high-level SVG
- distinguish dense BEV state, sparse query state, and training-only supervision
- add concise paper-grounded insights on geometry loss, missing sensors, temporal state, and pretraining horizons

## Why
The guide needed a scannable system view and sharper answers about persistent state, compute scaling, lost evidence, and degraded sensor or temporal inputs.

## Validation
- xmllint --noout on the SVG
- desktop and 390px mobile overflow checks
- npm run ci (18 tests, 226 pages)