### PR TITLE
Redesign coding practice workspace

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -5478,3 +5478,328 @@ html {
     padding-top: 5.75rem;
   }
 }
+
+/* Keep interview prompts focused and the runnable workspace reliably contained. */
+.code-practice-lab {
+  grid-template-columns: minmax(0, 0.84fr) minmax(32rem, 1.16fr);
+  align-items: start;
+  gap: 1.25rem;
+}
+
+.code-practice-lab__problem {
+  min-width: 0;
+  max-width: 100%;
+  padding: 1.25rem;
+  border: 1px solid rgba(118, 169, 255, 0.18);
+  border-radius: 24px;
+  background: linear-gradient(180deg, rgba(12, 20, 40, 0.98), rgba(7, 13, 26, 0.99));
+  box-shadow: 0 24px 48px rgba(7, 20, 48, 0.24);
+  color: #dff0ff;
+}
+
+:root[data-theme="dark"] .code-practice-lab__problem {
+  border-color: rgba(255, 228, 92, 0.2);
+  background: linear-gradient(180deg, rgba(10, 10, 10, 0.98), rgba(19, 16, 4, 0.98));
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.46);
+  color: #fff7cf;
+}
+
+.code-practice-lab__workspace {
+  min-width: 0;
+  max-width: 100%;
+  position: sticky;
+  top: 5.5rem;
+  align-self: start;
+}
+
+.code-practice-lab__problem-header,
+.code-practice-lab__workspace-header,
+.code-practice-lab__workspace-meta {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.code-practice-lab__problem-header h1,
+.code-practice-lab__workspace-header h2 {
+  margin: 0;
+  color: #f5fbff;
+}
+
+:root[data-theme="dark"] .code-practice-lab__problem-header h1,
+:root[data-theme="dark"] .code-practice-lab__workspace-header h2 {
+  color: #fff7cf;
+}
+
+.code-practice-lab__specs {
+  min-width: 0;
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1.25rem;
+}
+
+.code-practice-lab__specs .code-practice-lab__spec-card {
+  margin-top: 0;
+}
+
+.code-practice-lab__copy p,
+.code-practice-lab__list li {
+  overflow-wrap: anywhere;
+}
+
+.code-practice-lab__spec-card,
+.code-practice-lab__example,
+.code-practice-lab__spec-card pre,
+.code-practice-lab__example pre,
+.code-practice-lab__output pre {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.code-practice-lab__spec-card pre,
+.code-practice-lab__example pre,
+.code-practice-lab__output pre {
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+.code-practice-lab__spec-card pre code,
+.code-practice-lab__example pre code {
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
+}
+
+.code-practice-lab__workspace-controls,
+.code-practice-lab__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  max-width: 100%;
+}
+
+.code-practice-lab__workspace-controls {
+  justify-content: flex-end;
+}
+
+.code-practice-lab__button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  min-height: 2.75rem;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(127, 197, 255, 0.32);
+  border-radius: 12px;
+  background: rgba(18, 37, 68, 0.9);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
+  color: #eaf6ff;
+  cursor: pointer;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    border-color 0.18s ease,
+    background-color 0.18s ease;
+}
+
+.code-practice-lab__button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(127, 197, 255, 0.68);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.24);
+}
+
+.code-practice-lab__button:focus-visible {
+  outline: 3px solid rgba(127, 197, 255, 0.42);
+  outline-offset: 3px;
+}
+
+.code-practice-lab__button--primary {
+  border-color: rgba(108, 219, 171, 0.54);
+  background: linear-gradient(135deg, #168d67, #31ba88);
+  color: #f4fffb;
+}
+
+.code-practice-lab__button--primary:hover:not(:disabled) {
+  border-color: rgba(181, 255, 223, 0.8);
+  background: linear-gradient(135deg, #1aa878, #43c995);
+}
+
+.code-practice-lab__button--solution {
+  border-color: rgba(255, 204, 100, 0.48);
+  background: rgba(78, 54, 9, 0.82);
+}
+
+.code-practice-lab__button--solution:hover:not(:disabled) {
+  border-color: rgba(255, 228, 139, 0.82);
+  background: rgba(105, 73, 12, 0.9);
+}
+
+.code-practice-lab__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+  transform: none;
+  box-shadow: none;
+}
+
+.code-practice-lab__button kbd,
+.code-practice-lab__shortcut kbd {
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  padding: 0.16rem 0.34rem;
+  background: rgba(0, 0, 0, 0.14);
+  color: inherit;
+  font-family: inherit;
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+:root[data-theme="dark"] .code-practice-lab__button {
+  border-color: rgba(255, 228, 92, 0.28);
+  background: rgba(35, 28, 2, 0.88);
+  color: #fff7cf;
+}
+
+:root[data-theme="dark"] .code-practice-lab__button:hover:not(:disabled) {
+  border-color: rgba(255, 228, 92, 0.72);
+}
+
+:root[data-theme="dark"] .code-practice-lab__button--primary {
+  border-color: rgba(122, 240, 182, 0.58);
+  background: linear-gradient(135deg, #147454, #219b72);
+}
+
+:root[data-theme="dark"] .code-practice-lab__button--solution {
+  border-color: rgba(255, 228, 92, 0.5);
+  background: rgba(76, 57, 6, 0.9);
+}
+
+.code-practice-lab__workspace-meta {
+  align-items: center;
+  margin: 0.9rem 0 1rem;
+}
+
+.code-practice-lab__status,
+.code-practice-lab__shortcut {
+  margin: 0;
+}
+
+.code-practice-lab__shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: rgba(223, 240, 255, 0.72);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+:root[data-theme="dark"] .code-practice-lab__shortcut {
+  color: rgba(255, 247, 207, 0.72);
+}
+
+.code-practice-lab__editor-label {
+  margin-top: 0.25rem;
+  color: rgba(223, 240, 255, 0.82);
+}
+
+:root[data-theme="dark"] .code-practice-lab__editor-label {
+  color: rgba(255, 247, 207, 0.82);
+}
+
+.code-practice-lab__editor .cm-editor,
+.code-practice-lab__editor .cm-scroller {
+  min-height: 36rem;
+  max-width: 100%;
+}
+
+.code-practice-lab__actions {
+  justify-content: space-between;
+  margin-top: 0.9rem;
+}
+
+.code-practice-lab__output > div {
+  min-height: 7.5rem;
+}
+
+.code-index__header > div {
+  min-width: 0;
+}
+
+.code-index__environment {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(16rem, 0.8fr);
+  gap: 1.25rem;
+  padding: 1.2rem 1.25rem;
+  border: 1px solid rgba(125, 162, 247, 0.2);
+  border-radius: 22px;
+  background: var(--panel-bg);
+  box-shadow: var(--button-shadow);
+}
+
+.code-index__environment h2 {
+  margin: 0;
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+}
+
+.code-index__environment > div > p:last-child {
+  margin: 0.65rem 0 0;
+  line-height: 1.6;
+}
+
+.code-index__environment ul {
+  display: grid;
+  gap: 0.7rem;
+  align-content: center;
+  margin: 0;
+  padding-left: 1.15rem;
+}
+
+.code-index__environment li {
+  line-height: 1.45;
+}
+
+.code-index__environment code,
+.code-index__environment kbd {
+  border: 1px solid rgba(125, 162, 247, 0.28);
+  border-radius: 5px;
+  padding: 0.08rem 0.28rem;
+  background: rgba(125, 162, 247, 0.08);
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+}
+
+.code-index__count {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+@media (max-width: 980px) {
+  .code-practice-lab {
+    grid-template-columns: 1fr;
+  }
+
+  .code-practice-lab__workspace {
+    position: static;
+  }
+}
+
+@media (max-width: 820px) {
+  .code-practice-lab__problem-header,
+  .code-practice-lab__workspace-header,
+  .code-practice-lab__workspace-meta {
+    flex-direction: column;
+  }
+
+  .code-practice-lab__workspace-controls {
+    justify-content: flex-start;
+  }
+
+  .code-index__environment {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -1,4 +1,6 @@
-import React, { startTransition, useEffect, useRef, useState } from 'react';
+import React, { startTransition, useEffect, useMemo, useRef, useState } from 'react';
+import { Prec } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
 import CodeMirror from '@uiw/react-codemirror';
 import { githubDark, githubLight } from '@uiw/codemirror-theme-github';
 import { loadPyodideRuntime } from '../lib/pyodide-loader';
@@ -6,6 +8,7 @@ import type { PyodideRuntime } from '../lib/pyodide-loader';
 import {
   codeEditorExtensions,
   createCodeEditorThemeObserver,
+  createRunCodeKeyBindings,
   getCodeEditorThemeName,
 } from '../lib/code-editor';
 import { runPythonSnippet } from '../lib/python-runner';
@@ -15,50 +18,25 @@ interface CodePracticeLabProps {
   problem: CodePracticeProblem;
 }
 
-function formatPackages(packages: readonly string[] = []) {
-  return packages.map((packageName) => {
-    if (packageName === 'numpy') {
-      return 'NumPy';
-    }
-    if (packageName === 'torch') {
-      return 'PyTorch-style tensors';
-    }
-    return packageName;
-  });
-}
-
-function getRuntimeNote(packages: readonly string[] = []) {
-  if (packages.includes('torch')) {
-    return 'PyTorch-style tensors and torch.Tensor annotations are available through a lightweight NumPy-backed browser compatibility layer. NumPy is also available directly with `import numpy as np`. The compatibility layer does not provide autograd, CUDA, nn.Module, or full PyTorch.';
+function createHintCommentBlock(hints: readonly string[]) {
+  if (hints.length === 0) {
+    return '';
   }
 
-  const packageLabels = formatPackages(packages);
-  if (packageLabels.length === 0) {
-    return 'The in-browser Python runtime executes this workspace locally in the browser.';
-  }
-
-  if (packageLabels.length === 1) {
-    return `${packageLabels[0]} is available and will load automatically the first time you run the code.`;
-  }
-
-  const leadingPackages = packageLabels.slice(0, -1).join(', ');
-  const trailingPackage = packageLabels.at(-1);
-  return `${leadingPackages}, and ${trailingPackage} are available and will load automatically the first time you run the code.`;
+  return ['# Hints', ...hints.map((hint, index) => `# ${index + 1}. ${hint}`)].join('\n');
 }
 
 export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const containerRef = useRef<HTMLElement | null>(null);
   const runtimeRef = useRef<PyodideRuntime | null>(null);
   const loadingRef = useRef(false);
+  const isRunningRef = useRef(false);
+  const runHandlerRef = useRef<() => void>(() => {});
   const [code, setCode] = useState(problem.starterCode);
   const [output, setOutput] = useState('');
   const [errorOutput, setErrorOutput] = useState('');
-  const [showHint, setShowHint] = useState(false);
-  const [showSolution, setShowSolution] = useState(false);
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
-  const [statusMessage, setStatusMessage] = useState(
-    'Python runtime will load when this lab scrolls into view.',
-  );
+  const [statusMessage, setStatusMessage] = useState('Loading Python...');
   const [isRunning, setIsRunning] = useState(false);
   const [editorTheme, setEditorTheme] = useState(() =>
     getCodeEditorThemeName(
@@ -66,12 +44,36 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     ),
   );
 
+  const hintCommentBlock = useMemo(() => createHintCommentBlock(problem.hint), [problem.hint]);
+  const runShortcutExtension = useMemo(
+    () =>
+      Prec.highest([
+        keymap.of(createRunCodeKeyBindings(() => runHandlerRef.current())),
+        // Some browser contenteditable paths bypass the keymap handler. Bridge
+        // the same command at the editor DOM boundary so Ctrl/Cmd+Enter is reliable.
+        EditorView.domEventHandlers({
+          keydown(event) {
+            if (event.key !== 'Enter' || (!event.ctrlKey && !event.metaKey)) {
+              return false;
+            }
+
+            event.preventDefault();
+            runHandlerRef.current();
+            return true;
+          },
+        }),
+      ]),
+    [],
+  );
+  const editorExtensions = useMemo(
+    () => [...codeEditorExtensions, runShortcutExtension],
+    [runShortcutExtension],
+  );
+
   useEffect(() => {
     setCode(problem.starterCode);
     setOutput('');
     setErrorOutput('');
-    setShowHint(false);
-    setShowSolution(false);
   }, [problem]);
 
   useEffect(() => {
@@ -84,7 +86,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
 
       loadingRef.current = true;
       setStatus('loading');
-      setStatusMessage('Preparing the in-browser Python runtime...');
+      setStatusMessage('Loading Python...');
 
       try {
         const runtime = await loadPyodideRuntime();
@@ -94,16 +96,15 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
 
         runtimeRef.current = runtime;
         setStatus('ready');
-        setStatusMessage('Python is ready. Run the starter code or edit your solution.');
+        setStatusMessage('Python ready');
       } catch (error) {
         if (didCancel) {
           return;
         }
 
         setStatus('error');
-        setStatusMessage(
-          error instanceof Error ? error.message : 'The Python runtime failed to load.',
-        );
+        setStatusMessage('Python unavailable');
+        setErrorOutput(error instanceof Error ? error.message : 'The Python runtime failed to load.');
       } finally {
         loadingRef.current = false;
       }
@@ -162,11 +163,16 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const editorThemeExtension = editorTheme === 'dark' ? githubDark : githubLight;
 
   async function handleRun() {
-    if (!runtimeRef.current) {
-      setStatusMessage('Python is still loading. Try again in a moment.');
+    if (isRunningRef.current) {
       return;
     }
 
+    if (!runtimeRef.current) {
+      setStatusMessage(status === 'error' ? 'Python unavailable' : 'Python is loading...');
+      return;
+    }
+
+    isRunningRef.current = true;
     setIsRunning(true);
     setOutput('');
     setErrorOutput('');
@@ -185,6 +191,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     } catch (error) {
       setErrorOutput(error instanceof Error ? error.message : 'Unknown execution error.');
     } finally {
+      isRunningRef.current = false;
       setIsRunning(false);
     }
   }
@@ -195,145 +202,127 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     setErrorOutput('');
   }
 
+  function handleAddHints() {
+    if (!hintCommentBlock) {
+      return;
+    }
+
+    setCode((currentCode) =>
+      currentCode.startsWith(hintCommentBlock) ? currentCode : `${hintCommentBlock}\n\n${currentCode}`,
+    );
+  }
+
+  function handleLoadSolution() {
+    setCode(problem.solutionCode);
+    setOutput('');
+    setErrorOutput('');
+  }
+
+  // The CodeMirror keymap is created once, so route it through a ref to the
+  // current controlled editor state instead of rebuilding the editor on each keystroke.
+  runHandlerRef.current = () => {
+    void handleRun();
+  };
+
   return (
     <section className="code-practice-lab" ref={containerRef}>
-      <article className="code-practice-lab__hero">
-        <div className="code-practice-lab__hero-header">
+      <article className="code-practice-lab__problem">
+        <header className="code-practice-lab__problem-header">
           <div className="code-practice-lab__title-block">
             <p className="code-practice-lab__eyebrow">{`Problem ${String(problem.order).padStart(2, '0')}`}</p>
             <h1>{problem.title}</h1>
-            <p className="code-practice-lab__summary">{problem.summary}</p>
           </div>
+          <span className="code-practice-lab__difficulty">{problem.difficulty}</span>
+        </header>
 
-          <div className="code-practice-lab__hero-actions">
-            <span className="code-practice-lab__difficulty">{problem.difficulty}</span>
-            <button
-              type="button"
-              aria-expanded={showHint}
-              onClick={() => setShowHint((current) => !current)}
-            >
-              {showHint ? 'Hide hint' : 'Hint'}
-            </button>
-            <button
-              type="button"
-              aria-expanded={showSolution}
-              onClick={() => setShowSolution((current) => !current)}
-            >
-              {showSolution ? 'Hide solution' : 'Solution'}
-            </button>
-          </div>
+        <div className="code-practice-lab__copy">
+          {problem.prompt.map((paragraph) => (
+            <p key={paragraph}>{paragraph}</p>
+          ))}
         </div>
 
-        {showHint && (
-          <div className="code-practice-lab__hint-panel">
-            <p className="code-practice-lab__section-label">Hint</p>
+        <div className="code-practice-lab__specs">
+          <section className="code-practice-lab__spec-card">
+            <p className="code-practice-lab__section-label">Implement</p>
+            <pre>
+              <code>{problem.signature}</code>
+            </pre>
+          </section>
+
+          <section className="code-practice-lab__spec-card">
+            <p className="code-practice-lab__section-label">Requirements</p>
             <ul className="code-practice-lab__list">
-              {problem.hint.map((hintLine) => (
-                <li key={hintLine}>{hintLine}</li>
+              {problem.requirements.map((requirement) => (
+                <li key={requirement}>{requirement}</li>
               ))}
             </ul>
-          </div>
-        )}
+          </section>
 
-        {showSolution && (
-          <div className="code-practice-lab__solution-panel">
-            <div className="code-practice-lab__solution-header">
-              <p className="code-practice-lab__section-label">Solution</p>
-              <button type="button" onClick={() => setShowSolution(false)}>
-                Collapse
-              </button>
-            </div>
-
-            <div className="code-practice-lab__copy">
-              {problem.solutionNotes.map((note) => (
-                <p key={note}>{note}</p>
+          <section className="code-practice-lab__spec-card">
+            <p className="code-practice-lab__section-label">Examples</p>
+            <div className="code-practice-lab__examples">
+              {problem.examples.map((example) => (
+                <div key={example.label} className="code-practice-lab__example">
+                  <p>{example.label}</p>
+                  <pre>
+                    <code>{`${example.lines.join('\n')}\n\n${example.result}`}</code>
+                  </pre>
+                </div>
               ))}
             </div>
-            <pre>
-              <code>{problem.solutionCode}</code>
-            </pre>
-          </div>
-        )}
-
-        <div className="code-practice-lab__prompt">
-          <div className="code-practice-lab__copy">
-            {problem.prompt.map((paragraph) => (
-              <p key={paragraph}>{paragraph}</p>
-            ))}
-          </div>
-
-          <div className="code-practice-lab__spec-grid">
-            <article className="code-practice-lab__spec-card">
-              <p className="code-practice-lab__section-label">Implement</p>
-              <pre>
-                <code>{problem.signature}</code>
-              </pre>
-            </article>
-
-            <article className="code-practice-lab__spec-card">
-              <p className="code-practice-lab__section-label">Requirements</p>
-              <ul className="code-practice-lab__list">
-                {problem.requirements.map((requirement) => (
-                  <li key={requirement}>{requirement}</li>
-                ))}
-              </ul>
-            </article>
-
-            <article className="code-practice-lab__spec-card">
-              <p className="code-practice-lab__section-label">Examples</p>
-              <div className="code-practice-lab__examples">
-                {problem.examples.map((example) => (
-                  <div key={example.label} className="code-practice-lab__example">
-                    <p>{example.label}</p>
-                    <pre>
-                      <code>{`${example.lines.join('\n')}\n\n${example.result}`}</code>
-                    </pre>
-                  </div>
-                ))}
-              </div>
-            </article>
-          </div>
+          </section>
         </div>
       </article>
 
       <article className="code-practice-lab__workspace">
-        <div className="code-practice-lab__header code-practice-lab__header--workspace">
+        <header className="code-practice-lab__workspace-header">
           <div>
-            <p className="code-practice-lab__eyebrow">Python Workspace</p>
-            <h2>Run your solution</h2>
+            <p className="code-practice-lab__eyebrow">Workspace</p>
+            <h2>Your solution</h2>
           </div>
+          <div className="code-practice-lab__workspace-controls">
+            <button
+              className="code-practice-lab__button code-practice-lab__button--secondary"
+              type="button"
+              onClick={handleAddHints}
+            >
+              Add hints
+            </button>
+            <button
+              className="code-practice-lab__button code-practice-lab__button--solution"
+              type="button"
+              onClick={handleLoadSolution}
+            >
+              Load solution
+            </button>
+          </div>
+        </header>
+
+        <div className="code-practice-lab__workspace-meta">
           <p
             className={`code-practice-lab__status code-practice-lab__status--${status}`}
             aria-live="polite"
           >
             {statusMessage}
           </p>
-        </div>
-
-        <p className="code-practice-lab__runtime-note">{getRuntimeNote(problem.packages ?? [])}</p>
-
-        <div className="code-practice-lab__promptbar">
-          <span className="code-practice-lab__dot" />
-          <span className="code-practice-lab__dot" />
-          <span className="code-practice-lab__dot" />
-          <span className="code-practice-lab__prompt">python interview_practice.py</span>
+          <p className="code-practice-lab__shortcut">
+            <kbd>Ctrl / Cmd + Enter</kbd>
+            <span>runs code</span>
+          </p>
         </div>
 
         <label className="code-practice-lab__editor-label" htmlFor={editorId}>
-          Editable starter code
+          solution.py
         </label>
-        <p className="code-practice-lab__editor-help">
-          `Tab` indents, `Shift+Tab` outdents, and `Cmd/Ctrl + /` toggles comments.
-        </p>
         <div className="code-practice-lab__editor-shell">
           <CodeMirror
             id={editorId}
             className="code-practice-lab__editor"
-            aria-label="Editable starter code"
+            aria-label="Python solution editor"
             basicSetup={false}
-            extensions={codeEditorExtensions}
+            extensions={editorExtensions}
             theme={editorThemeExtension}
-            height="34rem"
+            height="36rem"
             editable
             indentWithTab={false}
             value={code}
@@ -342,22 +331,34 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
         </div>
 
         <div className="code-practice-lab__actions">
-          <button type="button" onClick={() => void handleRun()} disabled={status !== 'ready' || isRunning}>
-            {isRunning ? 'Running...' : 'Run code'}
+          <button
+            className="code-practice-lab__button code-practice-lab__button--primary"
+            type="button"
+            aria-label="Run code"
+            aria-keyshortcuts="Control+Enter Meta+Enter"
+            onClick={() => void handleRun()}
+            disabled={status !== 'ready' || isRunning}
+          >
+            <span>{isRunning ? 'Running...' : 'Run'}</span>
+            {!isRunning && <kbd>Ctrl / Cmd + Enter</kbd>}
           </button>
-          <button type="button" onClick={handleReset}>
-            Reset starter
+          <button
+            className="code-practice-lab__button code-practice-lab__button--secondary"
+            type="button"
+            onClick={handleReset}
+          >
+            Reset
           </button>
         </div>
 
-        <div className="code-practice-lab__output">
+        <div className="code-practice-lab__output" aria-live="polite">
           <div>
-            <p>stdout</p>
-            <pre>{output || 'Run the starter code to see your printed output here.'}</pre>
+            <p>Output</p>
+            <pre>{output || 'Output appears here.'}</pre>
           </div>
           <div>
-            <p>stderr</p>
-            <pre>{errorOutput || 'Execution errors will appear here.'}</pre>
+            <p>Errors</p>
+            <pre>{errorOutput || 'Errors appear here.'}</pre>
           </div>
         </div>
       </article>

--- a/src/lib/code-editor.ts
+++ b/src/lib/code-editor.ts
@@ -21,6 +21,7 @@ import {
   crosshairCursor,
   drawSelection,
   dropCursor,
+  EditorView,
   highlightActiveLine,
   highlightActiveLineGutter,
   highlightSpecialChars,
@@ -37,6 +38,24 @@ export const codeEditorKeyBindings: readonly KeyBinding[] = [
   { key: 'Shift-Tab', run: indentLess },
   indentWithTab,
 ];
+
+/**
+ * Adds the workspace run shortcut without changing the editor's shared
+ * indentation and comment behavior. Keep both bindings: `Mod` gives Windows
+ * and Linux users Ctrl+Enter (and macOS users Cmd+Enter), while the explicit
+ * Ctrl binding keeps Ctrl+Enter available on macOS too.
+ */
+export function createRunCodeKeyBindings(runCode: () => void): readonly KeyBinding[] {
+  const run = () => {
+    runCode();
+    return true;
+  };
+
+  return [
+    { key: 'Ctrl-Enter', run },
+    { key: 'Mod-Enter', run },
+  ];
+}
 
 export const codeEditorExtensions = [
   lineNumbers(),
@@ -56,6 +75,7 @@ export const codeEditorExtensions = [
   indentUnit.of(CODE_EDITOR_INDENT),
   EditorState.tabSize.of(4),
   python(),
+  EditorView.lineWrapping,
   Prec.highest(keymap.of([...codeEditorKeyBindings])),
   keymap.of([...defaultKeymap, ...historyKeymap, ...searchKeymap, ...lintKeymap]),
 ];

--- a/src/lib/code-practice.ts
+++ b/src/lib/code-practice.ts
@@ -23,7 +23,7 @@ export interface CodePracticeProblem {
 }
 
 export const CODE_PRACTICE_SECTION_SUMMARY =
-  'Interview-style PyTorch and NumPy exercises with runnable starter code, focused hints, and hidden solutions.';
+  'Interview-style PyTorch and NumPy exercises with runnable starter code, editor-inserted hints, and reference solutions.';
 
 const PYTORCH_AND_NUMPY_PACKAGES = ['torch', 'numpy'] as const;
 

--- a/src/pages/code.astro
+++ b/src/pages/code.astro
@@ -28,6 +28,23 @@ const problemCountLabel = String(codePracticeProblems.length).padStart(2, '0');
       </div>
     </div>
 
+    <section class="code-index__environment" aria-labelledby="code-environment-title">
+      <div>
+        <p class="code-index__eyebrow">Browser workspace</p>
+        <h2 id="code-environment-title">Run each problem locally</h2>
+        <p>
+          Every problem opens a local Python editor powered by Pyodide. NumPy loads on demand;
+          <code>torch</code> is a lightweight, NumPy-backed compatibility layer for the tensor
+          operations used in these exercises—not the full PyTorch runtime.
+        </p>
+      </div>
+      <ul>
+        <li><kbd>Ctrl / Cmd + Enter</kbd> runs the current editor contents.</li>
+        <li>Hints insert comments into the editor, and Solution loads the reference code.</li>
+        <li>No autograd, CUDA, or <code>nn.Module</code>.</li>
+      </ul>
+    </section>
+
     <ul class="code-index__list">
       {codePracticeProblems.map((problem) => (
         <li>

--- a/tests/code-editor.test.ts
+++ b/tests/code-editor.test.ts
@@ -2,8 +2,12 @@
 
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
-import { afterEach, describe, expect, it } from 'vitest';
-import { codeEditorExtensions, codeEditorKeyBindings } from '../src/lib/code-editor';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  codeEditorExtensions,
+  codeEditorKeyBindings,
+  createRunCodeKeyBindings,
+} from '../src/lib/code-editor';
 
 function getKeyBinding(key: string) {
   const binding = codeEditorKeyBindings.find((entry) => entry.key === key);
@@ -44,6 +48,18 @@ describe('codeEditorExtensions', () => {
     expect(codeEditorKeyBindings.map((binding) => binding.key)).toEqual(
       expect.arrayContaining(['Tab', 'Shift-Tab', 'Mod-/']),
     );
+  });
+
+  it('adds Ctrl+Enter and Cmd+Enter bindings for a workspace run action', () => {
+    const runCode = vi.fn();
+    const runBindings = createRunCodeKeyBindings(runCode);
+    const view = createView('print("starter")');
+
+    expect(runBindings.map((binding) => binding.key)).toEqual(
+      expect.arrayContaining(['Ctrl-Enter', 'Mod-Enter']),
+    );
+    expect(runBindings[0]?.run?.(view)).toBe(true);
+    expect(runCode).toHaveBeenCalledOnce();
   });
 
   it('indents and outdents the current selection', () => {

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -107,7 +107,7 @@ describe('CodePracticeLab', () => {
     return editor as HTMLElement;
   }
 
-  it('reveals the hint and solution only after the user clicks', async () => {
+  it('keeps hint and solution actions in the workspace and applies them to the editor', async () => {
     loadPyodideRuntime.mockResolvedValueOnce({
       runPythonAsync: vi.fn(),
     });
@@ -120,16 +120,26 @@ describe('CodePracticeLab', () => {
     expect(container.textContent).not.toContain('print("solution")');
 
     const buttons = Array.from(container.querySelectorAll('button'));
-    const hintButton = buttons.find((button) => button.textContent === 'Hint');
-    const solutionButton = buttons.find((button) => button.textContent === 'Solution');
+    const hintButton = buttons.find((button) => button.textContent === 'Add hints');
+    const solutionButton = buttons.find((button) => button.textContent === 'Load solution');
+
+    expect(hintButton?.closest('.code-practice-lab__workspace')).not.toBeNull();
+    expect(solutionButton?.closest('.code-practice-lab__workspace')).not.toBeNull();
 
     await act(async () => {
       hintButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(getEditor().textContent).toContain('# Hints');
+    expect(getEditor().textContent).toContain('# 1. Subtract the row max first.');
+    expect(getEditor().textContent).toContain('print("starter")');
+
+    await act(async () => {
       solutionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(container.textContent).toContain('Subtract the row max first.');
-    expect(container.textContent).toContain('print("solution")');
+    expect(getEditor().textContent).toContain('print("solution")');
+    expect(getEditor().textContent).not.toContain('print("starter")');
   });
 
   it('loads required packages and prints run output', async () => {
@@ -143,10 +153,7 @@ describe('CodePracticeLab', () => {
 
     await render();
 
-    expect(container.textContent).toContain('NumPy is also available directly');
-
-    const buttons = Array.from(container.querySelectorAll('button'));
-    const runButton = buttons.find((button) => button.textContent === 'Run code');
+    const runButton = container.querySelector<HTMLButtonElement>('button[aria-label="Run code"]');
 
     await act(async () => {
       runButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -155,6 +162,41 @@ describe('CodePracticeLab', () => {
 
     expect(loadPackage).toHaveBeenCalledWith(['numpy']);
     expect(container.textContent).toContain('0.41703');
+  });
+
+  it('runs the current editor contents with Ctrl+Enter', async () => {
+    const runPythonAsync = vi.fn().mockResolvedValue({
+      toJs: () => ['keyboard run\n', ''],
+    });
+    loadPyodideRuntime.mockResolvedValueOnce({
+      runPythonAsync,
+    });
+
+    await render();
+
+    const editorContent = container.querySelector<HTMLElement>('.cm-content');
+    expect(editorContent).not.toBeNull();
+
+    const shortcutEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperties(shortcutEvent, {
+      keyCode: { value: 13 },
+      which: { value: 13 },
+    });
+
+    await act(async () => {
+      editorContent?.dispatchEvent(shortcutEvent);
+    });
+    await flushAsyncWork();
+
+    expect(shortcutEvent.defaultPrevented).toBe(true);
+    expect(runPythonAsync).toHaveBeenCalledOnce();
+    expect(container.textContent).toContain('keyboard run');
   });
 
   it('renders a CodeMirror editor with the starter code', async () => {
@@ -166,6 +208,6 @@ describe('CodePracticeLab', () => {
 
     const editor = getEditor();
     expect(editor.textContent).toContain('print("starter")');
-    expect(container.textContent).toContain('Cmd/Ctrl + /');
+    expect(container.textContent).toContain('Ctrl / Cmd + Enter');
   });
 });


### PR DESCRIPTION
What changed: reorganizes each code problem into a left-hand brief and a right-hand workspace; adds editor-inserted hints, direct solution loading, Ctrl/Cmd+Enter execution, stronger controls, and containment styles.\n\nWhy: keeps problem pages focused while moving Pyodide/runtime guidance to the Code index.\n\nTesting: npm run ci; targeted editor/lab tests; local browser verification across all 18 problem routes at mobile and desktop widths.