### PR TITLE
Simplify blog titles and headings

### DIFF
--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Attention Mechanisms: A History and Map of Modern Variants'
+title: 'Attention Mechanisms: History and Modern Variants'
 date: '2025-05-25T04:00:00.000Z'
 section: blog
 postSlug: attention-mechanisms-demystified
@@ -14,13 +14,13 @@ summary: >-
 import PythonPlayground from '../../components/PythonPlayground';
 import { attentionMechanismsPlayground } from '../../lib/python-playground-examples';
 
-# Attention Mechanisms: A History and Map of Modern Variants
+# Attention Mechanisms: History and Modern Variants
 
 Attention began as an escape hatch from a fixed-size memory. An encoder-decoder recurrent neural network had to compress a source sentence into a hidden state and ask that state to preserve everything the decoder might need. Attention let each decoding step reach back to the encoder states directly. The Transformer made a larger move in 2017: it removed recurrence from the main sequence path and used attention itself to route information between positions.
 
 The core operation has survived. A query describes the current information need, keys determine which sources match it, and values carry the content returned by those sources. Most later variants do not replace that idea; they change where the keys and values come from, how much of them must be cached, which positions are eligible, or whether the past is stored token by token at all.
 
-## Why attention was invented
+## The encoder-decoder bottleneck
 
 Early sequence-to-sequence translation used one recurrent network to encode the input and another to decode the output. The decoder's next word depended on a compressed summary of the source, so long or information-dense sentences created a bottleneck: the relevant evidence might exist in an earlier encoder state but be poorly preserved in the final one.
 
@@ -47,7 +47,7 @@ The Transformer generalized the same idea. Instead of using attention as an acce
 
 This timeline is a lineage, not a claim that each idea appeared only once. Modern architectures combine branches from several rows.
 
-## The core mechanism: query, match, retrieve
+## Scaled dot-product attention
 
 Vaswani et al. define scaled dot-product attention as
 
@@ -72,7 +72,7 @@ Queries, keys, and values are separate because discoverability and payload are d
 
 The scaling term is not cosmetic. If query and key components are independent with mean zero and variance one, their dot product has variance $d_k$. As the key dimension grows, unscaled logits can push softmax into saturated regions with very small gradients. Dividing by $\sqrt{d_k}$ keeps comparisons trainable instead of making the model prematurely overconfident.
 
-## Self-attention rewrites a token with context
+## Self-attention
 
 In self-attention, one sequence supplies all three roles. For an input matrix $X \in \mathbb{R}^{n \times d_{\text{model}}}$,
 
@@ -106,7 +106,7 @@ In a decoder-only model, a causal mask removes future positions before softmax. 
 
 <PythonPlayground client:visible {...attentionMechanismsPlayground} />
 
-## From the equation to efficient PyTorch
+## Efficient PyTorch implementation
 
 The equations above are useful for reasoning, but a production implementation should not explicitly build the $T\times T$ score matrix, apply softmax, and save the full probability matrix in high-bandwidth memory. PyTorch's [`scaled_dot_product_attention`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention) keeps the same semantics while dispatching to an appropriate backend, including fused attention kernels when the device, dtype, and tensor layout support them.
 
@@ -157,7 +157,7 @@ class CausalSelfAttention(nn.Module):
 
 Three details carry most of the performance. The combined QKV projection reduces kernel launches; the head dimension remains the innermost contiguous dimension; and SDPA avoids a Python-level sequence of matmul, mask, softmax, dropout, and matmul operations. PyTorch selects the backend automatically, so forcing FlashAttention should be a diagnostic or benchmarking choice rather than a default. The dropout argument also requires care: SDPA applies dropout whenever `dropout_p` is nonzero, so evaluation must pass `0.0` explicitly as the module does above.
 
-## The first branches: multiple heads and external memory
+## Multi-head and cross-attention
 
 Multi-head attention repeats the same operation under several learned projections. Each head has its own $W^Q$, $W^K$, and $W^V$, so the layer can represent several routing patterns before concatenating their outputs. Heads do not reliably map to neat human concepts such as “the syntax head,” but parallel projections do let different token relationships coexist.
 
@@ -172,7 +172,7 @@ Cross-attention changes the source rather than the scoring rule. Queries come fr
 
 These labels describe where information comes from and how many projections are used. Modern variants below change different axes, so a model can use causal self-attention, GQA, and sliding windows simultaneously without contradiction.
 
-## Modern variants are responses to different bottlenecks
+## Attention variants by bottleneck
 
 Full multi-head attention stores a key and value for every previous token and every KV head. During prefill, the model computes a logically dense $T\times T$ pattern of token interactions. During cached autoregressive decoding, one new query reads an ever-growing KV cache, so each step scales linearly with the existing context and cache storage also grows with context length. FlashAttention improves how dense attention moves data and avoids materializing the full matrix in slow memory; it does not remove the underlying all-pairs arithmetic of dense prefill.
 
@@ -189,7 +189,7 @@ That cost created several distinct design families:
 
 The table is the map: these methods are not one flat list because they solve different problems.
 
-### MQA and GQA share the KV cache
+### Multi-query and grouped-query attention
 
 Standard MHA gives every query head its own key and value heads. Multi-query attention (MQA) takes the most aggressive sharing choice: all query heads use one K/V set. Grouped-query attention (GQA) lies between MHA and MQA, with groups of query heads sharing K/V projections.
 
@@ -274,7 +274,7 @@ def gqa_decode_step(q, k, v, k_cache, v_cache, position: int):
 
 For `n_query_heads=32` and `n_kv_heads=8`, four query heads share each stored K/V head, so the K/V portion of the cache is one quarter of the corresponding 32-head MHA cache. The decode helper also preallocates and updates that cache rather than calling `torch.cat` every step, which would repeatedly copy the growing prefix. Current PyTorch documentation still labels native GQA support experimental and lists backend constraints; confirm the target device and version instead of silently expanding K/V heads as a fallback.
 
-### MLA compresses instead of sharing
+### Multi-head latent attention
 
 Multi-head latent attention (MLA), introduced with DeepSeek-V2, attacks the same cache bottleneck differently. GQA stores fewer full K/V heads; MLA stores a lower-dimensional latent representation and reconstructs the state needed by attention. This makes MLA a learned cache-compression mechanism embedded inside the layer.
 
@@ -282,7 +282,7 @@ The distinction matters operationally. GQA is relatively simple and widely suppo
 
 DeepSeek-V2's ablations provide one useful but bounded comparison. In that model family, the authors report that their GQA and MQA variants underperformed MHA, while the tuned MLA configuration slightly exceeded MHA with a much smaller cache. That result supports MLA as a viable learned compression scheme; it does not establish that MLA will beat GQA at smaller scales, under a different training recipe, or on hardware without an optimized MLA path.
 
-### Sliding windows and learned sparsity reduce the lookup set
+### Sliding-window and sparse attention
 
 Sliding-window attention (SWA) keeps only a fixed local neighborhood visible in selected layers. It changes the number of positions examined, not the representation stored for each position. Architectures often mix local layers with periodic global layers so information can still travel across a long sequence. SWA also composes naturally with GQA: the window reduces how many tokens a layer reads, while grouping reduces how much K/V state each token contributes.
 
@@ -323,7 +323,7 @@ y = flex_attention(q, k, v, block_mask=block_mask)
 
 The mask function is the policy; the block mask is the execution plan. This separation is what lets a readable four-line causal-window rule become block-sparse work instead of dense attention followed by discarded scores. FlexAttention remains a prototype API, so pin and test the PyTorch version when using it in training or serving code.
 
-### Gated attention controls what enters the residual stream
+### Gated attention
 
 Gated full attention keeps the softmax lookup and adds a query-dependent gate to the retrieved features before the output projection. For one head, the update is
 
@@ -350,7 +350,7 @@ def gated_causal_sdpa(q, k, v, gate_logits, dropout_p=0.0):
 
 Raschka's Qwen example places this output gate alongside zero-centered QK-Norm and partial RoPE. Those two choices alter score normalization and positional encoding; they are useful co-designs, not parts of the definition of gating. Keeping the axes separate explains why an architecture can combine gated full attention with GQA, MLA, or a local window.
 
-### Linear attention turns the past into a recurrent state
+### Linear attention
 
 Linear attention changes the memory representation more radically. Softmax is applied after $QK^\top$, which couples every query to every key. Kernelized linear attention applies a feature map $\phi$ to queries and keys separately, allowing the multiplication to be reassociated. Instead of retaining every K/V pair, the model can update fixed-size running statistics such as
 
@@ -444,7 +444,7 @@ def gated_delta_net_step(q, k, v, state, log_decay, write_logits):
 
 Decode is naturally recurrent; prefill must expose parallel matrix work. Yang et al. derive a mathematically equivalent chunkwise algorithm by representing the cumulative state transitions as products of generalized Householder matrices. Tokens within each chunk become batched matrix operations, while a smaller recurrence carries state between chunks. Chunk size therefore changes the execution schedule and hardware utilization, not the DeltaNet retrieval rule. Their Triton implementation reported increasing speedups over a recurrent kernel as sequence length and head dimension grew, which is why a production prefill path should use a fused chunkwise kernel rather than a Python token loop.
 
-### Hybrid stacks keep an exact retrieval path
+### Hybrid attention stacks
 
 Fixed-size recurrent memory is efficient but necessarily capacity-limited. Modern hybrid architectures therefore use cheap sequence mixers for most layers and periodically restore a full or compressed softmax-attention layer. Qwen-style hybrids combine runs of Gated DeltaNet with gated full attention; other systems substitute Lightning Attention or Mamba-style state-space blocks. Ali's Kimi K3 account gives the ratio a concrete form: 23 four-layer groups, each with three Kimi Delta Attention layers followed by one gated MLA layer.
 
@@ -462,7 +462,7 @@ Attention Residuals changes a different axis: depth rather than token position. 
 
 This is the modern endpoint of the history. The original RNN bottleneck motivated direct retrieval from an explicit sequence; current long-context systems reintroduce compressed recurrent memory for efficiency, then retain selective attention layers because exact retrieval still matters.
 
-### Reported evidence does not settle the architecture choice
+### Evidence and comparison limits
 
 The most useful empirical results compare one mechanism against a nearby alternative inside the same training recipe. They should not be read as a universal leaderboard across attention families.
 
@@ -475,7 +475,7 @@ The most useful empirical results compare one mechanism against a nearby alterna
 
 Raschka's larger caveat is the right one: there is still no single matched-data, matched-compute study that trains GQA, MLA, sparse attention, gated attention, recurrent memory, and their hybrids under one controlled recipe. Kernel maturity also changes observed throughput. A theoretically cheaper hybrid can lose to conventional GQA on a local system if its recurrent or latent-attention path lacks an optimized kernel.
 
-## What changed, and what stayed the same
+## What attention variants change
 
 Attention still answers one question: for this output position, which sources match the current need, and what content should they contribute? The variants differ in where they pay for that answer.
 

--- a/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
+++ b/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
@@ -1,5 +1,5 @@
 ---
-title: 'From PPO to GRPO: RL for Reasoning and Vision-Language-Action Models'
+title: 'Reinforcement Learning for Reasoning and Vision-Language-Action Models'
 date: '2026-07-27T16:00:00.000Z'
 section: blog
 postSlug: from-ppo-to-grpo-rl-for-reasoning-and-vlas
@@ -11,7 +11,7 @@ tags:
 summary: 'How policy optimization evolved from PPO critics to offline preferences, group-relative rewards, and on-policy distillation—and which pieces survive contact with physical action.'
 ---
 
-# From PPO to GRPO: RL for Reasoning and Vision-Language-Action Models
+# Reinforcement Learning for Reasoning and Vision-Language-Action Models
 
 Reinforcement learning for language models can look like a parade of acronyms. PPO adds a critic and clips updates. DPO removes the online loop. GRPO removes the critic and compares samples. On-policy distillation brings a teacher back. For vision-language-action models, the same names reappear beside diffusion policies, sparse success rewards, simulators, and robot rollouts.
 
@@ -23,7 +23,7 @@ This essay follows that question from PPO through verifiable-reward reasoning an
 
 The evidence cutoff is July 27, 2026. PPO, DPO, DeepSeekMath/GRPO, GKD, DeepSeek-R1, and the early VLA-RL systems are reported evidence. The final hybrid design is synthesis: a falsifiable proposal, not a result already established across robots.
 
-## One equation contains the whole argument
+## The policy-gradient objective
 
 For a trajectory $\tau=(s_0,a_0,\ldots,s_T)$ sampled from policy $\pi_\theta$, a policy-gradient update has the form
 
@@ -48,7 +48,7 @@ The score-function term says which behavior becomes more likely. The advantage $
 
 This frame also separates two ideas that are routinely conflated. **On-policy** describes where training states come from: the current learner. **Reinforcement learning** describes how future reward weights an action's log-probability. A student can generate its own prefixes and receive teacher-token supervision there; that is on-policy distillation, even though no reward or policy gradient is required.
 
-## PPO: learn the baseline, constrain the reuse
+## PPO: Value baselines and clipped updates
 
 [Proximal Policy Optimization](/paper%20shorts/2017/07/01/proximal-policy-optimization-ppo.html) made actor-critic policy gradients operationally simple. The actor collects trajectories under $\pi_{\mathrm{old}}$. A value network estimates expected future return, and Generalized Advantage Estimation turns temporal-difference residuals into lower-variance $\hat A_t$. The actor then reuses the rollout for several minibatch epochs under a clipped surrogate:
 
@@ -71,7 +71,7 @@ That compromise fit early RLHF. A language model supplies tractable token log-pr
 
 PPO therefore established the durable skeleton—online sampling, relative probability updates, and reference control—while making the value model the obvious component to challenge.
 
-## DPO is an offline branch, not the next rung
+## DPO: Offline preference optimization
 
 [Direct Preference Optimization](/paper%20shorts/2023/05/01/direct-preference-optimization-dpo.html) is often placed between PPO and GRPO as if it were a newer policy-gradient algorithm. It changes the problem more radically. DPO assumes the evidence already arrives as fixed pairs: for prompt $x$, response $y_w$ is preferred to $y_l$. Under a Bradley–Terry preference model and KL-regularized reward optimum, the implicit reward can be expressed through policy-to-reference log-ratios. The training objective becomes
 
@@ -91,7 +91,7 @@ DPO belongs in the evolution because it clarified what online RL was buying. If 
 
 For VLAs, the “matched” condition is particularly fragile. Two text answers can share the same prompt. Two physical trajectories rarely share exactly the same camera pose, friction, object state, and intervention history. An apparent preference can encode an environment difference rather than an action difference. DPO remains useful for replayable simulations, local action alternatives from the same logged state, or carefully constructed intervention windows. It is not a generic conversion from “one robot rollout succeeded” and “another failed” into a clean preference pair.
 
-## GRPO: replace the critic with the other samples
+## GRPO: Group-relative baselines
 
 [DeepSeekMath](/paper%20shorts/2024/02/05/deepseekmath-group-relative-policy-optimization-grpo.html) makes a different trade. For each question, the current policy samples $G$ answers. An exact or learned verifier produces rewards $r_1,\ldots,r_G$, and GRPO normalizes them within that question:
 
@@ -116,7 +116,7 @@ Math and code fit unusually well. A sampler can produce eight solutions without 
 
 GRPO removes a model, not the need for a baseline. The group is the baseline, which makes group composition part of optimization.
 
-## The zero-gradient batch is GRPO's native failure
+## GRPO's zero-gradient failure
 
 If all sampled answers are correct, every normalized reward is zero. If all are wrong, the same thing happens. Easy and impossible questions consume generation without supplying a gradient. Near-zero variance also makes normalization noisy. A fixed prompt distribution therefore becomes progressively inefficient as the policy improves.
 
@@ -128,7 +128,7 @@ A second failure is temporal credit. Under outcome supervision, the same $\hat A
 
 Process rewards can address that, but they move difficulty into the verifier. A process critic must distinguish a recoverable detour from an invalid step, remain calibrated on current-policy traces, and resist optimization. The value model disappeared; a trustworthy process model can quietly reintroduce equivalent complexity.
 
-## On-policy distillation: keep the learner's states, replace the scalar
+## On-policy distillation
 
 [On-Policy Distillation of Language Models](/paper%20shorts/2023/06/23/on-policy-distillation-language-models-gkd.html) attacks the same credit problem from another direction. Generalized Knowledge Distillation samples prefixes from the student and asks a teacher for the full next-token distribution on those prefixes. The student minimizes a divergence such as forward KL, reverse KL, or Jensen–Shannon:
 
@@ -156,7 +156,7 @@ Distillation and RL optimize different evidence:
 
 That hybrid has become more relevant as reasoning policies improve. [Self-Supervised On-Policy Distillation for Reasoning LMs](https://arxiv.org/abs/2605.17497) uses the correct answers inside mixed GRPO groups as teachers for incorrect answers, extracting dense supervision from rollouts that would otherwise provide only a binary contrast. The 2026 paper reports a 65.6 macro Avg@12 for Qwen3-8B, 1.6 points above its GRPO baseline. This is frontier evidence, not yet a settled recipe, but it reveals the direction: reuse on-policy computation to manufacture denser, state-matched targets.
 
-## The methods are distinguished by evidence, not fashion
+## Comparing feedback and estimation methods
 
 | Method | Training states | Feedback unit | Baseline or anchor | Main cost | Native blind spot |
 | --- | --- | --- | --- | --- | --- |
@@ -168,33 +168,33 @@ That hybrid has become more relevant as reasoning policies improve. [Self-Superv
 
 The table prevents a common category error. DPO is not “GRPO but offline,” because its pairwise reference-relative margin encodes a different statistical object. On-policy distillation is not “RL with soft rewards,” because teacher logits supervise local action distributions without estimating future return. PPO and GRPO are closest: both weight policy ratios with advantages, but they construct the baseline differently.
 
-## Physical action breaks the reasoning assumptions
+## Why VLA policies need different assumptions
 
 Transferring these estimators to a VLA requires more than replacing “token” with “action.” Three assumptions change at once.
 
-### Resets are no longer free
+### Environment resets
 
 A math question can be sampled eight times from exactly the same prompt. A robot rollout changes the world. Resetting a deformable object, spill, drawer, or cluttered scene can require human labor and may not recreate the same state. Group-relative advantages are defensible only when rollouts are exchangeable enough that reward differences mostly reflect the policy.
 
 Simulation restores cheap resets, but creates a new estimator boundary: an advantage can be accurate for the simulator and wrong for reality. The important budget is not episodes; it is independent, correctly reset, deployment-relevant state transitions per robot-hour.
 
-### Action likelihood may be a model, not one number
+### Continuous-action likelihoods
 
 Autoregressive action tokens expose $\log\pi(a_t\mid s_t)$ directly. Modern VLAs often produce continuous chunks through diffusion or flow matching. A naïve PPO ratio over the final action ignores the stochastic denoising trajectory that generated it.
 
 [DPPO](https://arxiv.org/abs/2409.00588) treats denoising as an augmented Markov decision process and applies policy optimization to the diffusion policy's actual stochastic transitions. This is more than an implementation detail. If the likelihood ratio does not correspond to the deployed sampler, clipping controls the wrong distribution.
 
-### Terminal success is even farther from the action
+### Long-horizon credit assignment
 
 Copying one answer reward across 1,000 reasoning tokens is noisy. Copying one success bit across a long robot trajectory also confounds perception, planning, contact, controller latency, and environment dynamics. An early grasp may be correct even if the final placement fails; a bad approach may succeed because the gripper catches by chance.
 
 VLA post-training therefore needs a feedback unit between token and episode: action chunk, skill segment, state transition, or critic-estimated progress. That unit must remain replayable or observable enough to compare alternatives. Otherwise denser reward only creates denser confidence, not better credit.
 
-## The VLA branch is evolving along the same estimator axis
+## VLA reinforcement-learning methods
 
 The early VLA-RL literature can be organized by what replaces the critic and where high-quality trajectories come from.
 
-### Direct policy optimization when the environment is cheap
+### Direct policy optimization in simulation
 
 DPPO is the clean direct-RL branch for diffusion actors: retain online interaction, model the correct action likelihood, and optimize reward. [RIPT-VLA](https://arxiv.org/abs/2505.17016) shows a critic-free alternative for autoregressive VLAs. It uses sparse binary success, dynamic rollout sampling, and leave-one-out relative advantages. The paper reports a 21.2-point gain for QueST and 97.5% for an OpenVLA-OFT setup; in a one-demonstration case, it reports improvement from 4% to 97% within 15 iterations.
 
@@ -202,19 +202,19 @@ Those numbers are striking because the environment supplies cheap, repeated comp
 
 [SimpleVLA-RL](https://arxiv.org/abs/2509.09674) pushes the same systems direction on LIBERO and RoboTwin: scale parallel rollouts, filter uninformative groups, and make the policy update compatible with the VLA's action interface. As in reasoning, the optimizer's name hides the rollout scheduler.
 
-### Use RL to generate data when moving the generalist is risky
+### RL-generated training data
 
 [RLDG](https://arxiv.org/abs/2412.09858) trains task-specific RL specialists and distills their trajectories into a general robot policy. The source paper reports up to 40% higher success than human-demonstration training in its evaluated settings. The architectural lesson is broader than the number: RL can improve the state distribution without directly exposing a shared foundation model to every unstable reward update.
 
 This resembles on-policy distillation at a different boundary. A specialist visits difficult states and discovers successful behavior; the generalist learns from the resulting trajectories with supervised objectives. The teacher may be a policy, planner, privileged simulator agent, or previous checkpoint. Direct RL spends less storage and can adapt rapidly; RL-generated-data pipelines make updates reviewable, replayable, and easier to mix across embodiments.
 
-### Add process structure when one bit is too weak
+### Process rewards
 
 The frontier is moving toward intermediate feedback. [LifeLong-RFT](https://arxiv.org/abs/2602.10503) reports chunk-level on-policy RL and a multidimensional process reward, with a 22% average success gain over SFT while using 20% of the data in its evaluated suite. [RobustVLA](https://arxiv.org/abs/2511.01331) adds observation-sensitivity and action-smoothness regularization so reward improvement does not purchase brittle control. [VLA-RFT](https://arxiv.org/abs/2510.00406) uses a world simulator and verified rewards to reduce dependence on physical rollouts.
 
 These systems are recent and heterogeneous. Their reward definitions, simulators, embodiments, action heads, and evaluation protocols differ, so their headline gains should not be ranked as if they were optimizer ablations. What they collectively support is narrower: VLA RL is becoming a joint design of rollout distribution, feedback granularity, and action likelihood.
 
-## Choose the estimator from the cheapest honest comparison
+## Choosing an estimator
 
 The method decision can be made without starting from an acronym:
 
@@ -229,7 +229,7 @@ The method decision can be made without starting from an acronym:
 
 The last row is deliberately conservative. “On-policy” does not make evidence causal. If two robot episodes cannot be matched well enough for their reward difference to identify a policy decision, a relative advantage is numerically valid and scientifically weak.
 
-## A hybrid hypothesis for reasoning and VLAs
+## A hybrid training hypothesis
 
 The evolution suggests a shared endpoint: sparse external reward should select outcomes, while dense on-policy supervision should repair the trajectory states that produced them.
 
@@ -246,7 +246,7 @@ This hypothesis is falsifiable. Compare four methods under identical model initi
 
 Report success and safety, but also zero-variance group rate, critic/teacher calls, policy KL, action entropy, recovery success, real robot-hours, and performance after the teacher or simulator distribution shifts. The hybrid earns its complexity only if it improves reliable success per unit of interaction—not merely final reward after consuming more rollouts and teacher inference.
 
-## The evolution is a change in where learning gets its contrast
+## Where each method gets its learning signal
 
 PPO learns a critic so each action can be compared with expected return. DPO assumes the contrast has already been collected as a chosen/rejected pair. GRPO obtains the contrast from other attempts at the same prompt. On-policy distillation replaces a scalar contrast with a teacher distribution at the learner's own states.
 

--- a/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
+++ b/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
@@ -1,5 +1,5 @@
 ---
-title: 'From Seeing to Acting: A Reading Guide to Vision-Language Models'
+title: 'Vision-Language Models: A Reading Guide'
 date: '2026-07-05T20:00:00.000Z'
 section: blog
 postSlug: from-seeing-to-doing-the-evolution-of-vision-language-models
@@ -10,7 +10,7 @@ tags:
 summary: A reading guide to the interfaces that turned image-text models into grounded visual assistants and, eventually, robot policies.
 ---
 
-# From Seeing to Acting: A Reading Guide to Vision-Language Models
+# Vision-Language Models: A Reading Guide
 
 A model can name the mug, explain that mugs hold liquid, and still drive a gripper into the table beside it. That failure is not surprising once we stop treating “vision-language” as a single capability. Naming an object, grounding it in pixels, estimating its pose, predicting contact, and controlling a wrist are different contracts with different tolerances for lost information.
 
@@ -28,7 +28,7 @@ Do not read every paper with the same question. For alignment papers, identify t
 
 The recurring exercise is simple: draw the path from raw observation to evaluated output, then circle every irreversible compression step. That picture usually explains more than the model name.
 
-## 1. A VLM is an interface, not one architecture
+## 1. VLM architectures and interfaces
 
 “Vision-language model” covers several systems with different outputs:
 
@@ -46,7 +46,7 @@ The shared implementation pattern is simple. An image is converted into visual t
 
 The loss is the contract. Architecture matters because it determines what evidence remains available to satisfy that contract.
 
-## 2. Language replaced the fixed label set
+## 2. Open-vocabulary image-text alignment
 
 Before large-scale image-text pretraining, a vision classifier typically learned a closed vocabulary. Its final layer represented the categories chosen by the dataset designer. Adding a new class meant collecting labels and training again.
 
@@ -69,7 +69,7 @@ The tradeoff sits inside the objective. Batch-softmax contrastive learning treat
 
 What retrieval pretraining does not provide is equally important. A shared embedding can tell us that an image and sentence belong together without preserving which patch supports which phrase, how objects relate spatially, or how to generate a multi-sentence answer. Global semantic alignment is a strong prior, not a complete visual interface.
 
-## 3. Visual chat turned alignment into conditional generation
+## 3. Visual instruction tuning
 
 [LLaVA](/paper%20shorts/2023/04/01/visual-instruction-tuning-llava.html) made the next transition legible. Start with a pretrained visual encoder and an instruction-tuned language model. Learn a projector that maps visual features into the language model's token space. Then fine-tune on image-instruction-response examples.
 
@@ -89,7 +89,7 @@ This is a recurring pattern in foundation models: a modest interface plus the ri
 
 That result should change experiment allocation. Sweep the variables that determine what evidence enters the language model before polishing the bridge that carries it.
 
-### Instruction tuning teaches behavior, not eyesight
+### Limits of instruction tuning
 
 Visual instruction data solve a behavioral problem: how should the model respond when an image and request arrive together? They do not automatically repair information discarded by the visual encoder or compression scheme.
 
@@ -108,7 +108,7 @@ This distinction explains why modern VLM recipes separate several data roles:
 
 The operational question is no longer “How many multimodal examples do we have?” It is “Which behavior does each dataset teach, and which capability regresses when we increase its weight?”
 
-## 4. Visual tokens became the scarce resource
+## 4. Visual-token efficiency
 
 Text tokenization compresses language into a sequence of discrete symbols. Images do not arrive with an obvious equivalent. A $1024\times1024$ image can be divided into patches, encoded into a smaller feature grid, tiled at several resolutions, or compressed through a learned tokenizer. Every choice trades detail for sequence length: more visual tokens can preserve small objects and text but consume attention, memory, and latency; fewer tokens improve throughput but may create an irreversible perceptual bottleneck.
 
@@ -118,7 +118,7 @@ These systems differ in implementation, but they answer one shared question: **w
 
 A convincing comparison must therefore match more than parameter count. It should report visual tokens, input resolution, training and inference FLOPs, latency, and performance on tasks that isolate small text, counting, localization, and global scene reasoning. Otherwise, a “better architecture” may simply be buying more pixels.
 
-## 5. Grounding is the bridge from words to evidence
+## 5. Visual grounding
 
 A model can answer “the traffic light is red” for at least three reasons: it localized the light and read its state, it used a language prior about the scene, or it guessed from dataset regularities. Standard answer accuracy often fails to distinguish them.
 
@@ -136,7 +136,7 @@ This gives a useful hierarchy for evaluating visual evidence:
 
 The fifth level is the hardest and most revealing. If the answer remains unchanged after the traffic light is masked or its state is edited, the model's explanation was not causally grounded in that evidence.
 
-## 6. Video adds time, but not automatically causality
+## 6. Video and temporal modeling
 
 Video looks like “more images,” yet it changes the representation problem. Adjacent frames are highly redundant, important events can be brief, and the correct sampling rate depends on the question. Uniformly encoding every frame wastes context; aggressive sampling can delete the event.
 
@@ -153,7 +153,7 @@ For video VLMs, I would separate four tests:
 
 The first three measure temporal understanding. The fourth begins to test a model of action-conditioned worlds.
 
-## 7. Driving reveals the gap between an answer and a decision
+## 7. VLMs for autonomous driving
 
 Autonomous driving compresses nearly every VLM weakness into one domain: small distant objects, geometry, rules, rare hazards, temporal prediction, uncertainty, and hard latency limits.
 
@@ -171,7 +171,7 @@ These designs should not be collapsed into “VLMs for driving.” They correspo
 
 My current read is that the strongest near-term use is hybrid. VLMs contribute semantic knowledge, intent understanding, rare-scenario interpretation, and supervision. Metric perception, motion forecasting, safety constraints, and high-rate control retain explicit structure. This is not an argument that end-to-end systems cannot work. It is a statement about evidence: fluent rationales and open-loop trajectory metrics do not yet establish reliable closed-loop control.
 
-## 8. Benchmarks are testing whether the model looked
+## 8. Grounding-aware benchmarks
 
 [DriveBench](/paper%20shorts/2025/01/01/are-vlms-ready-for-autonomous-driving-drivebench.html), [IDKB](/paper%20shorts/2024/09/01/can-lvlms-obtain-a-drivers-license-idkb.html), [TOD3Cap](/paper%20shorts/2024/03/01/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.html), and [AutoTrust](/paper%20shorts/2024/12/01/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.html) attack different versions of the same problem: plausible language can hide weak evidence use.
 
@@ -188,7 +188,7 @@ A benchmark that tests only final-answer agreement can reward memorized priors. 
 
 The practical implication is uncomfortable: a higher aggregate VLM score may be less valuable than a lower score with better calibration and causal grounding. Deployment cares about the shape of failure, not only its average frequency.
 
-## 9. Robotics changes the output space
+## 9. VLMs for robotics
 
 Robotics completes the transition from description to intervention. Once the model emits actions, its outputs change the next observation. Errors compound under the state distribution created by the policy itself.
 
@@ -221,7 +221,7 @@ I use six questions to avoid being carried away by a capability collage.
 
 These questions turn a model paper into a decision record. If the answer to question four is “several things,” then the paper may demonstrate a strong recipe without identifying why it works. That is still useful, but it supports adoption more than causal understanding.
 
-## 11. A reading course, not a bibliography
+## 11. Reading course
 
 The list below is ordered by conceptual dependency. Each layer has a deliverable; without it, “reading the paper” too easily becomes collecting model names.
 

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -22,7 +22,7 @@ The same principle applies to tasks and time. Detection, occupancy, lanes, veloc
 
 This post explains those design choices and links each mechanism to an individual paper note.
 
-## The system in one graphic
+## Perception system overview
 
 At runtime, sensor-specific encoders feed metric fusion, persistent scene state, and task-specific outputs. The dashed path exists only during training.
 
@@ -31,7 +31,7 @@ _A high-level architecture synthesized from the linked literature._
 
 The rest of the architecture follows from four questions: what measurement must survive the encoder, where it becomes metric, what state persists through time, and which tasks can safely update the same parameters.
 
-## Sensor encoders should preserve sensor physics
+## Sensor-specific encoders
 
 ### Camera
 
@@ -62,7 +62,7 @@ Radar is not low-resolution LiDAR. Its useful measurements are range, radial vel
 ![Animation comparing early radar rasterization with attribute-aware radar tokens that retain Doppler and uncertainty](/assets/images/autonomous-perception-radar-encoder.gif)
 _Rasterization keeps where a return landed; attribute-aware tokens can also keep how it moved and how much to trust it. This conceptual animation synthesizes the design pressure behind [CRAFT](/paper%20shorts/2022/09/14/craft-camera-radar-3d-object-detection-with-spatio-contextual-fusion-transformer.html), [CRN](/paper%20shorts/2023/04/03/crn-camera-radar-net-for-3d-perception.html), and [RCBEVDet](/paper%20shorts/2024/03/25/rcbevdet-radar-camera-fusion-in-bev.html)._
 
-## Put the sensors in a common metric frame
+## Shared metric representations
 
 Cameras observe rays; driving tasks reason in meters. The central camera-perception problem is therefore the view transform: where along each ray should an image feature be placed in 3D?
 
@@ -90,7 +90,7 @@ The choice should follow the output:
 
 Many strong systems use more than one representation: dense BEV proposes and describes the scene, while sparse queries carry actors.
 
-## Fuse at the granularity required by the output
+## Fusion granularity
 
 Sensor fusion differs mainly in where correspondence is imposed.
 
@@ -113,7 +113,7 @@ A fused model is not automatically a fallback model. [UniBEV](/paper%20shorts/20
 ![Animation comparing complete-sensor-only training with modality-dropout training and fusion renormalization](/assets/images/autonomous-perception-modality-dropout.gif)
 _The left model sees only complete packets during training; the right cycles through supported missing-sensor modes and renormalizes the streams that remain. This conceptual animation synthesizes the fallback mechanisms in [UniBEV](/paper%20shorts/2023/09/25/unibev-robust-multimodal-detection-with-uniform-bev-encoders.html), [MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html), and [Grace-BEV](/paper%20shorts/2026/05/29/grace-bev-graceful-degradation-under-sensor-failures.html)._
 
-## Multi-task learning: share the trunk, control the gradients
+## Multi-task learning
 
 Detection, occupancy, lanes, velocity, and tracking all need semantic features, metric geometry, and ego motion. A shared trunk avoids recomputing those features and can make the outputs geometrically consistent. The heads should remain specialized because the tasks differ in resolution, label density, sensor affinity, and error tolerance.
 
@@ -138,7 +138,7 @@ The inverse variance changes the task weight and the logarithm prevents every we
 ![Animation contrasting an unmeasured sum of task gradients with measured, balanced, and selectively split multi-task updates](/assets/images/autonomous-perception-multitask-gradients.gif)
 _Loss weighting changes gradient magnitude; it does not guarantee agreement. The controlled path combines the questions separated by [homoscedastic weighting](/paper%20shorts/2017/05/19/multi-task-learning-using-homoscedastic-uncertainty.html), [GradNorm](/paper%20shorts/2017/11/07/gradnorm-adaptive-loss-balancing.html), and [PCGrad](/paper%20shorts/2020/01/19/pcgrad-gradient-surgery-for-multi-task-learning.html). Conceptual animation synthesized from those optimization mechanisms._
 
-## Use LiDAR during training without requiring it at inference
+## LiDAR supervision without LiDAR inference
 
 “Using LiDAR for depth” describes three different deployment contracts:
 
@@ -161,7 +161,7 @@ The deployed graph and the label-generation graph should be documented separatel
 
 Projected LiDAR is also imperfect supervision. Occlusion, timestamp mismatch, actor motion, and calibration error can move a return across an object boundary. Depth-label generation therefore needs visibility checks, pose interpolation, confidence, and ignore regions.
 
-## Temporal modeling: choose what persists
+## Temporal representations
 
 A single frame does not provide stable velocity, identity through occlusion, or enough parallax for reliable depth. Temporal models differ in the state they retain.
 
@@ -189,7 +189,7 @@ Sparse recurrence makes a missing frame computationally cheap, not semantically 
 
 The useful default is hybrid: short dense memory for road structure, free space, and query birth; longer sparse memory for actors and vectorized map elements. [SparseDrive](/paper%20shorts/2024/05/30/sparsedrive-end-to-end-autonomous-driving-via-sparse-scene-representation.html) extends this object-and-map state into motion prediction and planning.
 
-## Sparse transformers reduce specific costs, not the whole system
+## Sparse transformer tradeoffs
 
 Sparse LiDAR encoders avoid processing empty 3D space. Sparse camera detectors avoid constructing or repeatedly updating every BEV cell. Both save work, but neither makes the full perception stack sparse.
 
@@ -199,7 +199,7 @@ The key sparse-transformer papers change different terms. VoTr, SST, and DSVT bo
 
 Measure end-to-end P95 and P99 latency, peak memory, and recall under dense scenes. Average FPS can hide synchronization, transfer, sparse-kernel overhead, and the rare frame in which many queries or voxels become active.
 
-## Pretraining should teach geometry and persistence
+## Pretraining objectives
 
 Image-classification pretraining teaches appearance but not calibration, cross-view correspondence, metric depth, ego motion, or temporal persistence. Driving pretraining should use synchronized sensor packets or clips and a target that requires those relationships.
 

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -1,5 +1,5 @@
 ---
-title: 'My Journey So Far: The Full Story'
+title: 'My Life and Career So Far'
 date: '2025-02-08T05:00:00.000Z'
 section: blog
 postSlug: my-journey-so-far-full-story
@@ -11,7 +11,7 @@ summary: >-
   graduate school, DEKA, and Zoox.
 ---
 
-# My Journey So Far: The Full Story
+# My Life and Career So Far
 
 In 2023, I gave [this interview](https://theinterviewportal.com/2024/01/21/perception-roboticist-interview/) about how I became a robotics engineer focused on perception. Looking back, the interview mostly captured the wins. It did not say much about the missteps, low points, and strange detours that shaped the path just as much. This is the fuller version, starting from the beginning.
 
@@ -21,7 +21,7 @@ I grew up in Jaipur, a city that shaped much of my early life. I lost my father 
 
 Most of my schooling was in Jaipur, and like many aspiring engineers, I spent three intense years in Kota preparing for the JEE. Kota is often described as a **factory** ([Netflix show](https://www.netflix.com/title/81249783) / [Wiki](https://en.wikipedia.org/wiki/Kota_Factory)), and that description is not far off. The city runs on academic competition. It is also a perfect breeding ground for [Girard's mimetic theory of desire](https://en.wikipedia.org/wiki/Mimetic_theory), where students absorb each other's ambitions and anxieties until it becomes hard to tell what you actually want. Despite working hard, I did not clear the IIT exam. At 18, that failure felt crushing, like I had let everyone down after years of preparation. Even now, at 33, the memory still makes my body tense up.
 
-### What that period taught me
+### Early lessons
 - **Be resilient** in the face of adversity.
 - Sometimes, **no matter how hard you try, you will fail** - and that's okay.
 - **It's okay to indulge** in things you like (like video games), but don’t let them consume you.
@@ -41,7 +41,7 @@ Even with that ridiculous ending, the concept was real. A similar design is now 
 ![The areca-nut harvesting robot built for my undergraduate thesis](/assets/images/IMG_8842.jpg)
 _Our undergraduate prototype climbed an areca palm and used a remotely controlled cutter. Source: personal project archive._
 
-### What undergrad changed
+### Lessons from undergrad
 - **It's never too late to start.**
 - **Jugaad** (resourcefulness in Hindi) is okay, as long as you don’t cheat outright!
 - **Building things that help others** brings a ton of joy.
@@ -69,7 +69,7 @@ Those experiences helped me find a purpose and clarify what I wanted to work on.
 
 I was accepted into three schools. I still remember rereading the first acceptance email about five times because I could not quite believe it. I packed my bags and moved to the United States to study robotics at the Colorado School of Mines.
 
-### What the reset clarified
+### Recovery and perspective
 - **Depression can be scary.**
 - **Having a purpose** makes it low-effort to work hard.
 - **Always have a backup plan.**
@@ -96,13 +96,13 @@ _The hexapod project paired a 1D LiDAR and Pixy camera with a small mobile platf
 
 Looking back, the best thing I did was build a strong foundation in the skills I cared about and then find practical ways to use them. Grades mattered, but the projects I took on, the problems I solved, and the people I learned from shaped me more. My advice to current graduate students is simple: take on projects that stretch you, use the resources around you, and follow problems that genuinely excite you. That is how progress starts to compound.
 
-### What Mines taught me
+### Lessons from graduate school
 - **Focus on building a strong foundation** in the areas that excite you.
 - **It's okay to feel out of place** in the beginning. Navigating many changes at once can be overwhelming, but it's part of the process.
 - **Be intentional** about what you want to get out of grad school. Tailor your coursework and experiences to align with your interests.
 - **Seek out hands-on opportunities**, like TA and RA positions, to apply your learning in practical settings.
 
-## Finding a job after graduate school
+## Job search after graduate school
 
 Landing your first job out of grad school in the U.S. can be difficult, especially if you want the dream job immediately and you are not coming from a top university. Even if you spent grad school building skills, doing research, and working on relevant projects, the search can still be tough. These are the things that helped me:
 
@@ -117,7 +117,7 @@ Landing your first job out of grad school in the U.S. can be difficult, especial
 - **Career Fairs**: These can be helpful, but don’t rely on them exclusively.
 - **Honesty**: Never lie on your resume.
 
-## First job at DEKA
+## DEKA
 
 Right after grad school, I landed at DEKA and joined a small, tight-knit team building autonomous robots for FedEx's last-mile deliveries. DEKA was mostly known for medical devices, so the robotics project felt like new territory. I started in planning, but I soon found my way into robot perception and machine learning. That team is where I really expanded my skills, diving into PyTorch, TensorFlow, TensorRT, CUDA, and OpenCL.
 

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -1,5 +1,5 @@
 ---
-title: 'Pretraining Multimodal Models for Robotics: A Reading Guide'
+title: 'Pretraining Multimodal Models for Robotics'
 date: '2026-07-15T09:00:00.000Z'
 section: blog
 postSlug: omni-model-pretraining-decisions
@@ -11,7 +11,7 @@ tags:
 summary: A reading guide to the representations, robot data, action interfaces, mixtures, and scaling experiments behind multimodal robot policies.
 ---
 
-# Pretraining Multimodal Models for Robotics: A Reading Guide
+# Pretraining Multimodal Models for Robotics
 
 A robot can inherit the word “drawer” from the internet. The internet does not tell it how a sticky drawer feels, how far a particular arm can reach, or what to do after the gripper slips. Multimodal pretraining works because semantic and motor experience can transfer. It fails when “put everything in one model” becomes a substitute for deciding what should transfer, through which parameters, and under what evidence.
 
@@ -23,7 +23,7 @@ This is Part II of the series. [Part I](/blog/2026/07/05/from-seeing-to-doing-th
 
 The scope is pretraining design, not a catalog of multimodal models. I use papers in two ways: reported experiments establish what happened inside a particular recipe; the decision tests, kill criteria, and preferred architecture are my synthesis. Keeping that boundary visible matters because multimodal papers often change the tokenizer, data, parameter count, and training budget together. A strong result can justify adopting a recipe without identifying which ingredient caused the gain.
 
-## Begin with the capability contract
+## Capability requirements
 
 “Multimodal” is not a capability. A contrastive encoder, visual assistant, image generator, video predictor, and robot policy can all consume images and text while solving different problems.
 
@@ -41,7 +41,7 @@ The contract determines what must be shared. [CLIP](/paper%20shorts/2021/02/28/l
 
 No architecture dominates those contracts for free. Before comparing models, write down which behavior must work zero-shot, which can be adapted with a small target dataset, which control rate is non-negotiable, and which regression would kill the program. A vague contract makes every later ablation look positive.
 
-## Robot data is not web data
+## Robot data and web data
 
 Internet data offers extraordinary breadth because images and text are cheap to copy. Robot trajectories are expensive, correlated, and attached to hardware. An hour of teleoperation contains the operator's habits, the controller's smoothing, the camera calibration, the reset procedure, and the parts of the state that happened to be logged. “More trajectories” can mean more task coverage, more embodiments, or simply more repetitions of one narrow behavior.
 
@@ -61,7 +61,7 @@ Cross-embodiment learning therefore needs an explicit interface contract. Which 
 
 The most useful dataset table is not trajectory count. It reports task entropy, scene entropy, embodiment coverage, operator coverage, success and recovery rates, control frequencies, action normalization, missing modalities, and effective unique windows after temporal overlap. Those quantities tell you what generalization the corpus can plausibly support.
 
-## Representation is the first scaling law
+## Training representations
 
 Before choosing transformer depth, decide what counts as one training unit.
 
@@ -73,7 +73,7 @@ The unit determines sequence length, and sequence length determines attention co
 
 The first useful budget is therefore not “percentage of image data.” It is tokens or FLOPs per capability gain. A 10% video mixture can consume most of the compute if every clip expands into thousands of visual tokens.
 
-### Understanding and generation want different information
+### Representations for understanding and generation
 
 Understanding rewards invariance. A classifier should ignore texture changes that preserve object identity. Generation punishes lost detail. A tokenizer optimized for semantic invariance can be a poor reconstruction code; a pixel-faithful code can waste sequence budget on information irrelevant to reasoning.
 
@@ -90,7 +90,7 @@ Those designs are three answers to one question: where should modality specializ
 
 The kill experiment is matched compute and matched sequence length. If separate routes win only because they add parameters or visual tokens, the result is capacity, not reduced interference.
 
-## Decide where transfer is allowed
+## Cross-modal parameter sharing
 
 Architectures often get labeled “early fusion” or “late fusion,” but the operational choices are more granular:
 
@@ -118,7 +118,7 @@ Every cell should report transfer under a matched compute budget, along with gra
 
 This is where [MM1](/paper%20shorts/2024/03/14/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.html) is so useful. Its controlled studies suggest that image encoder quality, resolution, visual-token count, and data composition matter more than endlessly modifying the connector. That is an experiment-allocation result: sweep the variables with large causal leverage before polishing the bridge between them.
 
-## One model can use several losses
+## Multi-objective training
 
 A unified transformer does not require a unified objective.
 
@@ -143,7 +143,7 @@ Then measure parameter-level conflict. If video gradients are ten times larger i
 
 This distinction becomes acute in robotics. Overlapping windows from one trajectory can produce thousands of training examples without thousands of independent decisions. A long action chunk can contribute many supervised dimensions while representing one correlated maneuver. The cleanest dashboard keeps four ledgers side by side: sampled examples, predicted units, consumed FLOPs, and update norm by module. A mixture is balanced only relative to a capability objective, not because its percentages sum to 100.
 
-## A data mixture is a policy over scarce compute
+## Data mixture design
 
 An omni corpus is not a pile of datasets. It is a sampling policy over modalities, domains, quality levels, sequence lengths, and training stages.
 
@@ -163,13 +163,13 @@ The proxy study should vary:
 
 Report uncertainty on extrapolated rankings, not only fitted loss. The expensive decision is whether candidate A will still beat candidate B at target scale. If confidence intervals overlap, the proxy run did not justify a nine-figure allocation.
 
-### Curriculum changes the interaction
+### Training curricula
 
 Data mixtures are often nonstationary. A model may first learn vision-language alignment, then high-resolution grounding, then video, then action. [VideoLLaMA 3](/paper%20shorts/2025/01/01/videollama-3-frontier-multimodal-foundation-models.html) uses strong image-text alignment as the base for video and compresses redundant temporal tokens. [PaliGemma](/paper%20shorts/2024/07/10/paligemma-a-versatile-3b-vlm-for-transfer.html) upcycles resolution in stages. [Eagle 2](/paper%20shorts/2025/01/01/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.html) shows how post-training ordering and curation can make a smaller VLM competitive.
 
 Order can reduce optimization difficulty, but it can also cause forgetting. A staged curriculum needs retention evals after every transition and a controlled comparison with an interleaved mixture under equal compute.
 
-## Video is not automatically a world model
+## Video models and world models
 
 Video generation produces plausible futures. A world model preserves action-conditioned consequences. A policy chooses actions that achieve an outcome.
 
@@ -188,7 +188,7 @@ The evaluation contract must change when control enters. FID and visual preferen
 
 A model that produces a plausible door opening after any action is a video generator with weak conditioning, not a useful world model.
 
-## The action distribution is an architectural choice
+## Action representations
 
 Actions change the data distribution, carry embodiment-specific units, and operate under a control deadline. Treating them as ordinary tokens hides those constraints behind a convenient interface.
 
@@ -209,7 +209,7 @@ The action-interface memo should compare:
 
 The pretraining question is which action prior should be learned across robots. The answer cannot be read from imitation loss alone. Reconstruct a short trajectory with each representation, compare spectral and contact-heavy errors, measure effective horizon and wall-clock control rate, and test whether a small target dataset can change the embodiment without erasing semantic transfer. The post-training question comes later: does the chosen distribution expose the likelihoods and responsiveness required by the improvement loop?
 
-## Scaling evidence needs a falsification boundary
+## Testing scaling claims
 
 A smooth curve is not the same as a causal law. Every scaling claim should name:
 
@@ -233,7 +233,7 @@ For every candidate architecture, write a kill criterion before the proxy runs:
 
 That habit converts paper reading into capital allocation.
 
-## A large run is a fault-tolerant experiment
+## Fault-tolerant training
 
 Once the architecture and mixture are chosen, the research question becomes operational: can the training system preserve the intended experiment for months?
 
@@ -254,7 +254,7 @@ The runbook should cover:
 
 Every checkpoint must bind model state to optimizer, scheduler, data cursor, mixture policy, tokenizer, code commit, and evaluation config. A weight file without that lineage is not a recoverable experiment.
 
-## The minimum convincing proxy program
+## Proxy experiments before large runs
 
 Before a massive run, build a 100M–1B prototype program with at least text prediction, image-text understanding, visual generation, and a lightweight video or action objective.
 
@@ -275,7 +275,7 @@ The deliverables should be decision artifacts:
 
 Do not present one mixture such as “45% text, 25% image-text, 10% image generation, 15% video, 5% action” as a universal answer. Present how that allocation was estimated, which target it optimizes, how uncertainty changes the ranking, and what evidence triggers a new allocation.
 
-## A reading course with three routes
+## Reading paths
 
 There is no single best order after the foundations. Choose a route based on the decision you need to make, and produce an artifact after each layer.
 

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -1,5 +1,5 @@
 ---
-title: 'Post-Training VLAs: A Reading Guide to Closed-Loop Improvement'
+title: 'Post-Training Vision-Language-Action Models: A Reading Guide'
 date: '2026-07-16T10:00:00.000Z'
 section: blog
 postSlug: post-training-vision-language-action-models-zero-to-hero
@@ -11,7 +11,7 @@ tags:
 summary: A mechanism-first guide to turning robot rollouts into justified policy updates through correction data, preference learning, critics, reinforcement learning, and real evaluation.
 ---
 
-# Post-Training VLAs: A Reading Guide to Closed-Loop Improvement
+# Post-Training Vision-Language-Action Models: A Reading Guide
 
 A robot fails while closing a drawer. The episode gives us an outcome: failure. It does not tell us whether the camera missed the handle, the language model chose the wrong subtask, the trajectory approached at a bad angle, the gripper slipped, or the success detector fired too early. Post-training begins in that gap between outcome and explanation.
 
@@ -27,7 +27,7 @@ This is Part III of a three-part reading course. [Part I](/blog/2026/07/05/from-
 
 The scope is policy improvement after a broadly pretrained VLA exists. Paper-reported algorithms and results are the evidence layer. The failure taxonomy, evaluation pyramid, and recommended order of operations are my synthesis. I mark frontier work separately because a result in one simulator, embodiment, or reward setup is not yet a general robot-training recipe.
 
-## The distribution moves when the robot moves
+## Closed-loop distribution shift
 
 A modern VLA begins with two useful priors. Vision-language pretraining supplies objects, concepts, instructions, and scene semantics. Robot pretraining supplies a distribution over physically plausible behavior. [RT-2](/paper%20shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html) demonstrates the first transfer by expressing actions in the language-token interface. [Open X-Embodiment](/paper%20shorts/2023/10/13/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.html), [Octo](/paper%20shorts/2024/05/20/octo-an-open-source-generalist-robot-policy.html), and [OpenVLA](/paper%20shorts/2024/06/01/openvla-open-source-vision-language-action-model.html) make the second transfer concrete across heterogeneous robot data.
 
@@ -39,7 +39,7 @@ This is the first mental model to keep:
 
 That difference is why another million successful demonstrations may be worth less than ten thousand carefully selected recoveries.
 
-## Earn the supervised baseline
+## The supervised baseline
 
 Supervised fine-tuning hides most of its engineering inside the action target. Is the target a scalar joint bin, a whole action chunk, a diffusion denoising target, or a continuous regression vector? How much observation history is available? Does the policy act at 3 Hz or 50 Hz? Does it predict one step, replan a receding horizon, or temporally ensemble overlapping chunks? Those choices determine both the likelihood interface and the states the policy can recover from.
 
@@ -69,7 +69,7 @@ The supervised baseline should therefore be an adaptation matrix, not one ceremo
 
 Measure success, robot-data efficiency, control frequency, latency, forgetting, and semantic retention together. A policy that succeeds 3% more often but halves the control rate may be worse before the first rollout.
 
-## Language-model alignment supplies tools, not a robot recipe
+## Language-model alignment methods
 
 The classic language pipeline is documented by [InstructGPT](/paper%20shorts/2022/02/28/training-language-models-to-follow-instructions-with-human-feedback.html): supervised fine-tuning, a Bradley–Terry preference model, then [PPO](/paper%20shorts/2017/07/01/proximal-policy-optimization-ppo.html) against the learned reward with a KL penalty. [DPO](/paper%20shorts/2023/05/01/direct-preference-optimization-dpo.html) removes the explicit reward model and expresses the KL-regularized optimum directly through chosen and rejected responses.
 
@@ -105,13 +105,13 @@ The feedback interface should match what deployment actually observed:
 
 The central question is not “Can DPO be applied?” It is “What event has a defensible likelihood and a defensible preference label?” The method should follow the evidence unit, not the fashion cycle.
 
-## Feedback is an attribution problem
+## Feedback attribution
 
 Suppose the gripper misses the handle at step 42 and a human takes over at step 47. The binary episode label says the rollout failed. The intervention says the policy became unacceptable by step 47. Neither observation proves that every earlier action was wrong. Penalizing the whole trajectory can erase a good approach because of one bad contact. Training only on the human suffix can also be misleading if the human begins from a state the policy would never deliberately create.
 
 The safest useful label is therefore local. Preserve the prefix that still made progress. Mark the first defensible failure window. Record the reached state and the corrective continuation. If a paired alternative cannot be replayed from a matched state, use an unpaired outcome or correction objective rather than pretending to possess a counterfactual.
 
-### Failure mining determines the value of robot hours
+### Failure mining
 
 Rollouts are not automatically useful. A thousand identical successes provide little gradient. A thousand catastrophic failures may be unsafe and too far outside the policy's recoverable region. The valuable middle consists of near-boundary states: recoverable mistakes, ambiguous objects, distribution shifts, and action segments where a different local decision changes the outcome.
 
@@ -129,7 +129,7 @@ That taxonomy routes data. Semantic failures may need web/VLM retention or instr
 
 The next 1,000 robot hours should go where expected marginal information is highest: high-uncertainty critic regions, recoverable failures, rare safety cases, new environments, and tasks that discriminate between candidate post-training methods. Uniform collection is easy to schedule and often a poor research allocation.
 
-## Choose the method from the feedback unit
+## Choosing a method by feedback type
 
 Once failures are labeled, four families cover most practical updates.
 
@@ -165,7 +165,7 @@ For diffusion actors, [DPPO](/paper%20shorts/2024/09/01/dppo-diffusion-policy-po
 
 That observation produces a systems requirement: rollout scheduling must create informative contrasts. Sample tasks near the competence boundary, record policy versions, prevent correlated environments from masquerading as independent evidence, and reject groups with no reward variance.
 
-## The critic is part of the environment
+## Reward models and environment design
 
 A terminal success detector is sparse. A generic VLM reward can miss geometry, contact, occlusion, and temporal progress. A dense hand-engineered reward can teach the simulator rather than the task. The right critic is rarely “a bigger VLM asked whether the robot did well.”
 
@@ -179,27 +179,27 @@ A serious process critic should not collapse progress, completion, failure, safe
 
 Never celebrate rising critic reward alone. Track ground-truth task success, human judgment, critic disagreement, intervention rate, unsafe contact, entropy, KL from SFT, and the causal content of high-reward rollouts. If the policy can change what the critic sees, the critic is no longer a passive metric. It is part of the environment being optimized.
 
-## Evaluation must preserve the deployment decision
+## Evaluation levels
 
 Post-training claims are only as strong as the next evaluation layer they predict.
 
-### Level 1 · Offline diagnostics
+### Level 1: Offline diagnostics
 
 Measure action error, chunk likelihood, critic accuracy, preference accuracy, representation probes, and instruction/object grounding. These are cheap debugging tools. They do not measure recovery from the model's own actions.
 
-### Level 2 · Closed-loop simulation
+### Level 2: Closed-loop simulation
 
 [LIBERO](/paper%20shorts/2023/06/05/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.html) separates spatial, object, goal, and mixed transfer across 130 tasks. [RoboTwin 2.0](/paper%20shorts/2025/06/20/robotwin-2-scalable-data-generator-and-benchmark.html) adds bimanual tasks, structured domain randomization, and synthetic data generation. Report success by failure category and shift, not only the mean.
 
-### Level 3 · Real-to-sim correlation
+### Level 3: Real-to-sim correlation
 
 [SIMPLER](/paper%20shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html) asks whether simulation preserves real policy rankings and failure sensitivities. That correlation must be measured prospectively for every new policy family. A simulator calibrated for RT-style discrete actions may not rank a new flow policy correctly.
 
-### Level 4 · Reproducible real trials
+### Level 4: Reproducible real trials
 
 [VLA-REPLICA](/paper%20shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html) standardizes an inexpensive physical setup so independent labs can reproduce the result. Measure success with confidence intervals, intervention frequency, unsafe contacts, time, smoothness, latency, and hardware-versus-policy faults.
 
-### Level 5 · Natural interaction robustness
+### Level 5: Natural interaction robustness
 
 [LIBERO-Para](/paper%20shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html) reveals 22–52 point drops under instruction paraphrases and attributes most failures to planning divergence. A policy that succeeds only when the user repeats the fine-tuning phrase has not retained semantic grounding.
 
@@ -209,7 +209,7 @@ The staff-level metric sits above every level:
 
 > Reliable policy improvement per robot-hour, human-hour, annotation-hour, and unit of compute.
 
-## The loop must be reproducible
+## Reproducible training loops
 
 An RL trainer is one component of an online VLA program. The surrounding system needs versioned policies, rollout workers, environment and robot calibration records, synchronized video/state/action logs, feedback provenance, immutable dataset snapshots, critic versions, and rollback.
 
@@ -241,7 +241,7 @@ Use the cheapest method that attacks the diagnosed failure.
 | Sparse task reward | Process critic such as VLAC | Critic passes held-out error-localization tests |
 | Reward exploitation | Ensembles, conservative objective, real stopping metric | Critics disagree or gold performance turns down |
 
-## A reading course with five outputs
+## Reading course
 
 Do not read the following papers as a chronology. Read them as five passes through one hypothetical failure. At the end of each pass, produce an artifact. The artifacts should make your own post-training proposal harder to hand-wave.
 
@@ -255,7 +255,7 @@ Do not read the following papers as a chronology. Read them as five passes throu
 
 **Pass 5: test which evidence survives deployment.** Read [LIBERO](/paper%20shorts/2023/06/05/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.html), [SIMPLER](/paper%20shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html), [RoboTwin 2.0](/paper%20shorts/2025/06/20/robotwin-2-scalable-data-generator-and-benchmark.html), [VLA-REPLICA](/paper%20shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html), and [LIBERO-Para](/paper%20shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html). **Output:** an evaluation ladder in which every cheap metric names the expensive deployment decision it is expected to predict.
 
-## Frontier signals, not settled recipes
+## Emerging methods
 
 Several 2026 papers extend the loop toward fleet-scale asynchronous training, model-based optimization, continual reinforcement fine-tuning, and learned robot rewards: [SOP](https://arxiv.org/abs/2601.03044), [LifeLong-RFT](https://arxiv.org/abs/2602.10503), [VLA-MBPO](https://arxiv.org/abs/2603.20607), [Large Reward Models](https://arxiv.org/abs/2603.16065), [BORA](https://arxiv.org/abs/2605.30226), [ProcVLM](https://arxiv.org/abs/2605.08774), and [Advantage Collapse in GRPO](https://arxiv.org/abs/2605.21125). These are useful research signals, but their claims should be re-tested under common robot-hour, compute, and evaluation budgets before they become default infrastructure.
 

--- a/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
+++ b/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
@@ -1,5 +1,5 @@
 ---
-title: Replacing OpenClaw with Hermes Agent using local weights
+title: Replacing OpenClaw with Hermes Agent Using Local Weights
 date: '2026-04-04T17:59:45.000Z'
 section: blog
 postSlug: replacing-openclaw-with-hermes-agent-using-local-weights
@@ -13,7 +13,7 @@ summary: >-
   got it working with an already-downloaded Gemma GGUF instead of pulling new
   models.
 ---
-# Replacing OpenClaw with Hermes Agent using local weights
+# Replacing OpenClaw with Hermes Agent Using Local Weights
 
 I wanted a specific outcome: replace OpenClaw with [Hermes Agent](https://github.com/nousresearch/hermes-agent) while keeping inference fully local. That meant two constraints:
 
@@ -22,7 +22,7 @@ I wanted a specific outcome: replace OpenClaw with [Hermes Agent](https://github
 
 On this machine, the artifacts I could verify quickly were local Gemma GGUFs, so that is the path I got working end to end. I did not see my Qwen artifacts in the usual cache locations during setup, but the same `llama.cpp` pattern should apply to local Qwen GGUFs too.
 
-## Why I wanted Hermes instead
+## Why replace OpenClaw with Hermes Agent
 
 Hermes is a much more opinionated agent shell than a bare local chat loop. It has the things I actually care about when I say "agent" instead of "chatbot":
 
@@ -35,7 +35,7 @@ Hermes is a much more opinionated agent shell than a bare local chat loop. It ha
 
 Hermes does not force one inference path. It works with hosted providers, but it can also point at any OpenAI-compatible local endpoint. That separation let the agent framework stay fixed while the model runtime changed underneath it.
 
-## The install itself was easy
+## Installing Hermes Agent
 
 The Hermes install was not the hard part:
 
@@ -53,7 +53,7 @@ That bootstrapped:
 
 The real question was what local model server Hermes should talk to.
 
-## Ollama was the obvious first try, but it was the wrong one here
+## Why Ollama did not work
 
 Since I already had Ollama installed and local Gemma tags visible, I tried the most obvious route first.
 
@@ -61,7 +61,7 @@ Hermes could see the local endpoint. Ollama listed local Gemma models. But actua
 
 The key realization: Hermes was not the problem. My local model server choice was.
 
-## What actually worked: `llama-server` plus an existing Gemma GGUF
+## `llama-server` with a local Gemma GGUF
 
 The machine already had local Gemma GGUF artifacts in the Hugging Face cache, including:
 
@@ -99,7 +99,7 @@ http://127.0.0.1:18080/v1
 
 That split worked: Hermes stayed as the agent shell, and `llama.cpp` handled local serving.
 
-## The Hermes config I ended up using
+## Hermes Agent configuration
 
 I pointed Hermes at the local `llama-server` endpoint by editing `~/.hermes/config.yaml` to this:
 
@@ -118,7 +118,7 @@ After that, `hermes status --deep` showed exactly what I wanted:
 - provider set to `Custom endpoint`
 - no cloud API keys required
 
-## The actual proof that it was running
+## Verification
 
 The test I cared about was extremely boring on purpose:
 
@@ -134,7 +134,7 @@ READY
 
 That was enough proof: Hermes was running locally against weights already on disk.
 
-## What I would do next
+## Next steps
 
 This setup is already useful, but there are a few obvious next steps:
 

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -23,7 +23,7 @@ The short version, as of April 4, 2026:
 - Most direct low-level path: `llama.cpp`
 - Current Ollama status for Gemma 4 on this machine: it crashes before first token
 
-## What fits
+## Model memory requirements
 
 According to Google's current Gemma docs, approximate Q4 inference memory requirements are `3.2 GB` for `Gemma 4 E2B`, `5 GB` for `Gemma 4 E4B`, `15.6 GB` for `Gemma 4 26B A4B`, and `17.4 GB` for `Gemma 4 31B` ([Google docs](https://ai.google.dev/gemma/docs/core)).
 
@@ -66,7 +66,7 @@ The output task was intentionally boring and deterministic: read background text
 
 One important caveat: this is a fastest-practical-path comparison, not a perfect same-weights lab setup. I used the most direct current artifact for each runtime. That means the `E2B` comparison is not perfectly apples-to-apples: official `llama.cpp` GGUF for `E2B` is `Q8_0`, while the MLX and Ollama paths use 4-bit artifacts.
 
-## Controls that mattered
+## Benchmark controls
 
 These details kept the comparison about runtime behavior rather than hidden work:
 
@@ -76,7 +76,7 @@ These details kept the comparison about runtime behavior rather than hidden work
 - I split the test into short and long prompts on purpose. A runtime can look fine at `512` tokens and then feel much worse once prompt processing climbs into the `8K` range.
 - I tried Ollama with native `gemma4:*` tags, not a hacked local import path, so the Ollama result reflects the current easy path.
 
-## What the benchmarks say
+## Benchmark results
 
 I came into this expecting `llama.cpp` to win on raw speed.
 
@@ -84,7 +84,7 @@ That is not what the machine gave me.
 
 For the smaller models, MLX was clearly faster on this M5 Max. For `26B A4B`, the story got more nuanced: `llama.cpp` and MLX were effectively tied on the short prompt, but MLX still pulled ahead once the prompt got long. For `31B`, MLX went back to being the cleaner win, especially on prompt processing and time to first token.
 
-### Short suite
+### Short-context results
 
 | Model | Runtime | Artifact | TTFT | Decode tok/s | Avg tok/s |
 | ----- | ------- | -------- | ---- | ------------ | --------- |
@@ -97,7 +97,7 @@ For the smaller models, MLX was clearly faster on this M5 Max. For `26B A4B`, th
 | `31B` | MLX | `mlx-community/gemma-4-31b-it-4bit` | `906 ms` | `27.50` | `24.34` |
 | `31B` | llama.cpp | `ggml-org` `Q4_K_M` GGUF | `1279 ms` | `24.89` | `21.35` |
 
-### Long suite
+### Long-context results
 
 | Model | Runtime | Artifact | TTFT | Decode tok/s | Avg tok/s |
 | ----- | ------- | -------- | ---- | ------------ | --------- |
@@ -119,7 +119,7 @@ The pattern:
 - On longer prompts, MLX is still more comfortable because time to first token is substantially lower.
 - The difference between "weights fit" and "this feels good to use" shows up quickly once prompt length grows; TTFT hurts before decode speed does.
 
-## Ollama right now
+## Ollama compatibility
 
 I wanted a clean Ollama column here. I could not get one.
 
@@ -134,7 +134,7 @@ That matters because it changes the recommendation:
 
 So if your question is "should I start with Ollama because it is easiest," my current answer is no, not for Gemma 4 on this hardware, at least not until that backend issue is fixed.
 
-## What I would actually use
+## Recommendation
 
 If I cared about the strongest local Gemma 4 model, I would start with `31B`.
 

--- a/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
@@ -29,7 +29,7 @@ The short version so far:
 - `MLX` is the first runtime I would reach for on this Mac.
 - `4B` is the speed-first choice, but `14B` is where the local quality conversation starts getting more interesting.
 
-## What fits
+## Model memory requirements
 
 Qwen's current open model lineup immediately narrows the realistic local targets.
 
@@ -80,7 +80,7 @@ The task was intentionally boring and deterministic: read repeated background te
 
 I also kept the app and the benchmark harness text-only for this pass. No images, no multimodal prompts, and no hidden reasoning tokens if I could turn them off.
 
-## Controls that mattered
+## Benchmark controls
 
 These details kept the benchmark from measuring hidden work:
 
@@ -90,7 +90,7 @@ These details kept the benchmark from measuring hidden work:
 - I used official Qwen GGUF releases for `Qwen 3`, but for `Qwen 3.5` I fell back to pinned community `Q4_K_M` GGUFs because I did not find an official `Qwen 3.5` GGUF release on the Qwen organization page.
 - I had to disable Hugging Face Xet downloads for some official Qwen artifacts because a few larger MLX downloads stalled on incomplete blobs.
 
-## What the benchmarks say
+## Benchmark results
 
 The first finished runs made one thing clear: `4B` Qwen is workable on this machine and genuinely pleasant.
 
@@ -102,7 +102,7 @@ The first bigger model result, `Qwen 3.5 9B`, is useful because it shows where t
 
 The cross-runtime results sharpened the runtime recommendation. On `Qwen 3.5 9B`, `MLX` beat `llama.cpp` on both suites by a healthy margin, especially once prompt length hit the `8K` range. On `Qwen 3 14B`, the short prompt was much closer, but MLX still pulled ahead on the long prompt where prompt processing dominates the experience.
 
-### Short suite
+### Short-context results
 
 | Model | Runtime | Artifact | TTFT | Decode tok/s | Avg tok/s | Peak memory |
 | ----- | ------- | -------- | ---- | ------------ | --------- | ----------- |
@@ -113,7 +113,7 @@ The cross-runtime results sharpened the runtime recommendation. On `Qwen 3.5 9B`
 | `Qwen 3.5 9B` | MLX | `mlx-community/Qwen3.5-9B-MLX-4bit` | `301 ms` | `96.33` | `79.67` | `7.07 GB` |
 | `Qwen 3 4B` | MLX | `mlx-community/Qwen3-4B-4bit` | `392 ms` | `176.14` | `128.89` | `3.05 GB` |
 
-### Long suite
+### Long-context results
 
 | Model | Runtime | Artifact | TTFT | Decode tok/s | Avg tok/s | Peak memory |
 | ----- | ------- | -------- | ---- | ------------ | --------- | ----------- |
@@ -134,7 +134,7 @@ The pattern:
 - `Qwen 3 14B` makes the runtime story specific: `llama.cpp` is competitive on the short prompt, but MLX is still the better default once prompts get long.
 - Long-prompt behavior matters more than short-prompt decode speed if you care about whether a local model feels snappy.
 
-## What I would actually use
+## Recommendation
 
 Right now, my practical recommendation is simple:
 

--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -1,5 +1,5 @@
 ---
-title: Thoughts on Good Research in Industry
+title: Good Research in Industry
 date: '2026-03-22T04:00:00.000Z'
 section: blog
 postSlug: thoughts-on-good-research-in-industry
@@ -11,13 +11,13 @@ summary: >-
   Notes on research taste, collaboration, visibility, experimentation, and
   staying unblocked in industry.
 ---
-# Thoughts on Good Research in Industry
+# Good Research in Industry
 
 [Eugene Vinitsky's guide to good research](https://emerge-lab.github.io/papers/an-unsolicited-guide-to-good-research.pdf) stayed with me because it treats research as a craft rather than a sequence of heroic breakthroughs. Eugene leads the [EMERGE Lab](https://emerge-lab.github.io/), but much of his advice transfers to industry, where research is entangled with engineering, product, deadlines, and organizational constraints.
 
 Those constraints change the work without changing its central questions. A researcher still needs to decide what matters, design experiments that produce knowledge, and collaborate without losing momentum. Good ideas help. Clear judgment and reliable execution determine whether those ideas survive contact with an organization.
 
-## Developing taste
+## Research taste
 
 Research taste is the ability to decide what deserves attention. The literature grows faster than anyone can read it, while consequential ideas remain much rarer than papers. A new researcher experiences that gap as overload. An experienced one builds a compressed map: foundational results, useful extensions, unresolved questions, and noise.
 
@@ -25,13 +25,13 @@ Following researchers and labs with consistently strong work is a practical way 
 
 Virality works against this process. Social feeds reward visible consensus and rapid reaction, which pushes people toward the same papers and the same opinions. Taste develops more slowly, through sustained exposure and enough independent judgment to notice depth before the crowd supplies a verdict.
 
-## Work that pulls you forward
+## Choosing motivating problems
 
 The best work contains an element of play. The problem keeps pulling you back when nobody is asking for an update, not because it is easy, but because some part of it remains intrinsically interesting. Research is too uncertain to sustain on discipline alone.
 
 Interest is not the same as comfort. Work that teaches you something usually sits just beyond your current ability: difficult enough to force a new model of the problem, but bounded enough that effort can still produce feedback. Too little tension becomes routine; too much becomes paralysis.
 
-## Collaboration as leverage
+## Research collaboration
 
 Serious research increasingly depends on the same coordination as serious engineering. The relevant skill is not simply being agreeable. It is keeping information and decisions moving across people who hold different pieces of the system.
 
@@ -39,7 +39,7 @@ My simplest rule is: do not block. Surface constraints early, give honest timing
 
 Apply the same rule to yourself. Ask for help when someone else likely has the missing context. Do not spend days privately rediscovering an answer the team already knows. When the uncertainty is genuinely yours, step away long enough to stop repeating the same failed approach. A walk or a night's sleep often changes the representation of the problem, which is more useful than another hour of force.
 
-## Rigor and visibility
+## Experimental rigor and communication
 
 ML is empirical, so an experiment should change one interpretable decision whenever possible. Ablations turn a promising run into evidence about what caused the result. Without them, a team can produce plenty of activity and very little knowledge.
 
@@ -47,7 +47,7 @@ Documentation is part of the experiment. Future you needs to know what changed, 
 
 Visibility only helps when the work is legible. A presentation should maximize what the audience understands, not how much detail the author can display. Proving that you did the work and helping someone reason about it are different goals.
 
-## Throughput matters too
+## Experimental throughput
 
 Compute changes the value of good judgment because it determines how quickly a question can meet evidence. Keep the GPUs busy, but make each run interpretable. Velocity without rigor produces noise; rigor without enough throughput leaves important decisions unresolved. A good research system makes the two reinforce each other.
 


### PR DESCRIPTION
## Summary
- replace clever or metaphorical Blog headings with direct descriptive labels
- simplify eight Blog titles while preserving every postSlug and legacyPath
- retain the latest perception animations from main

## Validation
- git diff --check
- npm run ci
- 18 tests passed and 231 pages built