### PR TITLE
Add a retro volume lever to the music player

### DIFF
--- a/public/assets/js/music.js
+++ b/public/assets/js/music.js
@@ -1,10 +1,37 @@
 const MUSIC_CHANNEL_KEY = 'musicPlayerChannel';
 const MUSIC_PLAYBACK_KEY = 'musicPlayerPlayback';
+const MUSIC_VOLUME_KEY = 'musicPlayerVolume';
 const DEFAULT_MUSIC_CHANNEL = 'iranian-jazz';
+const DEFAULT_MUSIC_VOLUME = 70;
 const closeTimers = new WeakMap();
 const tuneTimers = new WeakMap();
 const youtubePlayers = new WeakMap();
 let youtubeApiPromise;
+
+function clampMusicVolume(value) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_MUSIC_VOLUME;
+  }
+
+  return Math.min(100, Math.max(0, parsed));
+}
+
+function readMusicVolume() {
+  try {
+    return clampMusicVolume(localStorage.getItem(MUSIC_VOLUME_KEY));
+  } catch {
+    return DEFAULT_MUSIC_VOLUME;
+  }
+}
+
+function writeMusicVolume(volume) {
+  try {
+    localStorage.setItem(MUSIC_VOLUME_KEY, String(volume));
+  } catch {
+    // The control remains usable when browser storage is unavailable.
+  }
+}
 
 function readPlaybackState() {
   try {
@@ -55,6 +82,69 @@ function loadYouTubeApi() {
 
 function getActiveChannel(player) {
   return getChannelButtons(player).find((button) => button.classList.contains('music-channel--active'));
+}
+
+function getVolumeSlider(player) {
+  const slider = player.querySelector('[data-music-volume]');
+  return slider instanceof HTMLInputElement ? slider : null;
+}
+
+function syncVolumeUi(player, volume) {
+  const slider = getVolumeSlider(player);
+  const control = player.querySelector('[data-music-volume-control]');
+  const readout = player.querySelector('[data-music-volume-readout]');
+
+  if (slider) {
+    slider.value = String(volume);
+    slider.setAttribute('aria-valuetext', `${volume}%`);
+  }
+  if (control instanceof HTMLElement) {
+    control.style.setProperty('--music-volume', `${volume}%`);
+  }
+  if (readout) {
+    readout.textContent = String(volume);
+  }
+}
+
+function syncVolumeAvailability(player, channel = getActiveChannel(player)) {
+  const slider = getVolumeSlider(player);
+  const control = player.querySelector('[data-music-volume-control]');
+  const isSupported = channel?.dataset.channelKind === 'youtube';
+
+  if (slider) {
+    slider.disabled = !isSupported;
+    slider.setAttribute(
+      'aria-label',
+      isSupported ? 'Volume' : 'Volume is controlled in the Spotify player',
+    );
+  }
+  if (control instanceof HTMLElement) {
+    control.classList.toggle('retro-tv__volume-control--unavailable', !isSupported);
+    control.title = isSupported ? 'Adjust volume' : 'Spotify controls volume in its player';
+  }
+}
+
+function applyYouTubeVolume(player, volume = readMusicVolume()) {
+  const iframe = player.querySelector('[data-music-iframe]');
+  const channel = getActiveChannel(player);
+  const record = iframe instanceof HTMLIFrameElement ? youtubePlayers.get(iframe) : null;
+
+  if (!record || channel?.dataset.channelKind !== 'youtube') {
+    return;
+  }
+
+  try {
+    record.api.setVolume(volume);
+  } catch {
+    // The player can briefly be unavailable while an iframe changes channels.
+  }
+}
+
+function setMusicVolume(player, requestedVolume) {
+  const volume = clampMusicVolume(requestedVolume);
+  syncVolumeUi(player, volume);
+  writeMusicVolume(volume);
+  applyYouTubeVolume(player, volume);
 }
 
 function persistYouTubePlayback(player) {
@@ -134,6 +224,7 @@ function connectYouTubePlayer(player) {
   loadYouTubeApi().then((YT) => {
     const existing = youtubePlayers.get(iframe);
     if (existing) {
+      applyYouTubeVolume(player);
       restoreYouTubePlayback(player, existing.api);
       startYouTubeProgress(player, iframe, existing.api);
       return;
@@ -143,6 +234,7 @@ function connectYouTubePlayer(player) {
       events: {
         onReady: (event) => {
           startYouTubeProgress(player, iframe, event.target);
+          applyYouTubeVolume(player);
           restoreYouTubePlayback(player, event.target);
         },
         onStateChange: (event) => {
@@ -228,6 +320,7 @@ function tuneToChannel(player, requestedId, animate = true) {
   }
 
   syncChannelDetails(player, channel);
+  syncVolumeAvailability(player, channel);
   if (tv instanceof HTMLElement) {
     tv.dataset.musicKind = channel.dataset.channelKind || 'youtube';
   }
@@ -356,6 +449,10 @@ function initMusicPlayer(player) {
   const closeButton = player.querySelector('[data-music-close]');
   const isStandalone = player.dataset.musicStandalone === 'true';
   const iframe = player.querySelector('[data-music-iframe]');
+  const volumeSlider = getVolumeSlider(player);
+
+  syncVolumeUi(player, readMusicVolume());
+  syncVolumeAvailability(player);
 
   if (trigger instanceof HTMLButtonElement) {
     trigger.addEventListener('click', (event) => {
@@ -397,6 +494,12 @@ function initMusicPlayer(player) {
       tuneToChannel(player, button.dataset.musicChannel);
     });
   });
+
+  if (volumeSlider) {
+    volumeSlider.addEventListener('input', () => {
+      setMusicVolume(player, volumeSlider.value);
+    });
+  }
 
   if (iframe instanceof HTMLIFrameElement) {
     iframe.addEventListener('load', () => connectYouTubePlayer(player));

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -680,6 +680,8 @@ img:not(.float-right):not(.float-left) {
 }
 
 .retro-tv {
+  --volume-control-width: 44px;
+  --volume-control-gap: 10px;
   position: relative;
   padding-top: 12px;
 }
@@ -687,7 +689,7 @@ img:not(.float-right):not(.float-left) {
 .retro-tv__aerial {
   position: absolute;
   top: -7px;
-  left: 50%;
+  left: calc(50% - (var(--volume-control-width) + var(--volume-control-gap)) / 2);
   width: 82px;
   height: 30px;
   transform: translateX(-50%);
@@ -742,6 +744,13 @@ img:not(.float-right):not(.float-left) {
     background 0.24s ease,
     border-color 0.24s ease,
     box-shadow 0.24s ease;
+}
+
+.retro-tv__set {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--volume-control-width);
+  align-items: stretch;
+  gap: var(--volume-control-gap);
 }
 
 .retro-tv__cabinet::after {
@@ -887,6 +896,180 @@ img:not(.float-right):not(.float-left) {
   background-position: center;
   background-size: 7px 7px;
   opacity: 0.76;
+}
+
+.retro-tv__volume-control {
+  --music-volume: 70%;
+  position: relative;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  justify-items: center;
+  padding: 7px 3px 6px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--tv-cabinet-edge) 88%, transparent);
+  border-radius: 14px;
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--tv-cabinet-highlight) 38%, transparent), transparent 38%),
+    color-mix(in srgb, var(--button-bg-hover) 82%, var(--tv-console-ink));
+  box-shadow:
+    inset 0 1px 1px color-mix(in srgb, #fff 26%, transparent),
+    inset 0 -2px 3px color-mix(in srgb, var(--tv-console-ink) 18%, transparent),
+    0 7px 14px color-mix(in srgb, var(--tv-cabinet-drop-shadow) 78%, transparent);
+  color: var(--tv-console-ink);
+  transition:
+    opacity 0.18s ease,
+    filter 0.18s ease;
+}
+
+.retro-tv__volume-label,
+.retro-tv__volume-readout {
+  position: relative;
+  z-index: 1;
+  color: var(--tv-console-ink);
+  font-family: var(--font-mono);
+  font-size: 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1;
+}
+
+.retro-tv__volume-label {
+  margin-top: 1px;
+}
+
+.retro-tv__volume-readout {
+  min-width: 2ch;
+  margin-bottom: 1px;
+  font-size: 0.48rem;
+  text-align: center;
+}
+
+.retro-tv__volume-rail {
+  position: relative;
+  width: 7px;
+  min-height: 70px;
+  margin: 8px 0;
+  border: 1px solid color-mix(in srgb, var(--tv-console-ink) 54%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tv-console-ink) 14%, transparent);
+  box-shadow:
+    inset 0 1px 2px color-mix(in srgb, #000 28%, transparent),
+    0 1px 0 color-mix(in srgb, #fff 30%, transparent);
+}
+
+.retro-tv__volume-fill {
+  position: absolute;
+  right: 1px;
+  bottom: 1px;
+  left: 1px;
+  height: var(--music-volume);
+  border-radius: inherit;
+  background: linear-gradient(to top, var(--accent-color), color-mix(in srgb, var(--accent-color) 58%, #fff));
+  box-shadow: 0 0 8px color-mix(in srgb, var(--accent-color) 46%, transparent);
+  transition: height 0.08s linear;
+}
+
+.retro-tv__volume-lever {
+  position: absolute;
+  z-index: 1;
+  bottom: var(--music-volume);
+  left: 50%;
+  width: 24px;
+  height: 12px;
+  border: 1px solid color-mix(in srgb, var(--tv-console-ink) 66%, transparent);
+  border-radius: 4px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.34), transparent 45%),
+    color-mix(in srgb, var(--button-bg-hover) 54%, var(--tv-console-ink));
+  box-shadow:
+    inset 0 1px 1px color-mix(in srgb, #fff 34%, transparent),
+    0 2px 4px color-mix(in srgb, #000 24%, transparent);
+  transform: translate(-50%, 50%);
+  transition: bottom 0.08s linear;
+}
+
+.retro-tv__volume-lever::before {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  bottom: 2px;
+  left: 4px;
+  border-top: 1px solid color-mix(in srgb, var(--tv-console-ink) 58%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, #fff 24%, transparent);
+  content: "";
+}
+
+.retro-tv__volume-slider {
+  position: absolute;
+  z-index: 2;
+  top: 23px;
+  right: 0;
+  bottom: 20px;
+  left: 0;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  writing-mode: vertical-lr;
+  direction: rtl;
+  background: transparent;
+  cursor: ns-resize;
+}
+
+.retro-tv__volume-slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: transparent;
+}
+
+.retro-tv__volume-slider::-webkit-slider-thumb {
+  width: 24px;
+  height: 12px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  -webkit-appearance: none;
+}
+
+.retro-tv__volume-slider::-moz-range-track {
+  border: 0;
+  background: transparent;
+}
+
+.retro-tv__volume-slider::-moz-range-thumb {
+  width: 24px;
+  height: 12px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.retro-tv__volume-slider:focus-visible {
+  outline: none;
+}
+
+.retro-tv__volume-control:focus-within {
+  box-shadow:
+    inset 0 1px 1px color-mix(in srgb, #fff 26%, transparent),
+    inset 0 -2px 3px color-mix(in srgb, var(--tv-console-ink) 18%, transparent),
+    0 0 0 2px color-mix(in srgb, var(--accent-color) 70%, transparent),
+    0 7px 14px color-mix(in srgb, var(--tv-cabinet-drop-shadow) 78%, transparent);
+}
+
+.retro-tv__volume-control--unavailable {
+  cursor: not-allowed;
+  filter: grayscale(0.6);
+  opacity: 0.54;
+}
+
+.retro-tv__volume-slider:disabled {
+  cursor: not-allowed;
 }
 
 .music-player__now-playing {
@@ -1140,6 +1323,10 @@ a:visited {
     gap: 9px;
     padding: 11px;
   }
+  .retro-tv {
+    --volume-control-width: 40px;
+    --volume-control-gap: 8px;
+  }
   .retro-tv__dial {
     width: 33px;
     height: 33px;
@@ -1163,6 +1350,10 @@ a:visited {
     grid-template-columns: minmax(0, 1fr) 48px;
     border-radius: 23px 23px 19px 19px;
   }
+  .retro-tv {
+    --volume-control-width: 34px;
+    --volume-control-gap: 6px;
+  }
   .retro-tv__console {
     padding-inline: 0;
   }
@@ -1175,6 +1366,17 @@ a:visited {
   }
   .retro-tv__speaker {
     width: 30px;
+  }
+  .retro-tv__volume-control {
+    padding-inline: 1px;
+    border-radius: 11px;
+  }
+  .retro-tv__volume-lever {
+    width: 20px;
+  }
+  .retro-tv__volume-label,
+  .retro-tv__volume-readout {
+    font-size: 0.42rem;
   }
   .music-player__now-playing {
     margin-top: 14px;

--- a/src/components/MusicPlayer.astro
+++ b/src/components/MusicPlayer.astro
@@ -88,26 +88,49 @@ const defaultChannel = channels[0];
       <span></span>
       <span></span>
     </div>
-    <div class="retro-tv__cabinet">
-      <div class="retro-tv__screen-bezel">
-        <div class="retro-tv__screen">
-          <iframe
-            id="music-player-frame"
-            data-music-iframe
-            title={`${defaultChannel.name} music player`}
-            allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
-          ></iframe>
-          <div class="retro-tv__scanlines" aria-hidden="true"></div>
-          <div class="retro-tv__static" aria-hidden="true"></div>
+    <div class="retro-tv__set">
+      <div class="retro-tv__cabinet">
+        <div class="retro-tv__screen-bezel">
+          <div class="retro-tv__screen">
+            <iframe
+              id="music-player-frame"
+              data-music-iframe
+              title={`${defaultChannel.name} music player`}
+              allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
+              referrerpolicy="strict-origin-when-cross-origin"
+              allowfullscreen
+            ></iframe>
+            <div class="retro-tv__scanlines" aria-hidden="true"></div>
+            <div class="retro-tv__static" aria-hidden="true"></div>
+          </div>
+        </div>
+        <div class="retro-tv__console" aria-hidden="true">
+          <div class="retro-tv__on-air"><span></span>ON</div>
+          <div class="retro-tv__dial"><span></span></div>
+          <div class="retro-tv__speaker"></div>
         </div>
       </div>
-      <div class="retro-tv__console" aria-hidden="true">
-        <div class="retro-tv__on-air"><span></span>ON</div>
-        <div class="retro-tv__dial"><span></span></div>
-        <div class="retro-tv__speaker"></div>
-      </div>
+
+      <label class="retro-tv__volume-control" data-music-volume-control title="Adjust volume">
+        <span class="retro-tv__volume-label" aria-hidden="true">VOL</span>
+        <span class="retro-tv__volume-rail" aria-hidden="true">
+          <span class="retro-tv__volume-fill"></span>
+          <span class="retro-tv__volume-lever"></span>
+        </span>
+        <input
+          class="retro-tv__volume-slider"
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          value="70"
+          aria-label="Volume"
+          aria-orientation="vertical"
+          aria-valuetext="70%"
+          data-music-volume
+        />
+        <output class="retro-tv__volume-readout" data-music-volume-readout aria-hidden="true">70</output>
+      </label>
     </div>
   </div>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,7 +14,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
-const themeStylesheetHref = '/css/override.css?v=20260726-music-tv';
+const themeStylesheetHref = '/css/override.css?v=20260809-volume-lever';
 ---
 
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- Add an accessible vertical volume lever beside the retro TV.
- Persist the selected volume and apply it to YouTube channels through the iframe API.
- Disable the control for the Spotify embed, which owns its own volume.

## Testing
- npm run ci
- Built /music.html verification at desktop and mobile widths