### PR TITLE
Add VLA4AD chronology and paper notes

### DIFF
--- a/src/content/posts/a-survey-on-vision-language-action-models-for-autonomous-driving.md
+++ b/src/content/posts/a-survey-on-vision-language-action-models-for-autonomous-driving.md
@@ -46,6 +46,34 @@ _Figure 2 summarizes the VLA4AD architecture blocks, connecting visual inputs, l
 | End-to-end VLA | Map scene inputs and instructions toward actions | OpenDriveVLA and related action models |
 | Augmented VLA | Add tools, chains of thought, or world models | DiffVLA and DriveVLA-W0-style extensions |
 
+### Chronology of the curated list
+
+The table uses each paper's initial arXiv submission date, not the Awesome list's year column or this site's publication date. It gives a reproducible reading order across the two driving fields; it does not, by itself, establish that a later paper was influenced by an earlier one.
+
+| Initial arXiv date | Paper | Main interface or evidence change |
+| ------------------ | ----- | -------------------------------- |
+| 2023-10-02 | [DriveGPT4](/paper%20shorts/2023/10/02/drivegpt4-interpretable-end-to-end-autonomous-driving-via-large-language-model.html) | One multimodal interface for explanations and low-level controls |
+| 2023-11-22 | [ADriver-I](/paper%20shorts/2023/11/22/adriver-i-a-general-world-model-for-autonomous-driving.html) | Interleaved vision-action world-model rollout |
+| 2024-02-16 | [RAG-Driver](/paper%20shorts/2024/02/16/rag-driver-generalisable-driving-explanations-with-retrieval-augmented-in-context-learning.html) | Retrieved demonstrations as driving evidence |
+| 2024-08-19 | [CoVLA](/paper%20shorts/2024/08/19/covla-comprehensive-vision-language-action-dataset-for-autonomous-driving.html) | Video, language, and trajectory data construction |
+| 2024-10-30 | [EMMA](/paper%20shorts/2024/10/01/emma-end-to-end-multimodal-model-for-autonomous-driving.html) | Tokenized multimodal driving inputs and outputs |
+| 2025-02-28 | [SafeAuto](/paper%20shorts/2025/02/28/safeauto-knowledge-enhanced-safe-autonomous-driving-with-multimodal-foundation-models.html) | Explicit loss, rule-checking, and retrieval safety interfaces |
+| 2025-03-12 | [SimLingo](/paper%20shorts/2025/03/12/simlingo-vision-only-closed-loop-autonomous-driving-with-language-action-alignment.html) | Camera-only language-action alignment |
+| 2025-03-14 | [DynRsl-VLM](/paper%20shorts/2025/03/14/dynrsl-vlm-enhancing-autonomous-driving-perception-with-dynamic-resolution-vision-language-models.html) | Dynamic-resolution visual evidence for VLM reasoning |
+| 2025-03-25 | [ORION](/paper%20shorts/2025/03/25/orion-a-holistic-end-to-end-autonomous-driving-framework-by-vision-language-instructed-action-generation.html) | Long-history reasoning connected to a generative planner |
+| 2025-03-30 | [OpenDriveVLA](/paper%20shorts/2025/03/30/opendrivevla-towards-end-to-end-autonomous-driving-with-large-vision-language-action-model.html) | Hierarchical 2D and 3D spatial-token alignment |
+| 2025-04-18 | [LangCoop](/paper%20shorts/2025/04/18/langcoop-collaborative-driving-with-language.html) | Language as a vehicle-to-vehicle communication packet |
+| 2025-05-19 | [TS-VLM](/paper%20shorts/2025/05/19/ts-vlm-text-guided-softsort-pooling-for-vision-language-models-in-multi-view-driving-reasoning.html) | Query-conditioned multi-view pooling |
+| 2025-05-22 | [DriveMoE](/paper%20shorts/2025/05/22/drivemoe-mixture-of-experts-for-vision-language-action-model-in-end-to-end-autonomous-driving.html) | Separate sparse routing of camera and action experts |
+| 2025-05-23 | [FutureSightDrive](/paper%20shorts/2025/05/23/futuresightdrive-thinking-visually-with-spatio-temporal-cot-for-autonomous-driving.html) | Predicted visual future as a planning trace |
+| 2025-05-26 | [DiffVLA](/paper%20shorts/2025/05/26/diffvla-vision-language-guided-diffusion-planning-for-autonomous-driving.html) | Vision-language-conditioned diffusion trajectories |
+| 2025-05-29 | [Impromptu VLA](/paper%20shorts/2025/05/29/impromptu-vla-open-weights-and-open-data-for-driving-vision-language-action-models.html) | Curated corner-case VLA data and diagnostics |
+| 2025-05-30 | [S4-Driver](/paper%20shorts/2025/05/30/s4-driver-scalable-self-supervised-driving-multimodal-large-language-model-with-spatio-temporal-visual-representation.html) | Self-supervised sparse 3D visual representation |
+| 2025-06-09 | [ReCogDrive](/paper%20shorts/2025/06/09/recogdrive-a-reinforced-cognitive-framework-for-end-to-end-autonomous-driving.html) | VLM cognition feeding a diffusion planner |
+| 2025-06-16 | [AutoVLA](/paper%20shorts/2025/06/16/autovla-a-vision-language-action-model-for-end-to-end-autonomous-driving-with-adaptive-reasoning-and-reinforcement-fine-tuning.html) | Adaptive reasoning plus tokenized feasible trajectories |
+| 2025-06-23 | [Drive-R1](/paper%20shorts/2025/06/23/drive-r1-bridging-reasoning-and-planning-in-vlms-for-autonomous-driving-with-reinforcement-learning.html) | RL for visual reasoning-plan alignment |
+| 2025-10-30 | [Alpamayo-R1](/paper%20shorts/2025/10/30/alpamayo-r1-bridging-reasoning-and-action-prediction-for-generalizable-autonomous-driving-in-the-long-tail.html) | Causal driving traces with diffusion action prediction |
+
 ## High-Level Takeaways
 
 - This survey informs how to partition a driving-VLA research portfolio across perception-language alignment, world modeling, action generation, datasets, and closed-loop evaluation. Its comparison unit is not one token or trajectory but a system interface: visual representation, language/reasoning backbone, action head, and deployment loop.

--- a/src/content/posts/adriver-i-a-general-world-model-for-autonomous-driving.md
+++ b/src/content/posts/adriver-i-a-general-world-model-for-autonomous-driving.md
@@ -1,0 +1,30 @@
+---
+title: 'ADriver-I: A General World Model for Autonomous Driving'
+date: '2023-11-22T17:44:29.000Z'
+section: paper-shorts
+postSlug: adriver-i-a-general-world-model-for-autonomous-driving
+legacyPath: /paper shorts/2023/11/22/adriver-i-a-general-world-model-for-autonomous-driving.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2023 – ADriver-I: A General World Model for Autonomous Driving"
+---
+## 2023 – ADriver-I
+
+**arXiv:** [2311.13549](https://arxiv.org/abs/2311.13549)
+
+## Summary
+
+ADriver-I turns an interleaved sequence of visual features and control signals into a driving world model. The model predicts the current control, conditions future-frame generation on that control and the history, then feeds the imagined frame back into another control step. It is therefore a joint action-and-observation rollout rather than a planner that predicts a trajectory once. The paper evaluates on nuScenes and a private dataset, but its abstract does not report a closed-loop metric or the horizon over which the recursive rollout remains reliable.
+
+## Core Insights
+
+The crucial representation is the interleaved vision-action pair. It makes control part of the temporal context that an MLLM and diffusion model can process, then lets generated controls influence future visual predictions. In principle, that structure exposes a useful consistency question: do actions lead to plausible visual consequences? In practice, rollout quality can degrade through both control error and image-generation error.
+
+The paper compares ADriver-I with constructed baselines and describes the result as favorable. The abstract gives neither the visual-token format, diffusion objective, action parameterization, data scale, nor a teacher-forced-versus-free-rollout ablation. A driving team would need those controls before treating a compelling imagined video as evidence that the world model is a safe planning model.
+
+## High-Level Takeaways
+
+- ADriver-I makes an interleaved vision-action transition the training unit, so action prediction and future observation prediction share a rollout interface.
+- Its reported evaluation covers nuScenes and private driving data, but the abstract does not establish long-horizon closed-loop stability.
+- The decisive experiment would hold the perception backbone and action head fixed while comparing direct planning, teacher-forced world-model planning, and free recursive rollout under the same safety budget.

--- a/src/content/posts/alpamayo-r1-bridging-reasoning-and-action-prediction-for-generalizable-autonomous-driving-in-the-long-tail.md
+++ b/src/content/posts/alpamayo-r1-bridging-reasoning-and-action-prediction-for-generalizable-autonomous-driving-in-the-long-tail.md
@@ -1,0 +1,34 @@
+---
+title: 'Alpamayo-R1: Bridging Reasoning and Action Prediction for Generalizable Autonomous Driving in the Long Tail'
+date: '2025-10-30T01:25:34.000Z'
+section: paper-shorts
+postSlug: alpamayo-r1-bridging-reasoning-and-action-prediction-for-generalizable-autonomous-driving-in-the-long-tail
+legacyPath: /paper shorts/2025/10/30/alpamayo-r1-bridging-reasoning-and-action-prediction-for-generalizable-autonomous-driving-in-the-long-tail.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – Alpamayo-R1: Bridging Reasoning and Action Prediction for Generalizable Autonomous Driving in the Long Tail"
+---
+## 2025 – Alpamayo-R1
+
+**arXiv:** [2511.00088](https://arxiv.org/abs/2511.00088)
+
+**Weights:** [nvidia/Alpamayo-R1-10B](https://huggingface.co/nvidia/Alpamayo-R1-10B)
+
+**Code:** [NVlabs/alpamayo](https://github.com/NVlabs/alpamayo)
+
+## Summary
+
+Alpamayo-R1 combines Chain of Causation reasoning with a diffusion trajectory decoder for long-tail driving. The Chain of Causation dataset uses automated labeling plus human-in-the-loop review to produce decision-grounded traces, Cosmos-Reason supplies the VLM backbone, and a multi-stage recipe uses supervised fine-tuning followed by RL for reasoning-action consistency. The paper reports up to 12% higher planning accuracy on challenging cases, a 35% lower close-encounter rate in closed-loop simulation, 45% higher reasoning quality, 37% higher reasoning-action consistency, and 99 ms on-vehicle latency. The abstract does not define each metric or report independent retraining variance.
+
+## Core Insights
+
+The system makes the reasoning-to-action interface explicit. A chain is supposed to represent causal driving factors; a diffusion decoder converts the resulting state into a dynamically feasible trajectory; reinforcement learning rewards consistency between the two. This is stronger than attaching a rationale to an already chosen plan, but it means the quality of the causal trace, the action decoder, and the reward model all jointly determine the apparent safety gain.
+
+The paper also reports consistent gains from 0.5B to 7B parameters and on-vehicle urban tests. Those are encouraging deployment signals, though the abstract does not report sensor setup, route diversity, long-tail case prevalence, confidence intervals, or the fallback behavior when the reasoning and action disagree. A credible scaling claim needs matched model sizes, training data, and inference budgets, plus a severe-case test that does not overlap the auto-labeling pipeline.
+
+## High-Level Takeaways
+
+- Alpamayo-R1 makes a decision-grounded causal trace, rather than generic chain of thought, the interface between visual reasoning and diffusion trajectory prediction.
+- Its reported closed-loop and on-vehicle results are unusually relevant, but the abstract does not yet establish metric definitions, repeatability, or causal attribution across its dataset, model, decoder, and RL changes.
+- The decisive test holds the trajectory decoder and data fixed while scrambling, replacing, or counterfactually editing the causal trace; the central claim weakens if safety and planning accuracy remain unchanged.

--- a/src/content/posts/autovla-a-vision-language-action-model-for-end-to-end-autonomous-driving-with-adaptive-reasoning-and-reinforcement-fine-tuning.md
+++ b/src/content/posts/autovla-a-vision-language-action-model-for-end-to-end-autonomous-driving-with-adaptive-reasoning-and-reinforcement-fine-tuning.md
@@ -1,0 +1,30 @@
+---
+title: 'AutoVLA: A Vision-Language-Action Model for End-to-End Autonomous Driving with Adaptive Reasoning and Reinforcement Fine-Tuning'
+date: '2025-06-16T17:58:50.000Z'
+section: paper-shorts
+postSlug: autovla-a-vision-language-action-model-for-end-to-end-autonomous-driving-with-adaptive-reasoning-and-reinforcement-fine-tuning
+legacyPath: /paper shorts/2025/06/16/autovla-a-vision-language-action-model-for-end-to-end-autonomous-driving-with-adaptive-reasoning-and-reinforcement-fine-tuning.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – AutoVLA: A Vision-Language-Action Model for End-to-End Autonomous Driving with Adaptive Reasoning and Reinforcement Fine-Tuning"
+---
+## 2025 – AutoVLA
+
+**arXiv:** [2506.13757](https://arxiv.org/abs/2506.13757)
+
+## Summary
+
+AutoVLA puts semantic reasoning and trajectory planning in one autoregressive generation stream. It discretizes continuous trajectories into feasible action tokens, trains both a fast trajectory-only mode and a slower chain-of-thought mode with supervised fine-tuning, then applies GRPO to reduce unnecessary reasoning on straightforward scenes. The paper reports competitive results across nuPlan, nuScenes, Waymo, and CARLA in open- and closed-loop settings. The abstract does not report the tokenization resolution, the trigger for slow reasoning, or the compute cost of its adaptive policy.
+
+## Core Insights
+
+The paper makes action tokenization the bridge between reasoning and control. A feasible trajectory becomes a sequence the same model can emit alongside language, which eliminates a separate planning decoder but introduces quantization and autoregressive latency. The two thinking modes make the design more specific: the system is supposed to spend more reasoning tokens only when the scene needs them, rather than paying a fixed chain-of-thought cost on every route.
+
+The abstract describes GRPO as the mechanism that encourages this economy, but does not disclose the reward design, thought-length constraint, action vocabulary, or a matched continuous-action baseline. It also does not establish that the selected amount of reasoning tracks actual driving difficulty rather than dataset artifacts. The needed test holds action quality and compute budgets fixed while comparing fixed short, fixed long, and learned adaptive reasoning under counterfactual scene complexity.
+
+## High-Level Takeaways
+
+- AutoVLA treats discrete feasible trajectory tokens as the shared interface between semantic reasoning and end-to-end planning.
+- Its broad benchmark coverage supports the unified model, but the abstract does not show how much accuracy, safety, or latency comes from tokenization versus adaptive reasoning and GRPO.
+- The adaptive-reasoning claim fails if fixed-budget policies match it on hard scenes or if the model spends longer traces on visually easy but linguistically familiar examples.

--- a/src/content/posts/covla-comprehensive-vision-language-action-dataset-for-autonomous-driving.md
+++ b/src/content/posts/covla-comprehensive-vision-language-action-dataset-for-autonomous-driving.md
@@ -1,0 +1,32 @@
+---
+title: 'CoVLA: Comprehensive Vision-Language-Action Dataset for Autonomous Driving'
+date: '2024-08-19T09:53:49.000Z'
+section: paper-shorts
+postSlug: covla-comprehensive-vision-language-action-dataset-for-autonomous-driving
+legacyPath: /paper shorts/2024/08/19/covla-comprehensive-vision-language-action-dataset-for-autonomous-driving.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2024 – CoVLA: Comprehensive Vision-Language-Action Dataset for Autonomous Driving"
+---
+## 2024 – CoVLA
+
+**arXiv:** [2408.10845](https://arxiv.org/abs/2408.10845)
+
+**Project:** [CoVLA-AD](https://turingmotors.github.io/covla-ad/)
+
+## Summary
+
+CoVLA contributes a driving dataset rather than a new action architecture. It contains more than 80 hours of real-world video, paired with generated driving trajectories and natural-language descriptions of the environment and maneuvers. The paper uses the collection to train and inspect multimodal models that emit language and action together. Its abstract reports coherent outputs, but does not give a closed-loop comparison or an independent annotation-quality audit.
+
+## Core Insights
+
+The data pipeline starts from raw in-vehicle sensor records, then combines automated processing with caption generation to construct vision-language-action examples. That makes the example unit a driving clip with both an executable-looking trajectory and a text account of the scene. The scalable construction is the point: end-to-end VLA work needs examples where the rationale and action refer to the same temporal event.
+
+The trade-off is provenance. Automated captions and trajectory pairing can enlarge a corpus much faster than human annotation, but a model can inherit errors or shortcuts from both generators. The abstract does not report the caption model, trajectory-label source, temporal alignment tolerance, human validation rate, or a comparison with an equivalently sized human-authored subset. Those are the controls needed to distinguish scale from label quality.
+
+## High-Level Takeaways
+
+- CoVLA makes a video, a maneuver description, and a trajectory the shared supervision unit for driving VLA training.
+- The reported scale—more than 80 hours of real-world driving video—addresses a genuine data bottleneck, but the abstract does not establish independent label fidelity.
+- A matched-data study should compare automated and human-verified captions and trajectories on the same clips; the dataset claim weakens if extra examples help only when their generated labels are trusted blindly.

--- a/src/content/posts/drive-r1-bridging-reasoning-and-planning-in-vlms-for-autonomous-driving-with-reinforcement-learning.md
+++ b/src/content/posts/drive-r1-bridging-reasoning-and-planning-in-vlms-for-autonomous-driving-with-reinforcement-learning.md
@@ -1,0 +1,30 @@
+---
+title: 'Drive-R1: Bridging Reasoning and Planning in VLMs for Autonomous Driving with Reinforcement Learning'
+date: '2025-06-23T01:57:14.000Z'
+section: paper-shorts
+postSlug: drive-r1-bridging-reasoning-and-planning-in-vlms-for-autonomous-driving-with-reinforcement-learning
+legacyPath: /paper shorts/2025/06/23/drive-r1-bridging-reasoning-and-planning-in-vlms-for-autonomous-driving-with-reinforcement-learning.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – Drive-R1: Bridging Reasoning and Planning in VLMs for Autonomous Driving with Reinforcement Learning"
+---
+## 2025 – Drive-R1
+
+**arXiv:** [2506.18234](https://arxiv.org/abs/2506.18234)
+
+## Summary
+
+Drive-R1 trains a small domain-specific VLM to reason from visual input to a driving plan, then reinforces it with trajectory- and meta-action-based rewards. Its supervised stage contains both long and short chains of thought; the reinforcement stage is intended to favor reasoning paths that improve planning rather than merely sound plausible. The paper reports superior results on nuScenes and DriveLM-nuScenes relative to its compared VLMs. The abstract does not provide planning metrics, reward weights, or a closed-loop evaluation.
+
+## Core Insights
+
+The paper starts from two failure hypotheses: VLMs may exploit historical input rather than visual evidence, and their chains of thought may be misaligned with the trajectories they generate. Long and short reasoning traces give the model alternative paths, while the RL reward connects those paths to trajectory and meta-action outcomes. This makes reasoning a policy component rather than an unscored explanation.
+
+The crucial causal question remains open. The abstract does not say how visual shortcuts are detected, what portion of the trajectory reward is attributable to the trace, or whether reasoning remains useful when history is masked or counterfactually edited. An appropriate ablation would compare visual-only, history-only, and jointly conditioned policies with matched trace lengths and rewards, then test whether visual edits alter both the trace and plan consistently.
+
+## High-Level Takeaways
+
+- Drive-R1 uses supervised chains of thought plus trajectory-aware reinforcement learning to connect visual reasoning with a driving plan.
+- Its reported nuScenes and DriveLM results support that alignment objective, but the abstract does not establish that the model relies on current visual evidence rather than historical shortcuts.
+- The key falsification is a counterfactual visual-and-history evaluation: if the plan remains unchanged when the causal visual evidence changes, a planning-aligned trace is still only a plausible narration.

--- a/src/content/posts/drivegpt4-interpretable-end-to-end-autonomous-driving-via-large-language-model.md
+++ b/src/content/posts/drivegpt4-interpretable-end-to-end-autonomous-driving-via-large-language-model.md
@@ -1,0 +1,30 @@
+---
+title: 'DriveGPT4: Interpretable End-to-end Autonomous Driving via Large Language Model'
+date: '2023-10-02T17:59:52.000Z'
+section: paper-shorts
+postSlug: drivegpt4-interpretable-end-to-end-autonomous-driving-via-large-language-model
+legacyPath: /paper shorts/2023/10/02/drivegpt4-interpretable-end-to-end-autonomous-driving-via-large-language-model.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLMs & Evaluation'
+summary: "2023 – DriveGPT4: Interpretable End-to-end Autonomous Driving via Large Language Model"
+---
+## 2023 – DriveGPT4
+
+**arXiv:** [2310.01412](https://arxiv.org/abs/2310.01412)
+
+## Summary
+
+DriveGPT4 puts natural-language explanation and low-level driving control behind one multimodal language-model interface. It consumes multi-frame video and textual queries, then produces scene-grounded answers, action rationales, and control signals. The paper reports quantitative and qualitative results on BDD-X and compares its domain-tuned system with GPT-4V for driving grounding; the abstract does not disclose a closed-loop safety evaluation.
+
+## Core Insights
+
+The paper's central choice is to make the same model answer a question about a maneuver and predict the maneuver's low-level control. A custom visual-instruction dataset supplies the driving-specific supervision, while the paper's mix-finetuning recipe combines that data with the base model's broader capabilities. This is a tighter coupling than a VLM used only as a captioner, but it does not by itself establish that a fluent explanation caused the control output.
+
+BDD-X makes the evaluation legible because it pairs driving video with human-facing explanations. The abstract does not report the action horizon, control representation, loss weighting, training-set size, or a matched ablation that removes explanation supervision while holding control data fixed. Those omissions matter: a shared decoder can correlate language and action without ensuring that its language evidence drives the control decision.
+
+## High-Level Takeaways
+
+- DriveGPT4 makes driving explanation and low-level control co-products of a multi-frame, text-conditioned model rather than separate modules.
+- Its reported BDD-X result is evidence for driving grounding and explanation, not a demonstration of closed-loop robustness under distribution shift.
+- The expensive decision is whether to train one autoregressive interface for words and controls; a matched control-only versus joint-training study would test whether the language channel improves action rather than merely describes it.

--- a/src/content/posts/drivemoe-mixture-of-experts-for-vision-language-action-model-in-end-to-end-autonomous-driving.md
+++ b/src/content/posts/drivemoe-mixture-of-experts-for-vision-language-action-model-in-end-to-end-autonomous-driving.md
@@ -1,0 +1,32 @@
+---
+title: 'DriveMoE: Mixture-of-Experts for Vision-Language-Action Model in End-to-End Autonomous Driving'
+date: '2025-05-22T06:23:04.000Z'
+section: paper-shorts
+postSlug: drivemoe-mixture-of-experts-for-vision-language-action-model-in-end-to-end-autonomous-driving
+legacyPath: /paper shorts/2025/05/22/drivemoe-mixture-of-experts-for-vision-language-action-model-in-end-to-end-autonomous-driving.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – DriveMoE: Mixture-of-Experts for Vision-Language-Action Model in End-to-End Autonomous Driving"
+---
+## 2025 – DriveMoE
+
+**arXiv:** [2505.16278](https://arxiv.org/abs/2505.16278)
+
+**Project:** [DriveMoE](https://thinklab-sjtu.github.io/DriveMoE/)
+
+## Summary
+
+DriveMoE adds two sparse-routing decisions to a Drive-$\pi_0$ VLA baseline. A scene-specialized Vision MoE selects camera evidence for the driving context, while a skill-specialized Action MoE selects behavior modules for different maneuvers. The paper reports state-of-the-art Bench2Drive closed-loop performance. Its abstract does not give the number of experts, routing load, action latency, or a matched dense-capacity baseline.
+
+## Core Insights
+
+The two routers act at different stages. Vision routing allocates perception compute across cameras; action routing allocates policy capacity across driving skills. That separation targets two sources of averaging: processing every view equally and asking one action function to cover heterogeneous maneuvers. It also creates two ways to fail: the system can suppress the camera that contains the hazard, or select an unsuitable action expert before the maneuver is fully visible.
+
+The result cannot establish which router accounts for the reported improvement without controlled ablations. The abstract does not disclose routing regularization, load balance, expert utilization, data mixture, or whether rare maneuvers receive enough examples to train their specialist. A useful scale test would keep total active FLOPs and demonstrations fixed while comparing a dense model, vision-only routing, action-only routing, and both routers under long-tail route splits.
+
+## High-Level Takeaways
+
+- DriveMoE uses sparse specialization twice: once to choose visual evidence and once to choose a driving behavior module.
+- The reported closed-loop result motivates expert routing, but the abstract does not yet isolate its efficiency, calibration, or rare-event benefits from the larger composite architecture.
+- The key rejection test holds active compute and data fixed; if a dense conditional policy matches safety and long-tail success, the extra routing complexity is not justified.

--- a/src/content/posts/dynrsl-vlm-enhancing-autonomous-driving-perception-with-dynamic-resolution-vision-language-models.md
+++ b/src/content/posts/dynrsl-vlm-enhancing-autonomous-driving-perception-with-dynamic-resolution-vision-language-models.md
@@ -1,0 +1,30 @@
+---
+title: 'DynRsl-VLM: Enhancing Autonomous Driving Perception with Dynamic Resolution Vision-Language Models'
+date: '2025-03-14T10:19:24.000Z'
+section: paper-shorts
+postSlug: dynrsl-vlm-enhancing-autonomous-driving-perception-with-dynamic-resolution-vision-language-models
+legacyPath: /paper shorts/2025/03/14/dynrsl-vlm-enhancing-autonomous-driving-perception-with-dynamic-resolution-vision-language-models.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLMs & Evaluation'
+summary: "2025 – DynRsl-VLM: Enhancing Autonomous Driving Perception with Dynamic Resolution Vision-Language Models"
+---
+## 2025 – DynRsl-VLM
+
+**arXiv:** [2503.11265](https://arxiv.org/abs/2503.11265)
+
+## Summary
+
+DynRsl-VLM changes the visual interface of a driving VLM. Instead of accepting a heavily downsampled image, it uses dynamic-resolution processing to retain entity detail while keeping the Vision Transformer input tractable. A custom image-text alignment module replaces a Q-Former for the resulting variable-resolution features. The paper frames distant pedestrians, signs, and obstacles as the motivation; the abstract does not report a driving benchmark, a control result, or a quantitative small-object analysis.
+
+## Core Insights
+
+Resolution is a deployment decision, not merely a vision-backbone setting. Fixed downsampling spends roughly the same visual budget everywhere and can discard the objects that matter most in driving. DynRsl-VLM instead keeps a flexible number of image features, then aligns them to text with an interface designed for that representation. The intended gain is perceptual coverage without an unbounded token cost.
+
+The trade-off is that dynamic resolution moves cost and variance into the tokenization and alignment path. The abstract does not disclose the resolution-selection rule, visual-token distribution, inference latency, data mixture, or an equal-compute comparison against fixed high- and low-resolution baselines. A clear evaluation would stratify objects by pixel size, distance, and occlusion while holding the end-to-end token budget constant.
+
+## High-Level Takeaways
+
+- DynRsl-VLM makes preservation of small and distant driving evidence the primary representation decision, then adapts the language-alignment interface to that variable input.
+- The abstract establishes a perceptual motivation but does not yet establish that dynamic resolution improves action quality or safety at a fixed latency.
+- A matched token- and wall-clock-budget study should compare dynamic resolution with fixed-resolution and adaptive-cropping baselines; the claim weakens if any of them recover the same small-object evidence.

--- a/src/content/posts/futuresightdrive-thinking-visually-with-spatio-temporal-cot-for-autonomous-driving.md
+++ b/src/content/posts/futuresightdrive-thinking-visually-with-spatio-temporal-cot-for-autonomous-driving.md
@@ -1,0 +1,32 @@
+---
+title: 'FutureSightDrive: Thinking Visually with Spatio-Temporal CoT for Autonomous Driving'
+date: '2025-05-23T09:55:32.000Z'
+section: paper-shorts
+postSlug: futuresightdrive-thinking-visually-with-spatio-temporal-cot-for-autonomous-driving
+legacyPath: /paper shorts/2025/05/23/futuresightdrive-thinking-visually-with-spatio-temporal-cot-for-autonomous-driving.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – FutureSightDrive: Thinking Visually with Spatio-Temporal CoT for Autonomous Driving"
+---
+## 2025 – FutureSightDrive (FSDrive)
+
+**arXiv:** [2505.17685](https://arxiv.org/abs/2505.17685)
+
+**Code:** [MIV-XJTU/FSDrive](https://github.com/MIV-XJTU/FSDrive)
+
+## Summary
+
+FutureSightDrive makes its chain of thought a predicted visual scene rather than a text trace. A world-model path generates a future frame with background, future lane dividers, and 3D boxes; an inverse-dynamics VLA then plans a trajectory from the current observation and that visual spatio-temporal CoT. The paper reports improved trajectory accuracy and fewer collisions on nuScenes and NAVSIM, plus competitive video-generation FID and DriveLM understanding results. The abstract does not report the planning latency or a control that replaces the imagined frame with an equally informative nonvisual state.
+
+## Core Insights
+
+The representation choice is deliberate. Textual reasoning can discard geometry and temporal relations before planning, whereas a predicted future scene can carry lanes, actors, and motion in one visual object. FSDrive expands the vocabulary with visual tokens and jointly trains VQA and future-frame prediction. Its progressive curriculum predicts structural priors before rendering the whole scene, which makes physical constraints part of the generation target rather than an after-the-fact caption.
+
+The cost is prediction error. The planner consumes a generated scene, so errors in lanes, boxes, or background can become action errors even when the current camera view is clear. The abstract does not disclose the visual-token budget, forecast horizon, loss weights, or a teacher-forced imagined-scene comparison. The key safety test should measure how action quality changes as forecast error is injected independently into map structure, moving actors, and scene appearance.
+
+## High-Level Takeaways
+
+- FSDrive makes a predicted visual future the intermediate reasoning object, then conditions an inverse-dynamics planner on that object.
+- Its reported nuScenes and NAVSIM results support the visual-CoT hypothesis, but do not isolate prediction quality from the rest of the VLA training recipe.
+- The approach is justified only if planning degrades gracefully under forecast errors; an equally sized latent or structured prediction state that matches safety would weaken the case for rendering a future frame.

--- a/src/content/posts/impromptu-vla-open-weights-and-open-data-for-driving-vision-language-action-models.md
+++ b/src/content/posts/impromptu-vla-open-weights-and-open-data-for-driving-vision-language-action-models.md
@@ -1,0 +1,32 @@
+---
+title: 'Impromptu VLA: Open Weights and Open Data for Driving Vision-Language-Action Models'
+date: '2025-05-29T17:59:46.000Z'
+section: paper-shorts
+postSlug: impromptu-vla-open-weights-and-open-data-for-driving-vision-language-action-models
+legacyPath: /paper shorts/2025/05/29/impromptu-vla-open-weights-and-open-data-for-driving-vision-language-action-models.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – Impromptu VLA: Open Weights and Open Data for Driving Vision-Language-Action Models"
+---
+## 2025 – Impromptu VLA
+
+**arXiv:** [2505.23757](https://arxiv.org/abs/2505.23757)
+
+**Code, data, and models:** [ahydchh/Impromptu-VLA](https://github.com/ahydchh/Impromptu-VLA)
+
+## Summary
+
+Impromptu VLA is a data and evaluation intervention for unstructured driving corner cases. Its dataset contains more than 80,000 curated video clips distilled from more than two million clips across eight open datasets. The clips are organized around four challenging categories and pair planning-oriented questions with action trajectories. The paper reports improved NeuroNCAP closed-loop scores and collision rates, plus near state-of-the-art open-loop nuScenes trajectory accuracy; the abstract does not disclose the data split, model architectures, or a human-quality audit of the annotations.
+
+## Core Insights
+
+The paper's contribution is to make the example unit richer than a trajectory: a clip carries visual evidence, questions that probe perception, prediction, and planning, and an action target. This creates a diagnostic bridge between what a VLA says it sees and what it plans to do. The paper's four-category taxonomy is intended to concentrate data on unstructured cases where generic driving corpora provide weak coverage.
+
+The key trade-off is curation versus distributional representativeness. Reducing over two million source clips to 80,000 targeted examples can improve coverage of difficult cases, but it can also bake the taxonomy and the question generator into the benchmark. The abstract does not report category balance, source-dataset overlap with evaluation, annotation provenance, or a matched random-subset control. Those are necessary to tell whether the gain comes from hard-case selection, more data, or benchmark alignment.
+
+## High-Level Takeaways
+
+- Impromptu VLA makes a corner-case video, planning question, and trajectory the shared training and diagnostic unit.
+- Its reported closed- and open-loop signals support targeted data curation, but the abstract does not establish independence between the curated corpus and the evaluations.
+- The claim should be tested against equal-size random and taxonomy-matched subsets on held-out environments; it weakens if the advantage disappears when the question style or source domain changes.

--- a/src/content/posts/langcoop-collaborative-driving-with-language.md
+++ b/src/content/posts/langcoop-collaborative-driving-with-language.md
@@ -1,0 +1,32 @@
+---
+title: 'LangCoop: Collaborative Driving with Language'
+date: '2025-04-18T02:03:14.000Z'
+section: paper-shorts
+postSlug: langcoop-collaborative-driving-with-language
+legacyPath: /paper shorts/2025/04/18/langcoop-collaborative-driving-with-language.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – LangCoop: Collaborative Driving with Language"
+---
+## 2025 – LangCoop
+
+**arXiv:** [2504.13406](https://arxiv.org/abs/2504.13406)
+
+**Project and code:** [LangCoop](https://xiangbogaobarry.github.io/LangCoop/)
+
+## Summary
+
+LangCoop makes natural language the communication medium between collaborating vehicles. Its $M^3$CoT component structures zero-shot vision-language reasoning, while LangPack turns selected information into concise language messages. In CARLA, the paper reports up to a 96% reduction in communication bandwidth, with messages under 2 KB, while retaining competitive closed-loop driving performance. The abstract does not report message loss, latency, or an evaluation against adversarial or misleading language.
+
+## Core Insights
+
+The paper changes what travels across the vehicle-to-vehicle link. Rather than transmitting raw images or dense learned features, one agent packages a language description intended to preserve decision-relevant evidence for another. This is attractive for bandwidth and heterogeneous sensor stacks because language is compact and semantically structured. It also gives the receiver a lossy, generated representation whose omissions and ambiguities can change a maneuver.
+
+The abstract couples message selection, language generation, and driving evaluation. It does not disclose the message vocabulary, length distribution, decoding delay, receiver model, or a matched semantic-token baseline at equal bandwidth. A communication result should test not only mean driving score but also whether a corrupted, delayed, or confidently wrong message produces detectable uncertainty rather than a confident unsafe action.
+
+## High-Level Takeaways
+
+- LangCoop treats a compact language message as the inter-agent coordination unit, replacing high-bandwidth visual exchange with generated decision-relevant content.
+- The reported bandwidth reduction is substantial, but the abstract does not establish resilience to message corruption, ambiguity, or communication delay.
+- A matched study should compare language, learned discrete tokens, and compressed feature packets under the same byte budget and network faults; the language interface fails if its semantic compression hides hazards the other media preserve.

--- a/src/content/posts/orion-a-holistic-end-to-end-autonomous-driving-framework-by-vision-language-instructed-action-generation.md
+++ b/src/content/posts/orion-a-holistic-end-to-end-autonomous-driving-framework-by-vision-language-instructed-action-generation.md
@@ -1,0 +1,30 @@
+---
+title: 'ORION: A Holistic End-to-End Autonomous Driving Framework by Vision-Language Instructed Action Generation'
+date: '2025-03-25T15:18:43.000Z'
+section: paper-shorts
+postSlug: orion-a-holistic-end-to-end-autonomous-driving-framework-by-vision-language-instructed-action-generation
+legacyPath: /paper shorts/2025/03/25/orion-a-holistic-end-to-end-autonomous-driving-framework-by-vision-language-instructed-action-generation.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – ORION: A Holistic End-to-End Autonomous Driving Framework by Vision-Language Instructed Action Generation"
+---
+## 2025 – ORION
+
+**arXiv:** [2503.19755](https://arxiv.org/abs/2503.19755)
+
+## Summary
+
+ORION couples long-horizon scene history, language-model reasoning, and a generative trajectory planner in one end-to-end framework. QT-Former aggregates the history, an LLM produces driving reasoning, and the planner turns the combined state into precise trajectories. On Bench2Drive, the paper reports a 77.74 driving score and 54.62% success rate—improvements of 14.28 score points and 19.61 percentage points over its stated prior best. The abstract does not report latency, number of seeds, or a reasoning-ablation matched to the planner.
+
+## Core Insights
+
+ORION is organized around a specific interface problem: semantic reasoning and numeric trajectories inhabit different spaces. The model aligns them while jointly optimizing VQA and planning, so the reasoning path can condition action generation instead of remaining a post-hoc explanation. QT-Former supplies longer temporal context before that reasoning step, which is important for interactive driving decisions that a single frame cannot determine.
+
+The reported closed-loop improvement is stronger evidence than an open-loop trajectory score, but it does not by itself isolate why the system wins. The abstract omits the training corpus, loss balance between VQA and planning, action representation, and a test that substitutes uninformative or counterfactual reasoning while preserving the visual input. Without those controls, semantic reasoning, history aggregation, and the generative planner remain coupled interventions.
+
+## High-Level Takeaways
+
+- ORION joins a history encoder, an LLM reasoning path, and a generative planner to make semantic context an input to trajectory generation.
+- Its reported Bench2Drive result is meaningful closed-loop evidence, though the abstract does not separate the contributions of reasoning, temporal context, and planning architecture.
+- The decisive falsification replaces the reasoning trace with matched-length irrelevant or counterfactual traces; the reasoning-action claim weakens if safety and success do not change in the predicted direction.

--- a/src/content/posts/rag-driver-generalisable-driving-explanations-with-retrieval-augmented-in-context-learning.md
+++ b/src/content/posts/rag-driver-generalisable-driving-explanations-with-retrieval-augmented-in-context-learning.md
@@ -1,0 +1,30 @@
+---
+title: 'RAG-Driver: Generalisable Driving Explanations with Retrieval-Augmented In-Context Learning in Multi-Modal Large Language Model'
+date: '2024-02-16T16:57:18.000Z'
+section: paper-shorts
+postSlug: rag-driver-generalisable-driving-explanations-with-retrieval-augmented-in-context-learning
+legacyPath: /paper shorts/2024/02/16/rag-driver-generalisable-driving-explanations-with-retrieval-augmented-in-context-learning.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLMs & Evaluation'
+summary: "2024 – RAG-Driver: Generalisable Driving Explanations with Retrieval-Augmented In-Context Learning"
+---
+## 2024 – RAG-Driver
+
+**arXiv:** [2402.10828](https://arxiv.org/abs/2402.10828)
+
+## Summary
+
+RAG-Driver uses retrieved expert demonstrations as in-context evidence for a multimodal driving model. Its stated goal is to generate a control prediction together with driving explanations and justifications without repeatedly fine-tuning a large model for every domain. The paper reports state-of-the-art results on its evaluated explanation and control tasks, plus zero-shot generalization to unseen environments; the abstract does not provide the benchmark breakdown or a closed-loop safety result.
+
+## Core Insights
+
+The paper moves adaptation from model weights to the prompt. A retrieval step selects expert demonstrations that the multimodal language model can condition on when interpreting the current driving scene. That is useful when annotations are scarce or data domains differ, because the system can change its evidence set without a training run. It also creates a new deployment dependency: irrelevant or misleading retrieval can change both the explanation and the predicted control.
+
+The abstract frames expensive annotation, domain gaps, training cost, and catastrophic forgetting as the inherited constraints. It does not disclose the retrieval embedding, the number of demonstrations, the control representation, or an ablation that separates retrieval quality from in-context reasoning. The central claim would be stronger with a matched retrieval-free prompt, random demonstrations, and an oracle-retrieval condition evaluated on both explanation fidelity and action safety.
+
+## High-Level Takeaways
+
+- RAG-Driver treats a retrieved multimodal demonstration, not a gradient update, as the primary unit of driving adaptation.
+- Its reported zero-shot result supports retrieval as a way to transfer explanation and control behavior, but not as proof that the retrieved evidence is causally used.
+- At larger deployment scale, retrieval coverage and failure detection are likely to matter more than decoder fluency; random- and oracle-retrieval controls would falsify an apparent retrieval gain.

--- a/src/content/posts/recogdrive-a-reinforced-cognitive-framework-for-end-to-end-autonomous-driving.md
+++ b/src/content/posts/recogdrive-a-reinforced-cognitive-framework-for-end-to-end-autonomous-driving.md
@@ -1,0 +1,30 @@
+---
+title: 'ReCogDrive: A Reinforced Cognitive Framework for End-to-End Autonomous Driving'
+date: '2025-06-09T03:14:04.000Z'
+section: paper-shorts
+postSlug: recogdrive-a-reinforced-cognitive-framework-for-end-to-end-autonomous-driving
+legacyPath: /paper shorts/2025/06/09/recogdrive-a-reinforced-cognitive-framework-for-end-to-end-autonomous-driving.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – ReCogDrive: A Reinforced Cognitive Framework for End-to-End Autonomous Driving"
+---
+## 2025 – ReCogDrive
+
+**arXiv:** [2506.08052](https://arxiv.org/abs/2506.08052)
+
+## Summary
+
+ReCogDrive separates driving cognition from continuous action generation. An autoregressive VLM learns driving priors through a three-stage data pipeline—generation, refinement, and quality control—then conditions a diffusion planner that produces continuous trajectories. A Diffusion Group Relative Policy Optimization stage targets safety and comfort. The paper reports state-of-the-art results on NAVSIM and Bench2Drive, plus qualitative DriveBench understanding results; the abstract does not provide the underlying scores, planning latency, or a component-level ablation.
+
+## Core Insights
+
+The design responds to a language-action mismatch: trajectory coordinates represented as text can be invalid, infeasible, or slow to decode. ReCogDrive retains an autoregressive model for driving understanding, but transfers its learned priors into a diffusion trajectory planner instead of asking the language model to serialize controls itself. The staged data pipeline is intended to give the VLM a more structured cognitive representation before that handoff.
+
+The model changes three major variables at once—data curation, action interface, and reinforcement objective. The abstract does not specify the trajectory diffusion parameterization, the rewards used by DiffGRPO, the relative loss weights, or a matched continuous non-diffusion planner. A causal result would need to freeze the data and VLM, then independently swap the action decoder and the reinforcement stage while measuring safety, comfort, and wall-clock cost.
+
+## High-Level Takeaways
+
+- ReCogDrive uses language-like cognition to condition a continuous diffusion planner, explicitly splitting understanding from the physical action interface.
+- Its reported NAVSIM and Bench2Drive results make the hybrid plausible, but the abstract does not identify whether data curation, diffusion, or DiffGRPO drives the outcome.
+- The architecture earns its complexity only if a matched continuous decoder and equal-budget RL study cannot recover the same safety and comfort improvements.

--- a/src/content/posts/s4-driver-scalable-self-supervised-driving-multimodal-large-language-model-with-spatio-temporal-visual-representation.md
+++ b/src/content/posts/s4-driver-scalable-self-supervised-driving-multimodal-large-language-model-with-spatio-temporal-visual-representation.md
@@ -1,0 +1,32 @@
+---
+title: 'S4-Driver: Scalable Self-Supervised Driving Multimodal Large Language Model with Spatio-Temporal Visual Representation'
+date: '2025-05-30T02:20:14.000Z'
+section: paper-shorts
+postSlug: s4-driver-scalable-self-supervised-driving-multimodal-large-language-model-with-spatio-temporal-visual-representation
+legacyPath: /paper shorts/2025/05/30/s4-driver-scalable-self-supervised-driving-multimodal-large-language-model-with-spatio-temporal-visual-representation.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – S4-Driver: Scalable Self-Supervised Driving Multimodal Large Language Model with Spatio-Temporal Visual Representation"
+---
+## 2025 – S4-Driver
+
+**arXiv:** [2505.24139](https://arxiv.org/abs/2505.24139)
+
+**Project:** [S4-Driver](https://s4-driver.github.io/)
+
+## Summary
+
+S4-Driver turns multi-view, multi-frame visual features from a PaLI multimodal model into a sparse 3D volume, then plans in that 3D representation without fine-tuning the vision encoder. The self-supervised recipe targets trajectories directly and avoids human intermediate annotations. The paper reports favorable results against supervised multi-task approaches on nuScenes and Waymo Open Motion Dataset camera data, with further scaling on unannotated driving logs. The abstract does not give the pretraining volume, the self-supervised objective, or closed-loop safety metrics.
+
+## Core Insights
+
+The paper's hypothesis is that 2D reasoning features are a poor native interface for 3D planning. Its sparse volume connects views and time in a spatial representation before the planner produces a trajectory. The intervention is therefore not a language-model decoder trick; it is the carrier used between the pretrained vision model and the action output. Freezing the visual encoder keeps the scaling path focused on driving logs and the new 3D representation.
+
+Self-supervision removes the cost of object, map, and motion labels, but it does not remove the need for a planning target or a reliable geometric convention. The abstract does not report how the sparse volume is constructed, temporal alignment, trajectory loss, camera coverage, or a matched frozen-encoder 2D baseline. A useful test would hold all image data and planning targets fixed while varying only the representation carrier—2D tokens, BEV features, and the sparse volume.
+
+## High-Level Takeaways
+
+- S4-Driver makes a sparse spatio-temporal volume, rather than 2D language-aligned features, the planning representation.
+- Its reported nuScenes and Waymo results support self-supervised 3D feature construction, but do not establish which part of the gain comes from geometry, data scale, or the frozen PaLI prior.
+- The decisive control is an equal-data, equal-compute representation comparison; the self-supervised claim weakens if a simple 2D or BEV adapter matches planning quality without the sparse-volume machinery.

--- a/src/content/posts/safeauto-knowledge-enhanced-safe-autonomous-driving-with-multimodal-foundation-models.md
+++ b/src/content/posts/safeauto-knowledge-enhanced-safe-autonomous-driving-with-multimodal-foundation-models.md
@@ -1,0 +1,32 @@
+---
+title: 'SafeAuto: Knowledge-Enhanced Safe Autonomous Driving with Multimodal Foundation Models'
+date: '2025-02-28T21:53:47.000Z'
+section: paper-shorts
+postSlug: safeauto-knowledge-enhanced-safe-autonomous-driving-with-multimodal-foundation-models
+legacyPath: /paper shorts/2025/02/28/safeauto-knowledge-enhanced-safe-autonomous-driving-with-multimodal-foundation-models.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – SafeAuto: Knowledge-Enhanced Safe Autonomous Driving with Multimodal Foundation Models"
+---
+## 2025 – SafeAuto
+
+**arXiv:** [2503.00211](https://arxiv.org/abs/2503.00211)
+
+**Code:** [AI-secure/SafeAuto](https://github.com/AI-secure/SafeAuto)
+
+## Summary
+
+SafeAuto combines three safety-oriented interfaces around a multimodal foundation model: a position-dependent cross-entropy loss for text-encoded controls, traffic rules translated into first-order logic and checked through a Markov Logic Network, and retrieval over prior multimodal driving experience. The paper reports gains over its baselines across multiple datasets. The abstract does not report the safety metrics, the rate at which the rule checker catches harmful actions, or a closed-loop intervention study.
+
+## Core Insights
+
+The architecture accepts that a language-model control sequence can be syntactically valid yet physically unsafe. PDCE changes how errors in text-form control values are weighted, while the rule path checks proposed actions against recognized environmental attributes and formal traffic rules. The retrieval path supplies past video, controls, and attributes as additional evidence. These components change different failure modes—numeric token error, rule violation, and missing precedent—so the resulting gain cannot be assigned to one without factorial controls.
+
+The atomic decision is whether safety knowledge belongs only in training data or remains as an explicit verification interface at inference. The abstract does not disclose the PDCE weighting function, knowledge-base coverage, false-positive and false-negative rates, or the arbitration rule when the verifier rejects a prediction. A useful test would hold the perception and control model fixed, then measure rule-checker calibration against an independent, adversarially curated set of traffic conflicts.
+
+## High-Level Takeaways
+
+- SafeAuto keeps safety knowledge explicit: text-control loss shaping, symbolic rule checking, and multimodal retrieval each address a different interface failure.
+- Its reported multi-dataset gains do not yet identify whether the deployed safety improvement comes from better prediction, better verification, or both.
+- The central falsification is a closed-loop ablation that removes each interface independently and reports violations, rejected-safe actions, latency, and recovery behavior under the same route distribution.

--- a/src/content/posts/simlingo-vision-only-closed-loop-autonomous-driving-with-language-action-alignment.md
+++ b/src/content/posts/simlingo-vision-only-closed-loop-autonomous-driving-with-language-action-alignment.md
@@ -1,0 +1,30 @@
+---
+title: 'SimLingo: Vision-Only Closed-Loop Autonomous Driving with Language-Action Alignment'
+date: '2025-03-12T17:58:06.000Z'
+section: paper-shorts
+postSlug: simlingo-vision-only-closed-loop-autonomous-driving-with-language-action-alignment
+legacyPath: /paper shorts/2025/03/12/simlingo-vision-only-closed-loop-autonomous-driving-with-language-action-alignment.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLA & Planning'
+summary: "2025 – SimLingo: Vision-Only Closed-Loop Autonomous Driving with Language-Action Alignment"
+---
+## 2025 – SimLingo
+
+**arXiv:** [2503.09594](https://arxiv.org/abs/2503.09594)
+
+## Summary
+
+SimLingo is a camera-only VLM that is trained to do closed-loop driving, vision-language understanding, and language-action alignment together. Its claim is narrower and more useful than a generic VQA score: language understanding matters for driving only when the answer remains consistent with the action. The paper reports strong Bench2Drive performance in CARLA and identifies the system as the CARLA Challenge 2024 winner; the abstract does not specify action frequency, training data size, or a real-road evaluation.
+
+## Core Insights
+
+The paper treats language-action alignment as a distinct task rather than assuming that good captions imply good maneuvers. A vision-language model receives only camera input, so it must map visual evidence into an action policy while preserving enough semantic structure to answer driving questions. This makes the model's explanation and behavior testable against one another, but a common latent decoder can still produce consistent wrong answers and wrong actions.
+
+The abstract establishes a three-task training target but does not disclose the objective weights, the annotation protocol for alignment, or an ablation that removes each task while matching total optimization budget. The key comparison should test whether alignment supervision improves closed-loop safety beyond a driving-only policy and whether it survives counterfactual visual edits that should change the maneuver but not irrelevant narration.
+
+## High-Level Takeaways
+
+- SimLingo makes a camera-only driving policy answerable in language while explicitly checking that its language and action outputs agree.
+- The reported Bench2Drive result is closed-loop simulator evidence, not proof that language alignment transfers to physical driving or rare visual failures.
+- The costly design choice is multitask supervision; a matched driving-only, VQA-only, and joint-training sweep would reveal whether alignment is a causal control signal rather than an auxiliary reporting head.

--- a/src/content/posts/ts-vlm-text-guided-softsort-pooling-for-vision-language-models-in-multi-view-driving-reasoning.md
+++ b/src/content/posts/ts-vlm-text-guided-softsort-pooling-for-vision-language-models-in-multi-view-driving-reasoning.md
@@ -1,0 +1,30 @@
+---
+title: 'TS-VLM: Text-Guided SoftSort Pooling for Vision-Language Models in Multi-View Driving Reasoning'
+date: '2025-05-19T03:37:15.000Z'
+section: paper-shorts
+postSlug: ts-vlm-text-guided-softsort-pooling-for-vision-language-models-in-multi-view-driving-reasoning
+legacyPath: /paper shorts/2025/05/19/ts-vlm-text-guided-softsort-pooling-for-vision-language-models-in-multi-view-driving-reasoning.html
+tags:
+  - Other
+field: 'Autonomous Driving: VLMs & Evaluation'
+summary: "2025 – TS-VLM: Text-Guided SoftSort Pooling for Vision-Language Models in Multi-View Driving Reasoning"
+---
+## 2025 – TS-VLM
+
+**arXiv:** [2505.12670](https://arxiv.org/abs/2505.12670)
+
+## Summary
+
+TS-VLM replaces costly cross-view attention with Text-Guided SoftSort Pooling. A question ranks multi-view visual features by their semantic relevance, then pools them into the language path. On DriveLM, the paper reports BLEU-4 56.82, METEOR 41.91, ROUGE-L 74.64, and CIDEr 3.39; its smallest model has 20.1 million parameters and is reported to reduce compute by up to 90%. Those are reasoning metrics, not evidence of a vehicle control policy.
+
+## Core Insights
+
+The design asks a useful question before fusion: which camera views should matter for this query? Instead of paying attention cost across every token and view, TGSSP uses text semantics to order and aggregate features. The output is a query-adaptive view summary, so the model can favor a rear or side camera when the language task requires it without learning a full dense attention map.
+
+The saving depends on the comparison contract. The abstract does not report the number of views, visual tokens per view, hardware, latency distribution, or a matched-parameter sparse-attention baseline. It also does not test whether pooling preserves low-probability but safety-critical views when the question does not explicitly name them. A robust driving interface should answer that latter question before treating average VQA efficiency as deployment readiness.
+
+## High-Level Takeaways
+
+- TS-VLM changes multi-view fusion from all-to-all attention to query-conditioned ranking and pooling.
+- Its reported DriveLM scores and small-model compute result support efficient driving reasoning, not direct closed-loop action quality.
+- The relevant falsification is a matched-latency test with unexpected hazards in a visually secondary view; the approach fails if semantic pooling systematically discards evidence before the question reveals its importance.


### PR DESCRIPTION
## What changed

- Add 18 source-grounded VLA4AD paper notes from Awesome-VLA4AD.
- Add a 21-paper chronology to the VLA4AD survey, ordered by initial arXiv submission.
- Place the notes across Autonomous Driving: VLMs & Evaluation and Autonomous Driving: VLA & Planning.

## Validation

- npm run ci