### PR TITLE
Annotate code practice solutions in place

### DIFF
--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -11,6 +11,7 @@ import {
   createRunCodeKeyBindings,
   getCodeEditorThemeName,
 } from '../lib/code-editor';
+import { augmentCodeWithSolution } from '../lib/code-solution';
 import { runPythonSnippet } from '../lib/python-runner';
 import type { CodePracticeProblem } from '../lib/code-practice';
 
@@ -213,7 +214,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   }
 
   function handleLoadSolution() {
-    setCode(problem.solutionCode);
+    setCode((currentCode) => augmentCodeWithSolution(problem, currentCode));
     setOutput('');
     setErrorOutput('');
   }

--- a/src/lib/code-solution.ts
+++ b/src/lib/code-solution.ts
@@ -1,0 +1,243 @@
+import type { CodePracticeProblem } from './code-practice';
+
+const REFERENCE_MARKER = '# Reference solution loaded:';
+
+interface PythonDefinition {
+  kind: 'class' | 'function';
+  name: string;
+  indent: number;
+  parentClasses: readonly string[];
+  start: number;
+  headerEnd: number;
+  end: number;
+}
+
+function getIndent(line: string) {
+  return line.length - line.trimStart().length;
+}
+
+function findHeaderEnd(lines: readonly string[], start: number) {
+  for (let index = start; index < lines.length; index += 1) {
+    if (lines[index].trimEnd().endsWith(':')) {
+      return index;
+    }
+  }
+
+  return start;
+}
+
+function findBlockEnd(lines: readonly string[], headerEnd: number, indent: number) {
+  for (let index = headerEnd + 1; index < lines.length; index += 1) {
+    if (lines[index].trim() && getIndent(lines[index]) <= indent) {
+      return index;
+    }
+  }
+
+  return lines.length;
+}
+
+function getPythonDefinitions(code: string): PythonDefinition[] {
+  const lines = code.split('\n');
+  const definitions: Omit<PythonDefinition, 'parentClasses'>[] = [];
+
+  lines.forEach((line, start) => {
+    const match = line.match(/^(\s*)(?:async\s+)?(def|class)\s+([A-Za-z_]\w*)\b/);
+    if (!match) {
+      return;
+    }
+
+    const indent = match[1].length;
+    const headerEnd = findHeaderEnd(lines, start);
+    definitions.push({
+      kind: match[2] === 'class' ? 'class' : 'function',
+      name: match[3],
+      indent,
+      start,
+      headerEnd,
+      end: findBlockEnd(lines, headerEnd, indent),
+    });
+  });
+
+  return definitions.map((definition) => ({
+    ...definition,
+    parentClasses: definitions
+      .filter(
+        (candidate) =>
+          candidate.kind === 'class' &&
+          candidate.start < definition.start &&
+          candidate.end >= definition.end &&
+          candidate.indent < definition.indent,
+      )
+      .sort((left, right) => left.indent - right.indent)
+      .map((candidate) => candidate.name),
+  }));
+}
+
+function definitionKey(definition: Pick<PythonDefinition, 'kind' | 'name' | 'parentClasses'>) {
+  return `${definition.parentClasses.join('.')}/${definition.kind}/${definition.name}`;
+}
+
+function findContainingFunction(definitions: readonly PythonDefinition[], lineIndex: number) {
+  return definitions
+    .filter(
+      (definition) =>
+        definition.kind === 'function' &&
+        definition.start <= lineIndex &&
+        lineIndex < definition.end,
+    )
+    .sort((left, right) => right.indent - left.indent)
+    .at(0);
+}
+
+function reindentBody(
+  lines: readonly string[],
+  sourceDefinition: PythonDefinition,
+  replacementIndent: string,
+) {
+  const sourceBodyIndent = sourceDefinition.indent + 4;
+
+  return lines.map((line) => {
+    if (!line.trim()) {
+      return '';
+    }
+
+    return `${replacementIndent}${line.slice(sourceBodyIndent)}`;
+  });
+}
+
+function getMissingTopLevelImports(solutionCode: string, code: string) {
+  const presentLines = new Set(code.split('\n').map((line) => line.trim()));
+
+  return solutionCode
+    .split('\n')
+    .filter(
+      (line) =>
+        /^(?:from\s+[\w.]+\s+import\s+.+|import\s+.+)$/.test(line) &&
+        !line.startsWith('from __future__') &&
+        !presentLines.has(line.trim()),
+    );
+}
+
+function insertSupportingDefinitions(
+  code: string,
+  solutionCode: string,
+  solutionDefinitions: readonly PythonDefinition[],
+) {
+  const currentDefinitions = getPythonDefinitions(code);
+  const currentTopLevelKeys = new Set(
+    currentDefinitions
+      .filter((definition) => definition.indent === 0)
+      .map((definition) => definitionKey(definition)),
+  );
+  const helperDefinitions = solutionDefinitions.filter(
+    (definition) =>
+      definition.kind === 'function' &&
+      definition.indent === 0 &&
+      !currentTopLevelKeys.has(definitionKey(definition)),
+  );
+  const missingImports = getMissingTopLevelImports(solutionCode, code);
+
+  if (helperDefinitions.length === 0 && missingImports.length === 0) {
+    return code;
+  }
+
+  const firstAnnotatedDefinition = currentDefinitions
+    .filter(
+      (definition) =>
+        definition.indent === 0 &&
+        code
+          .split('\n')
+          .slice(definition.start, definition.end)
+          .some((line) => line.includes(REFERENCE_MARKER)),
+    )
+    .sort((left, right) => left.start - right.start)
+    .at(0);
+  const insertionIndex =
+    firstAnnotatedDefinition?.start ??
+    currentDefinitions.filter((definition) => definition.indent === 0).at(0)?.start ??
+    code.split('\n').length;
+  const solutionLines = solutionCode.split('\n');
+  const additions = [
+    ...missingImports,
+    ...(missingImports.length > 0 && helperDefinitions.length > 0 ? [''] : []),
+    ...helperDefinitions.flatMap((definition, index) => [
+      ...solutionLines.slice(definition.start, definition.end),
+      ...(index === helperDefinitions.length - 1 ? [] : ['']),
+    ]),
+  ];
+  const lines = code.split('\n');
+
+  lines.splice(insertionIndex, 0, ...additions, ...(additions.length > 0 ? [''] : []));
+  return lines.join('\n');
+}
+
+/**
+ * Keeps the starter scaffold intact while replacing each explicit exercise
+ * placeholder with the matching annotated reference body. The original raise
+ * remains as a comment so readers can still see the exact starting point.
+ */
+export function augmentCodeWithSolution(
+  problem: Pick<CodePracticeProblem, 'solutionCode' | 'solutionNotes' | 'starterCode'>,
+  currentCode = problem.starterCode,
+) {
+  if (currentCode.includes(REFERENCE_MARKER)) {
+    return currentCode;
+  }
+
+  const solutionDefinitions = getPythonDefinitions(problem.solutionCode);
+  const solutionByKey = new Map(
+    solutionDefinitions.map((definition) => [definitionKey(definition), definition]),
+  );
+  const starterDefinitions = getPythonDefinitions(currentCode);
+  const lines = currentCode.split('\n');
+  let didInsertReference = false;
+
+  const annotatedLines = lines.flatMap((line, lineIndex) => {
+    const placeholder = line.match(/^(\s*)raise NotImplementedError\("Implement ([A-Za-z_]\w*)"\)\s*$/);
+    if (!placeholder) {
+      return [line];
+    }
+
+    const starterDefinition = findContainingFunction(starterDefinitions, lineIndex);
+    if (!starterDefinition || starterDefinition.name !== placeholder[2]) {
+      return [line];
+    }
+
+    const solutionDefinition = solutionByKey.get(definitionKey(starterDefinition));
+    if (!solutionDefinition) {
+      return [line];
+    }
+
+    const indentation = placeholder[1];
+    const solutionLines = problem.solutionCode.split('\n');
+    const body = reindentBody(
+      solutionLines.slice(solutionDefinition.headerEnd + 1, solutionDefinition.end),
+      solutionDefinition,
+      indentation,
+    );
+    const introduction = didInsertReference
+      ? []
+      : [
+          `${indentation}${REFERENCE_MARKER}`,
+          ...problem.solutionNotes.map((note) => `${indentation}# ${note}`),
+          `${indentation}# The TODO plan above stays in place; the annotated lines below implement it.`,
+        ];
+
+    didInsertReference = true;
+    return [
+      `${indentation}# Original placeholder: ${line.trim()}`,
+      ...introduction,
+      ...body,
+    ];
+  });
+
+  if (!didInsertReference) {
+    return currentCode;
+  }
+
+  return insertSupportingDefinitions(
+    annotatedLines.join('\n'),
+    problem.solutionCode,
+    solutionDefinitions,
+  );
+}

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -32,8 +32,14 @@ const testProblem: CodePracticeProblem = {
   ],
   hint: ['Subtract the row max first.'],
   solutionNotes: ['Use a row-wise max shift before the exponentials.'],
-  solutionCode: 'print("solution")',
-  starterCode: 'print("starter")',
+  solutionCode: `def softmax_cross_entropy(logits, labels):
+    # Return the reference value after following the stable path.
+    return "solution"`,
+  starterCode: `def softmax_cross_entropy(logits, labels):
+    # TODO: implement the stable path.
+    raise NotImplementedError("Implement softmax_cross_entropy")
+
+print("starter")`,
   packages: ['torch', 'numpy'],
   tags: ['PyTorch', 'NumPy'],
 };
@@ -117,7 +123,7 @@ describe('CodePracticeLab', () => {
     expect(container.textContent).toContain('Problem 01');
     expect(container.textContent).toContain('Stable softmax cross-entropy');
     expect(container.textContent).not.toContain('Subtract the row max first.');
-    expect(container.textContent).not.toContain('print("solution")');
+    expect(container.textContent).not.toContain('return "solution"');
 
     const buttons = Array.from(container.querySelectorAll('button'));
     const hintButton = buttons.find((button) => button.textContent === 'Add hints');
@@ -138,8 +144,13 @@ describe('CodePracticeLab', () => {
       solutionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(getEditor().textContent).toContain('print("solution")');
-    expect(getEditor().textContent).not.toContain('print("starter")');
+    expect(getEditor().textContent).toContain('print("starter")');
+    expect(getEditor().textContent).toContain('# Original placeholder: raise NotImplementedError');
+    expect(getEditor().textContent).toContain('# Reference solution loaded:');
+    expect(getEditor().textContent).toContain('return "solution"');
+    expect(getEditor().textContent).not.toMatch(
+      /^\s+raise NotImplementedError\("Implement softmax_cross_entropy"\)$/m,
+    );
   });
 
   it('loads required packages and prints run output', async () => {

--- a/tests/code-solution.test.ts
+++ b/tests/code-solution.test.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { codePracticeProblems } from '../src/lib/code-practice';
+import { augmentCodeWithSolution } from '../src/lib/code-solution';
+
+function compilePython(code: string) {
+  execFileSync(
+    'python3',
+    ['-c', 'import sys; compile(sys.stdin.read(), "solution.py", "exec")'],
+    { encoding: 'utf8', input: code },
+  );
+}
+
+function getPlaceholderLines(code: string) {
+  return code
+    .split('\n')
+    .filter((line) => /^\s*raise NotImplementedError\("Implement [A-Za-z_]\w*"\)$/.test(line));
+}
+
+describe('augmentCodeWithSolution', () => {
+  it('keeps every starter scaffold and inserts annotated reference bodies in place', () => {
+    for (const problem of codePracticeProblems) {
+      const placeholders = getPlaceholderLines(problem.starterCode);
+      const lastPlaceholder = problem.starterCode.lastIndexOf(placeholders.at(-1) ?? '');
+      const trailingScaffold = problem.starterCode.slice(
+        problem.starterCode.indexOf('\n', lastPlaceholder) + 1,
+      );
+      const annotatedCode = augmentCodeWithSolution(problem);
+
+      expect(placeholders, problem.id).not.toHaveLength(0);
+      for (const starterLine of problem.starterCode.split('\n')) {
+        if (starterLine.trim() && !placeholders.includes(starterLine)) {
+          expect(annotatedCode, problem.id).toContain(starterLine);
+        }
+      }
+      expect(annotatedCode, problem.id).toContain(trailingScaffold);
+      expect(annotatedCode, problem.id).toContain('# Reference solution loaded:');
+      expect(annotatedCode, problem.id).toContain(
+        '# The TODO plan above stays in place; the annotated lines below implement it.',
+      );
+
+      for (const placeholder of placeholders) {
+        expect(annotatedCode, problem.id).toContain(
+          `# Original placeholder: ${placeholder.trim()}`,
+        );
+      }
+
+      expect(annotatedCode, problem.id).not.toMatch(
+        /^\s+raise NotImplementedError\("Implement [A-Za-z_]\w*"\)$/m,
+      );
+      expect(() => compilePython(annotatedCode), problem.id).not.toThrow();
+      expect(augmentCodeWithSolution(problem, annotatedCode), problem.id).toBe(annotatedCode);
+    }
+  });
+
+  it('adds solution-only imports and helpers before the starter function that uses them', () => {
+    const softmaxProblem = codePracticeProblems.find(
+      (problem) => problem.id === 'stable-softmax-cross-entropy',
+    );
+    const temperatureProblem = codePracticeProblems.find(
+      (problem) => problem.id === 'temperature-scaling-of-logits',
+    );
+
+    expect(softmaxProblem).toBeDefined();
+    expect(temperatureProblem).toBeDefined();
+
+    const softmaxCode = augmentCodeWithSolution(softmaxProblem!);
+    const temperatureCode = augmentCodeWithSolution(temperatureProblem!);
+
+    expect(softmaxCode.indexOf('def _validate_classification_inputs')).toBeLessThan(
+      softmaxCode.indexOf('def softmax_cross_entropy'),
+    );
+    expect(temperatureCode).toContain('import math');
+  });
+
+  it('augments the current editor contents without discarding an inserted hint', () => {
+    const problem = codePracticeProblems.find(
+      (candidate) => candidate.id === 'stable-softmax-cross-entropy',
+    );
+    const hintedStarter = `# Hint: subtract the row maximum before exponentiating.\n\n${problem!.starterCode}`;
+
+    const annotatedCode = augmentCodeWithSolution(problem!, hintedStarter);
+
+    expect(annotatedCode).toContain(
+      '# Hint: subtract the row maximum before exponentiating.',
+    );
+    expect(annotatedCode).toContain('# Reference solution loaded:');
+    expect(annotatedCode).toContain('return torch.mean(losses)');
+  });
+});


### PR DESCRIPTION
## What changed

- Load Solution now preserves the current starter scaffold, TODOs, samples, and any inserted hints.
- It comments the original placeholder and inserts the matching commented reference implementation where the learner writes code.
- It also brings in solution-only imports and helpers when a reference implementation needs them.

## Verification

- `npm run ci`
- Browser QA: Ctrl+Enter ran stable softmax to `0.41703`; narrow stable-softmax and N-gram workspaces stayed within the viewport.