### PR TITLE
Compact code practice reference workspace

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -5968,3 +5968,303 @@ html {
     grid-template-columns: 1fr;
   }
 }
+
+/* Keep the reference workspace compact enough to read an answer in one pass. */
+.code-problem-page {
+  padding: 5.25rem clamp(0.75rem, 2.5vw, 2.5rem) 1.5rem;
+}
+
+.code-problem-page__shell {
+  width: min(100%, 108rem);
+}
+
+.code-practice-lab {
+  grid-template-columns: minmax(17.5rem, 0.58fr) minmax(0, 1.72fr);
+  gap: clamp(1.5rem, 3.2vw, 3.5rem);
+}
+
+.code-practice-lab__problem {
+  padding: 0.25rem clamp(1.25rem, 2.5vw, 2.5rem) 1rem 0;
+  border: 0;
+  border-right: 1px solid rgba(118, 169, 255, 0.2);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+:root[data-theme="dark"] .code-practice-lab__problem {
+  border-color: rgba(255, 228, 92, 0.2);
+  background: transparent;
+  box-shadow: none;
+}
+
+.code-practice-lab__problem-header h1 {
+  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  line-height: 1.15;
+}
+
+.code-practice-lab__copy {
+  margin-top: 0.8rem;
+}
+
+.code-practice-lab__copy p {
+  margin-bottom: 0.7rem;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.code-practice-lab__specs {
+  gap: 0;
+  margin-top: 1rem;
+}
+
+.code-practice-lab__spec-card,
+.code-practice-lab__specs .code-practice-lab__spec-card {
+  margin: 0;
+  padding: 0.8rem 0;
+  border: 0;
+  border-top: 1px solid rgba(118, 169, 255, 0.16);
+  border-radius: 0;
+  background: transparent;
+}
+
+:root[data-theme="dark"] .code-practice-lab__spec-card,
+:root[data-theme="dark"] .code-practice-lab__specs .code-practice-lab__spec-card {
+  border-color: rgba(255, 228, 92, 0.16);
+  background: transparent;
+}
+
+.code-practice-lab__list {
+  gap: 0.4rem;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.code-practice-lab__example {
+  padding: 0.35rem 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+:root[data-theme="dark"] .code-practice-lab__example {
+  background: transparent;
+}
+
+.code-practice-lab__workspace {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  height: min(62rem, calc(100dvh - 6.75rem));
+  min-height: 35rem;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: #dff0ff;
+  top: 5.25rem;
+}
+
+:root[data-theme="dark"] .code-practice-lab__workspace {
+  background: transparent;
+  box-shadow: none;
+}
+
+.code-practice-lab__workspace-header {
+  align-items: center;
+  min-width: 0;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid rgba(118, 169, 255, 0.18);
+}
+
+:root[data-theme="dark"] .code-practice-lab__workspace-header {
+  border-color: rgba(255, 228, 92, 0.18);
+}
+
+.code-practice-lab__workspace-identity {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.code-practice-lab__workspace-identity .code-practice-lab__eyebrow {
+  margin: 0;
+}
+
+.code-practice-lab__workspace-identity .code-practice-lab__status {
+  margin: 0 0 0 0.15rem;
+  color: rgba(223, 240, 255, 0.62);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+:root[data-theme="dark"] .code-practice-lab__workspace-identity .code-practice-lab__status {
+  color: rgba(255, 247, 207, 0.62);
+}
+
+.code-practice-lab__file-name {
+  margin: 0;
+  color: rgba(223, 240, 255, 0.82);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+:root[data-theme="dark"] .code-practice-lab__file-name {
+  color: rgba(255, 247, 207, 0.84);
+}
+
+.code-practice-lab__workspace-controls {
+  gap: 0.4rem;
+}
+
+.code-practice-lab__button {
+  min-height: 2.3rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 9px;
+  box-shadow: none;
+  font-size: 0.8rem;
+}
+
+.code-practice-lab__button:hover:not(:disabled) {
+  box-shadow: none;
+}
+
+.code-practice-lab__button kbd,
+.code-practice-lab__shortcut kbd {
+  padding: 0.1rem 0.25rem;
+  font-size: 0.62rem;
+}
+
+.code-practice-lab__editor-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.code-practice-lab__editor-shell {
+  min-height: 0;
+  height: 100%;
+  border-radius: 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.code-practice-lab__editor {
+  height: 100%;
+  font-size: 0.84rem;
+}
+
+.code-practice-lab__editor .cm-editor,
+.code-practice-lab__editor .cm-scroller {
+  height: 100%;
+  min-height: 0;
+}
+
+.code-practice-lab__editor .cm-scroller {
+  line-height: 1.42;
+}
+
+.code-practice-lab__editor .cm-content,
+.code-practice-lab__editor .cm-gutter {
+  padding-top: 0.6rem;
+  padding-bottom: 0.6rem;
+}
+
+.code-practice-lab--reference .code-practice-lab__editor {
+  font-size: 0.75rem;
+}
+
+.code-practice-lab--reference .code-practice-lab__editor .cm-scroller {
+  line-height: 1.28;
+}
+
+.code-practice-lab--reference .code-practice-lab__editor .cm-content,
+.code-practice-lab--reference .code-practice-lab__editor .cm-gutter {
+  padding-top: 0.45rem;
+  padding-bottom: 0.45rem;
+}
+
+.code-practice-lab--reference .code-practice-lab__editor .cm-comment {
+  opacity: 0.76;
+}
+
+.code-practice-lab__output {
+  display: block;
+  margin-top: 0.55rem;
+}
+
+.code-practice-lab__output > div {
+  min-height: 0;
+  margin: 0;
+  padding: 0.5rem 0.7rem;
+  border-radius: 10px;
+}
+
+.code-practice-lab__output p {
+  margin-bottom: 0.35rem;
+  font-size: 0.68rem;
+}
+
+.code-practice-lab__output pre {
+  max-height: 7rem;
+  overflow: auto;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+@media (max-width: 980px) {
+  .code-practice-lab {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .code-practice-lab__problem {
+    padding: 0 0 1.25rem;
+    border-right: 0;
+    border-bottom: 1px solid rgba(118, 169, 255, 0.2);
+  }
+
+  :root[data-theme="dark"] .code-practice-lab__problem {
+    border-color: rgba(255, 228, 92, 0.2);
+  }
+
+  .code-practice-lab__workspace {
+    position: static;
+    height: min(50rem, calc(100dvh - 6.5rem));
+    min-height: 30rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .code-problem-page {
+    padding-inline: 0.85rem;
+  }
+
+  .code-practice-lab__workspace {
+    height: min(44rem, calc(100dvh - 4.5rem));
+    min-height: 26rem;
+  }
+
+  .code-practice-lab__workspace-header {
+    align-items: flex-start;
+  }
+
+  .code-practice-lab__workspace-controls {
+    justify-content: flex-start;
+    gap: 0.35rem;
+  }
+
+  .code-practice-lab__button {
+    min-height: 2.2rem;
+    padding-inline: 0.55rem;
+    font-size: 0.74rem;
+  }
+
+  .code-practice-lab__button--primary kbd {
+    display: none;
+  }
+
+}

--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -39,6 +39,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [statusMessage, setStatusMessage] = useState('Loading Python...');
   const [isRunning, setIsRunning] = useState(false);
+  const [hasRun, setHasRun] = useState(false);
   const [editorTheme, setEditorTheme] = useState(() =>
     getCodeEditorThemeName(
       typeof document === 'undefined' ? 'light' : document.documentElement.getAttribute('data-theme'),
@@ -75,6 +76,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     setCode(problem.starterCode);
     setOutput('');
     setErrorOutput('');
+    setHasRun(false);
   }, [problem]);
 
   useEffect(() => {
@@ -162,6 +164,8 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
 
   const editorId = `${problem.id}-editor`;
   const editorThemeExtension = editorTheme === 'dark' ? githubDark : githubLight;
+  const isReferenceLoaded = code.includes('# Reference solution');
+  const hasExecutionResult = hasRun || Boolean(errorOutput);
 
   async function handleRun() {
     if (isRunningRef.current) {
@@ -175,6 +179,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
 
     isRunningRef.current = true;
     setIsRunning(true);
+    setHasRun(true);
     setOutput('');
     setErrorOutput('');
 
@@ -201,6 +206,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     setCode(problem.starterCode);
     setOutput('');
     setErrorOutput('');
+    setHasRun(false);
   }
 
   function handleAddHints() {
@@ -217,6 +223,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     setCode((currentCode) => augmentCodeWithSolution(problem, currentCode));
     setOutput('');
     setErrorOutput('');
+    setHasRun(false);
   }
 
   // The CodeMirror keymap is created once, so route it through a ref to the
@@ -226,7 +233,10 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   };
 
   return (
-    <section className="code-practice-lab" ref={containerRef}>
+    <section
+      className={`code-practice-lab${isReferenceLoaded ? ' code-practice-lab--reference' : ''}`}
+      ref={containerRef}
+    >
       <article className="code-practice-lab__problem">
         <header className="code-practice-lab__problem-header">
           <div className="code-practice-lab__title-block">
@@ -277,9 +287,17 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
 
       <article className="code-practice-lab__workspace">
         <header className="code-practice-lab__workspace-header">
-          <div>
-            <p className="code-practice-lab__eyebrow">Workspace</p>
-            <h2>Your solution</h2>
+          <div className="code-practice-lab__workspace-identity">
+            <p className="code-practice-lab__eyebrow">
+              {isReferenceLoaded ? 'Reference' : 'Workspace'}
+            </p>
+            <p className="code-practice-lab__file-name">solution.py</p>
+            <p
+              className={`code-practice-lab__status code-practice-lab__status--${status}`}
+              aria-live="polite"
+            >
+              {statusMessage}
+            </p>
           </div>
           <div className="code-practice-lab__workspace-controls">
             <button
@@ -296,24 +314,29 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
             >
               Load solution
             </button>
+            <button
+              className="code-practice-lab__button code-practice-lab__button--primary"
+              type="button"
+              aria-label="Run code"
+              aria-keyshortcuts="Control+Enter Meta+Enter"
+              onClick={() => void handleRun()}
+              disabled={status !== 'ready' || isRunning}
+            >
+              <span>{isRunning ? 'Running...' : 'Run'}</span>
+              {!isRunning && <kbd>Ctrl / Cmd + Enter</kbd>}
+            </button>
+            <button
+              className="code-practice-lab__button code-practice-lab__button--secondary"
+              type="button"
+              onClick={handleReset}
+            >
+              Reset
+            </button>
           </div>
         </header>
 
-        <div className="code-practice-lab__workspace-meta">
-          <p
-            className={`code-practice-lab__status code-practice-lab__status--${status}`}
-            aria-live="polite"
-          >
-            {statusMessage}
-          </p>
-          <p className="code-practice-lab__shortcut">
-            <kbd>Ctrl / Cmd + Enter</kbd>
-            <span>runs code</span>
-          </p>
-        </div>
-
         <label className="code-practice-lab__editor-label" htmlFor={editorId}>
-          solution.py
+          solution.py editor
         </label>
         <div className="code-practice-lab__editor-shell">
           <CodeMirror
@@ -323,7 +346,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
             basicSetup={false}
             extensions={editorExtensions}
             theme={editorThemeExtension}
-            height="36rem"
+            height="100%"
             editable
             indentWithTab={false}
             value={code}
@@ -331,37 +354,14 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
           />
         </div>
 
-        <div className="code-practice-lab__actions">
-          <button
-            className="code-practice-lab__button code-practice-lab__button--primary"
-            type="button"
-            aria-label="Run code"
-            aria-keyshortcuts="Control+Enter Meta+Enter"
-            onClick={() => void handleRun()}
-            disabled={status !== 'ready' || isRunning}
-          >
-            <span>{isRunning ? 'Running...' : 'Run'}</span>
-            {!isRunning && <kbd>Ctrl / Cmd + Enter</kbd>}
-          </button>
-          <button
-            className="code-practice-lab__button code-practice-lab__button--secondary"
-            type="button"
-            onClick={handleReset}
-          >
-            Reset
-          </button>
-        </div>
-
-        <div className="code-practice-lab__output" aria-live="polite">
-          <div>
-            <p>Output</p>
-            <pre>{output || 'Output appears here.'}</pre>
+        {hasExecutionResult && (
+          <div className="code-practice-lab__output" aria-live="polite">
+            <div>
+              <p>{errorOutput ? 'Errors' : 'Output'}</p>
+              <pre>{errorOutput || output || 'Program finished with no output.'}</pre>
+            </div>
           </div>
-          <div>
-            <p>Errors</p>
-            <pre>{errorOutput || 'Errors appear here.'}</pre>
-          </div>
-        </div>
+        )}
       </article>
     </section>
   );

--- a/src/lib/code-solution.ts
+++ b/src/lib/code-solution.ts
@@ -1,6 +1,6 @@
 import type { CodePracticeProblem } from './code-practice';
 
-const REFERENCE_MARKER = '# Reference solution loaded:';
+const REFERENCE_MARKER = '# Reference solution';
 
 interface PythonDefinition {
   kind: 'class' | 'function';
@@ -105,6 +105,67 @@ function reindentBody(
   });
 }
 
+function negateCondition(condition: string) {
+  const trimmed = condition.trim();
+  if (trimmed.startsWith('not ')) {
+    return trimmed.slice(4);
+  }
+
+  const inequality = trimmed.match(/^(.+?)\s*!=\s*(.+)$/);
+  if (inequality && !/\s(?:and|or)\s/.test(trimmed)) {
+    return `${inequality[1]} == ${inequality[2]}`;
+  }
+
+  return `not (${trimmed})`;
+}
+
+function compactSimpleValueErrorGuards(lines: readonly string[]) {
+  const compacted: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const guard = line.match(/^(\s*)if\s+(.+):\s*$/);
+    const raiseLine = lines[index + 1]?.match(/^(\s+)raise ValueError\((.+)\)$/);
+
+    if (guard && raiseLine && getIndent(raiseLine[1]) > getIndent(guard[1])) {
+      compacted.push(`${guard[1]}assert ${negateCondition(guard[2])}, ${raiseLine[2]}`);
+      index += 1;
+      continue;
+    }
+
+    compacted.push(line);
+  }
+
+  return compacted;
+}
+
+/**
+ * The stored solution remains the complete reference implementation. The code
+ * inserted into the editor is intentionally a shorter, interview-style view:
+ * it keeps executable logic and precondition checks while omitting narration
+ * that would otherwise hide the algorithm below the fold.
+ */
+function createCompactReference(solutionCode: string) {
+  const uncommented = solutionCode
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('#'));
+  const guarded = compactSimpleValueErrorGuards(uncommented);
+  const compacted: string[] = [];
+  let previousWasBlank = true;
+
+  for (const line of guarded) {
+    const isBlank = !line.trim();
+    if (isBlank && previousWasBlank) {
+      continue;
+    }
+
+    compacted.push(line);
+    previousWasBlank = isBlank;
+  }
+
+  return compacted.join('\n').trim();
+}
+
 function getMissingTopLevelImports(solutionCode: string, code: string) {
   const presentLines = new Set(code.split('\n').map((line) => line.trim()));
 
@@ -177,14 +238,15 @@ function insertSupportingDefinitions(
  * remains as a comment so readers can still see the exact starting point.
  */
 export function augmentCodeWithSolution(
-  problem: Pick<CodePracticeProblem, 'solutionCode' | 'solutionNotes' | 'starterCode'>,
+  problem: Pick<CodePracticeProblem, 'solutionCode' | 'starterCode'>,
   currentCode = problem.starterCode,
 ) {
   if (currentCode.includes(REFERENCE_MARKER)) {
     return currentCode;
   }
 
-  const solutionDefinitions = getPythonDefinitions(problem.solutionCode);
+  const compactReference = createCompactReference(problem.solutionCode);
+  const solutionDefinitions = getPythonDefinitions(compactReference);
   const solutionByKey = new Map(
     solutionDefinitions.map((definition) => [definitionKey(definition), definition]),
   );
@@ -209,7 +271,7 @@ export function augmentCodeWithSolution(
     }
 
     const indentation = placeholder[1];
-    const solutionLines = problem.solutionCode.split('\n');
+    const solutionLines = compactReference.split('\n');
     const body = reindentBody(
       solutionLines.slice(solutionDefinition.headerEnd + 1, solutionDefinition.end),
       solutionDefinition,
@@ -219,8 +281,6 @@ export function augmentCodeWithSolution(
       ? []
       : [
           `${indentation}${REFERENCE_MARKER}`,
-          ...problem.solutionNotes.map((note) => `${indentation}# ${note}`),
-          `${indentation}# The TODO plan above stays in place; the annotated lines below implement it.`,
         ];
 
     didInsertReference = true;
@@ -237,7 +297,7 @@ export function augmentCodeWithSolution(
 
   return insertSupportingDefinitions(
     annotatedLines.join('\n'),
-    problem.solutionCode,
+    compactReference,
     solutionDefinitions,
   );
 }

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -146,8 +146,9 @@ describe('CodePracticeLab', () => {
 
     expect(getEditor().textContent).toContain('print("starter")');
     expect(getEditor().textContent).toContain('# Original placeholder: raise NotImplementedError');
-    expect(getEditor().textContent).toContain('# Reference solution loaded:');
+    expect(getEditor().textContent).toContain('# Reference solution');
     expect(getEditor().textContent).toContain('return "solution"');
+    expect(container.querySelector('.code-practice-lab--reference')).not.toBeNull();
     expect(getEditor().textContent).not.toMatch(
       /^\s+raise NotImplementedError\("Implement softmax_cross_entropy"\)$/m,
     );
@@ -166,6 +167,8 @@ describe('CodePracticeLab', () => {
 
     const runButton = container.querySelector<HTMLButtonElement>('button[aria-label="Run code"]');
 
+    expect(runButton?.closest('.code-practice-lab__workspace-header')).not.toBeNull();
+
     await act(async () => {
       runButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -173,6 +176,7 @@ describe('CodePracticeLab', () => {
 
     expect(loadPackage).toHaveBeenCalledWith(['numpy']);
     expect(container.textContent).toContain('0.41703');
+    expect(container.querySelector('.code-practice-lab__output')).not.toBeNull();
   });
 
   it('runs the current editor contents with Ctrl+Enter', async () => {

--- a/tests/code-solution.test.ts
+++ b/tests/code-solution.test.ts
@@ -34,10 +34,7 @@ describe('augmentCodeWithSolution', () => {
         }
       }
       expect(annotatedCode, problem.id).toContain(trailingScaffold);
-      expect(annotatedCode, problem.id).toContain('# Reference solution loaded:');
-      expect(annotatedCode, problem.id).toContain(
-        '# The TODO plan above stays in place; the annotated lines below implement it.',
-      );
+      expect(annotatedCode, problem.id).toContain('# Reference solution');
 
       for (const placeholder of placeholders) {
         expect(annotatedCode, problem.id).toContain(
@@ -73,6 +70,33 @@ describe('augmentCodeWithSolution', () => {
     expect(temperatureCode).toContain('import math');
   });
 
+  it('uses a compact reference view with assertions instead of verbose guard blocks', () => {
+    const problem = codePracticeProblems.find(
+      (candidate) => candidate.id === 'stable-softmax-cross-entropy',
+    );
+    const nmsProblem = codePracticeProblems.find(
+      (candidate) => candidate.id === 'non-maximum-suppression',
+    );
+    const annotatedCode = augmentCodeWithSolution(problem!);
+    const nmsCode = augmentCodeWithSolution(nmsProblem!);
+    const sourceCommentCount = problem!.solutionCode
+      .split('\n')
+      .filter((line) => line.trimStart().startsWith('#')).length;
+    const annotatedCommentCount = annotatedCode
+      .split('\n')
+      .filter((line) => line.trimStart().startsWith('#')).length;
+
+    expect(annotatedCode).toContain(
+      'assert logits.ndim == 2, "logits must have shape (N, C)"',
+    );
+    expect(annotatedCode).not.toContain('raise ValueError("logits must have shape (N, C)")');
+    expect(annotatedCode).not.toContain('# Convert compatible inputs once');
+    expect(annotatedCommentCount).toBeLessThan(sourceCommentCount);
+    expect(nmsCode).toContain(
+      'assert not (boxes.ndim != 2 or boxes.shape[1] != 4), "boxes must have shape (N, 4)"',
+    );
+  });
+
   it('augments the current editor contents without discarding an inserted hint', () => {
     const problem = codePracticeProblems.find(
       (candidate) => candidate.id === 'stable-softmax-cross-entropy',
@@ -84,7 +108,7 @@ describe('augmentCodeWithSolution', () => {
     expect(annotatedCode).toContain(
       '# Hint: subtract the row maximum before exponentiating.',
     );
-    expect(annotatedCode).toContain('# Reference solution loaded:');
+    expect(annotatedCode).toContain('# Reference solution');
     expect(annotatedCode).toContain('return torch.mean(losses)');
   });
 });


### PR DESCRIPTION
## What changed

- Load Solution now adds a compact, assertion-based reference view without removing the starter scaffold.
- The workspace is editor-first: a larger viewport-filling editor, compact top toolbar, and on-demand output.
- Problem details are flattened into a compact reading rail.

## Verification

- npm run ci
- Local browser QA: the stable-softmax reference fits at 1440x900, mobile stays contained, and Ctrl+Enter prints 0.41703.