### PR TITLE
Reduce Code page editor font size

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -6154,7 +6154,8 @@ html {
 
 .code-practice-lab__editor {
   height: 100%;
-  font-size: 0.84rem;
+  /* Keep standard 80-character starter and hint lines on one visual row. */
+  font-size: 0.76rem;
 }
 
 .code-practice-lab__editor .cm-editor,


### PR DESCRIPTION
## What changed
- Reduce the effective CodeMirror editor font from 0.84rem to 0.76rem.
- Keep standard 80-character starter and hint lines on one visual row.

## Why
The Code page editor was wrapping common long lines in the split workspace.

## Tested
- npm run ci
- Local desktop and 390px responsive browser QA
- No local console warnings or errors