### PR TITLE
Add PyTorch tensor revision notes

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -5041,6 +5041,62 @@ html {
   margin-bottom: 0;
 }
 
+.revision-code-pair {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+  align-items: start;
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.revision-code-pair__reference,
+.revision-code-pair__runner {
+  min-width: 0;
+}
+
+.revision-code-pair__reference {
+  overflow: hidden;
+  border: 1px solid var(--code-border-color);
+  border-radius: 18px;
+  background: var(--panel-bg);
+}
+
+.revision-code-pair__reference > summary {
+  padding: 1rem 1.1rem;
+  color: var(--text-color);
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.revision-code-pair__reference > summary:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
+}
+
+.revision-code-pair__reference[open] > summary {
+  border-bottom: 1px solid var(--code-border-color);
+}
+
+.revision-code-pair__reference pre {
+  max-height: 34rem;
+  margin: 0;
+  overflow: auto;
+  padding: 1rem 1.1rem;
+  background: var(--code-block-bg-dark, var(--background-secondary));
+}
+
+.revision-code-pair__reference code {
+  white-space: pre;
+}
+
+.revision-code-pair__runner .python-playground {
+  height: 100%;
+  box-sizing: border-box;
+  margin: 0;
+}
+
 .code-practice-lab {
   display: grid;
   gap: 1.5rem;
@@ -5616,6 +5672,10 @@ html {
   .python-playground__output,
   .python-playground__variables {
     display: grid;
+  }
+
+  .revision-code-pair {
+    grid-template-columns: 1fr;
   }
 
   .code-practice-lab__hero-header,

--- a/src/components/PythonPlayground.tsx
+++ b/src/components/PythonPlayground.tsx
@@ -4,6 +4,14 @@ import type { PyodideRuntime } from '../lib/pyodide-loader';
 import type { PythonPlaygroundProps } from '../lib/python-playground';
 import { runPythonSnippet } from '../lib/python-runner';
 
+function createHeadingId(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .replace(/[\s-]+/g, '-');
+}
+
 export default function PythonPlayground({
   title,
   initialCode,
@@ -137,7 +145,7 @@ export default function PythonPlayground({
       <div className="python-playground__header">
         <div>
           <p className="python-playground__eyebrow">Interactive Python</p>
-          <h3>{title}</h3>
+          <h3 id={createHeadingId(title)}>{title}</h3>
         </div>
         <p
           className={`python-playground__status python-playground__status--${status}`}
@@ -214,7 +222,7 @@ export default function PythonPlayground({
           <div className="python-playground__walkthrough-header">
             <div>
               <p className="python-playground__eyebrow">Guided Trace</p>
-              <h4>{currentStep.label}</h4>
+              <h4 id={createHeadingId(currentStep.label)}>{currentStep.label}</h4>
             </div>
             <p>
               Step {activeStep + 1} of {walkthroughSteps.length}

--- a/src/components/RevisionCodePair.astro
+++ b/src/components/RevisionCodePair.astro
@@ -1,0 +1,37 @@
+---
+import PythonPlayground from './PythonPlayground';
+
+interface Props {
+  title: string;
+  initialCode: string;
+  referenceCode: string;
+  description?: string;
+  notes?: string;
+}
+
+const { title, initialCode, referenceCode, description, notes } = Astro.props;
+const samples = [
+  {
+    label: 'Starting example',
+    code: initialCode,
+    description,
+  },
+];
+---
+
+<section class="revision-code-pair" aria-label={`${title} code example`}>
+  <details class="revision-code-pair__reference">
+    <summary>Reference code</summary>
+    <pre><code>{referenceCode}</code></pre>
+  </details>
+
+  <div class="revision-code-pair__runner">
+    <PythonPlayground
+      client:visible
+      title={title}
+      initialCode={initialCode}
+      samples={samples}
+      notes={notes}
+    />
+  </div>
+</section>

--- a/src/content/posts/pytorch-tensor-revision-notes.mdx
+++ b/src/content/posts/pytorch-tensor-revision-notes.mdx
@@ -1,0 +1,107 @@
+---
+title: PyTorch Tensor Revision Notes
+date: '2026-08-09T04:00:00.000Z'
+section: revision-notes
+postSlug: pytorch-tensor-revision-notes
+legacyPath: /revision notes/2026/08/09/pytorch-tensor-revision-notes.html
+tags:
+  - PyTorch
+summary: A source-linked reference for constructing, inspecting, indexing, joining, reshaping, and mutating PyTorch tensors.
+---
+import RevisionCodePair from '../../components/RevisionCodePair.astro';
+import { pytorchTensorExamples } from '../../lib/pytorch-revision-examples';
+
+# PyTorch Tensor Revision Notes
+
+## Quick overview
+
+According to the [PyTorch 2.13 tensor documentation](https://docs.pytorch.org/docs/2.13/tensors.html), a `torch.Tensor` is a multi-dimensional matrix whose elements have one data type. The useful refinement is that a regular tensor is also a strided view over storage: its shape, dtype, strides, storage offset, and device determine how an index maps to the backing buffer; `torch.tensor(data, dtype=..., device=...)` constructs a new tensor by copying `data`.
+
+This note builds the mental model needed to predict tensor shapes, values, aliasing, and mutation. It covers construction, factory functions, metadata, scalar extraction, indexing, slicing, joining, reshaping, and in-place operations.
+
+The interactive panel is on the right of each example. It runs through Pyodide with a small NumPy-backed compatibility layer because the compiled PyTorch runtime is not shipped to the browser. The panel supports the tensor idioms used here, but it is not full PyTorch: there is no CUDA execution, autograd engine, or `nn.Module` implementation. The collapsed block on the left is the actual PyTorch reference code.
+
+## 1. Constructing tensors
+
+`torch.tensor(data)` accepts a scalar, list, nested sequence, NumPy array, or another tensor. It always copies the input data and creates a tensor with no autograd history by default. That copy is a semantic boundary: later changes to a NumPy source array or input tensor do not change the result.
+
+When avoiding a copy is intentional, use the API that says so. `torch.as_tensor(data)` preserves existing tensor history and avoids copies where possible; `torch.from_numpy(array)` creates a CPU tensor sharing storage with a NumPy array. A shared tensor is useful for interoperability, but it also means that a write through either object can change the other.
+
+`dtype` controls how each element is represented, while `device` controls where the storage lives, usually `cpu`, `cuda`, or `mps`. Pass them to the constructor or a factory function instead of constructing first and silently relying on later conversions. Tensors do not generally move between devices automatically, so model parameters and inputs must be placed deliberately.
+
+<RevisionCodePair {...pytorchTensorExamples.construction} />
+
+The example uses `device="cpu"` so it remains executable in the browser. In a real program, a common explicit choice is `device = torch.device("cuda" if torch.cuda.is_available() else "cpu")`, followed by `torch.zeros((2, 3), dtype=torch.float32, device=device)`.
+
+## 2. Creation ops: zeros, ones, and random values
+
+Factory functions express the intended initialization directly. `zeros` and `ones` create constant tensors; `full` chooses another fill value; `rand` samples uniformly from $[0, 1)$; and `randn` samples from a standard normal distribution. `arange` is useful for integer-like sequences, while `linspace` chooses a fixed number of evenly spaced points. `empty` allocates the requested shape without initializing the elements, so it is only safe when every position will be overwritten before it is read.
+
+The `*_like` family copies shape, dtype, and usually device from an existing tensor: `zeros_like(x)`, `ones_like(x)`, and `empty_like(x)` are often clearer than repeating metadata manually. Random factories consume a pseudorandom generator; call `torch.manual_seed` when a reproducible debugging example matters, and remember that reproducibility across devices and releases has additional constraints.
+
+<RevisionCodePair {...pytorchTensorExamples.creationOps} />
+
+The important prediction is the shape before the values. A call such as `torch.rand((2, 3))` creates six independent logical elements, whereas `torch.rand(2, 3, 1)` creates a rank-three tensor with shape `(2, 3, 1)`.
+
+## 3. A tensor is metadata plus a view over storage
+
+A dense PyTorch tensor is not a nested Python list. Its storage is a contiguous one-dimensional buffer of bytes; tensor metadata gives the dtype, shape, stride, and storage offset needed to interpret that buffer. Multiple tensors can therefore refer to the same storage while exposing different shapes or index-to-memory mappings. This is why a slice or transpose can be cheap, and also why a write through a view can modify the original tensor.
+
+The scalar boundary needs a precise description. `x.item()` does not “get the underlying storage”; it converts a tensor containing exactly one element into a standard Python number and is not differentiable. Use `x.tolist()` for a small tensor of Python values, `x.numpy()` for CPU interoperability when the storage permits it, and `x.detach().cpu().numpy()` when the tensor may require gradients or live on an accelerator. Use `untyped_storage().data_ptr()` when the question is whether two tensors share storage, not when the question is what values they contain.
+
+<RevisionCodePair {...pytorchTensorExamples.inspectStorage} />
+
+The view in the example has a different shape and stride but the same storage identity as `base`. For dense tensors, the logical byte count is commonly reasoned about as `numel() * element_size()`, while a view can cover only part of a larger storage. `stride()` tells you how many storage elements the next index in each dimension skips; it is the bridge between an abstract shape and memory traffic.
+
+## 4. Indexing and slicing
+
+Tensor indexing follows Python and NumPy conventions: indices start at zero, negative indices count from the end, `:` selects a range, and a step such as `::2` skips elements. For a tensor `x` with shape `(B, T, D)`, `x[b]` removes the first dimension, `x[:, t]` selects one position for every batch item, and `x[..., -1]` selects the last feature without spelling out the leading dimensions.
+
+Basic indexing and slicing generally return views. Advanced indexing—integer index tensors, lists of indices, or boolean masks—returns a new tensor containing the selected values. Assignment through either basic or advanced indexing is still an in-place write to the destination. The distinction matters when you mutate the result and expect the source to change.
+
+<RevisionCodePair {...pytorchTensorExamples.indexing} />
+
+When debugging a shape error, print the shape after every indexing step rather than reasoning only from the source shape. Indexing with an integer removes a dimension; slicing preserves it; inserting `None` or calling `unsqueeze` adds a dimension of size one.
+
+## 5. Joining, stacking, and reshaping
+
+`torch.cat` joins tensors along an existing dimension. All non-concatenated dimensions must match, so concatenating two `(B, T, D)` tensors along `T` produces `(B, T_1 + T_2, D)`. `torch.stack` requires every input to have the same shape and inserts a new dimension, so stacking two `(B, T, D)` tensors along dimension zero produces `(2, B, T, D)`.
+
+This is the fastest shape check: ask whether the operation should preserve rank. If yes, start with `cat`; if the operation represents a new batch, time, ensemble, or sample axis, start with `stack`. `split` and `chunk` are the corresponding ways to divide a tensor along an existing dimension.
+
+`view` changes shape without copying when the requested shape is compatible with the current strides. `reshape` is more permissive: it returns a view when possible and makes a copy otherwise, so code should not depend on aliasing through `reshape`. `transpose` and `permute` rearrange dimensions and commonly create non-contiguous views; call `contiguous()` when a downstream operation requires contiguous storage.
+
+<RevisionCodePair {...pytorchTensorExamples.joining} />
+
+The output shapes are determined by the operation, not by the values. Predict them first, then use `.shape` to confirm the prediction. This habit catches most errors in batched linear algebra before the numerical result becomes distracting.
+
+## 6. Mutating operations and autograd
+
+Most tensor expressions are out-of-place: `y = x + 1` allocates a result and leaves `x` unchanged. Methods ending in an underscore—`add_`, `zero_`, `fill_`, `copy_`, and many others—mutate their receiver and return it. Indexing assignment such as `x[:, 0] = 0` is also in-place, even though the syntax does not end in an underscore.
+
+In-place updates can save memory, but they can also invalidate values that autograd saved for backward. Mutating a leaf tensor that requires gradients is often prohibited; when an intentional parameter or buffer update is needed outside the gradient calculation, use `with torch.no_grad():`. Prefer out-of-place expressions in ordinary `forward` code unless the memory and autograd consequences are understood. `.data` is not a safe substitute for `no_grad`.
+
+<RevisionCodePair {...pytorchTensorExamples.mutation} />
+
+The interview-level distinction is simple: the absence of an underscore does not prove that an operation is pure—index assignment is the counterexample—while the presence of an underscore is an explicit request to mutate existing storage.
+
+## 7. Rapid recall
+
+| Question | Short answer | Common trap |
+| --- | --- | --- |
+| What is a tensor? | A typed, strided multi-dimensional view over storage on a device. | Treating it as a Python list with nested shape semantics. |
+| Does `torch.tensor(x)` share `x`? | No; it copies `x` and creates a fresh leaf by default. | Using it when `as_tensor` or `from_numpy` was intended. |
+| What does `item()` do? | Converts a one-element tensor to a Python scalar. | Calling it on a tensor with many elements or confusing it with storage access. |
+| `cat` or `stack`? | `cat` joins an existing dimension; `stack` inserts a new one. | Forgetting that `stack` requires equal input shapes. |
+| `view` or `reshape`? | `view` requires compatible strides; `reshape` may copy. | Assuming every reshape aliases the input. |
+| What does `_` mean? | The operation mutates the receiver in-place. | Breaking autograd by mutating a saved or gradient-tracked tensor. |
+| How do devices interact? | Move explicitly with `.to(device)` and keep participating tensors compatible. | Assuming PyTorch will move ordinary tensors automatically. |
+
+## Source links
+
+- [PyTorch 2.13 tensor documentation](https://docs.pytorch.org/docs/2.13/tensors.html)
+- [Tensor attributes: dtype, device, layout, and strides](https://docs.pytorch.org/docs/2.13/tensor_attributes.html)
+- [Tensor views and aliasing](https://docs.pytorch.org/docs/2.13/tensor_view.html)
+- [`torch.Tensor.item`](https://docs.pytorch.org/docs/2.13/generated/torch.Tensor.item.html)
+- [Creation ops](https://docs.pytorch.org/docs/2.13/torch.html#creation-ops)
+- [Indexing, slicing, joining, and mutating ops](https://docs.pytorch.org/docs/2.13/torch.html#indexing-slicing-joining-mutating-ops)

--- a/src/lib/pytorch-revision-examples.ts
+++ b/src/lib/pytorch-revision-examples.ts
@@ -1,0 +1,255 @@
+export interface PytorchTensorExample {
+  title: string;
+  initialCode: string;
+  referenceCode: string;
+  description: string;
+  notes?: string;
+}
+
+export const pytorchTensorExamples: Record<string, PytorchTensorExample> = {
+  construction: {
+    title: 'Construct, copy, and place a tensor',
+    description: 'Edit the source value or dtype, then run the snippet again.',
+    initialCode: `import numpy as np
+import torch
+
+source = np.array([[1, 2], [3, 4]], dtype=np.float32)
+copied = torch.tensor(source, dtype=torch.float32, device="cpu")
+shared = torch.as_tensor(source)
+
+source[0, 0] = 99
+
+print("copied:", copied.tolist())
+print("shared:", shared.tolist())
+print("dtype:", copied.dtype)
+print("device:", copied.device)
+`,
+    referenceCode: `import numpy as np
+import torch
+
+source = np.array([[1, 2], [3, 4]], dtype=np.float32)
+
+# torch.tensor always copies its input data.
+copied = torch.tensor(source, dtype=torch.float32, device="cpu")
+
+# These APIs can share CPU storage when the input permits it.
+shared = torch.as_tensor(source)
+shared_from_numpy = torch.from_numpy(source)
+
+source[0, 0] = 99
+
+print("copied:", copied.tolist())
+print("as_tensor:", shared.tolist())
+print("from_numpy:", shared_from_numpy.tolist())
+print("dtype:", copied.dtype)
+print("device:", copied.device)
+`,
+    notes:
+      'The browser runner uses NumPy underneath, so its copy/share behavior mirrors the example but it does not allocate CUDA tensors.',
+  },
+
+  creationOps: {
+    title: 'Create zeros, ones, and random tensors',
+    description: 'The seed makes the random examples repeatable in this small exercise.',
+    initialCode: `import torch
+
+torch.manual_seed(7)
+
+factories = {
+    "zeros": torch.zeros((2, 3)),
+    "ones": torch.ones((2, 3)),
+    "full": torch.full((2, 3), 7),
+    "rand": torch.rand((2, 3)),
+    "randn": torch.randn((2, 3)),
+    "arange": torch.arange(6).reshape(2, 3),
+    "eye": torch.eye(3),
+}
+
+for name, value in factories.items():
+    print(name, "shape:", value.shape)
+    print(value)
+`,
+    referenceCode: `import torch
+
+torch.manual_seed(7)
+
+zeros = torch.zeros((2, 3), dtype=torch.float32)
+ones = torch.ones((2, 3), dtype=torch.float32)
+full = torch.full((2, 3), fill_value=7, dtype=torch.int64)
+uniform = torch.rand((2, 3), dtype=torch.float32)       # [0, 1)
+normal = torch.randn((2, 3), dtype=torch.float32)       # N(0, 1)
+sequence = torch.arange(6, dtype=torch.int64).reshape(2, 3)
+identity = torch.eye(3, dtype=torch.float32)
+empty = torch.empty((2, 3))  # allocated, but not initialized
+
+for name, value in {
+    "zeros": zeros,
+    "ones": ones,
+    "full": full,
+    "uniform": uniform,
+    "normal": normal,
+    "sequence": sequence,
+    "identity": identity,
+}.items():
+    print(name, "shape:", value.shape)
+    print(value)
+`,
+    notes: 'Try changing the factory shape. `empty` is useful when every element will be overwritten, but never read it before initialization.',
+  },
+
+  inspectStorage: {
+    title: 'Inspect shape, scalar values, and storage views',
+    description: 'Change the slice and observe the shape, stride, and storage relationship.',
+    initialCode: `import torch
+
+base = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+view = base[:, 1:3]
+
+print("shape:", base.shape)
+print("ndim:", base.ndim)
+print("numel:", base.numel())
+print("element size:", base.element_size(), "bytes")
+print("base stride:", base.stride())
+print("view stride:", view.stride())
+print("share storage:", base.untyped_storage().data_ptr() == view.untyped_storage().data_ptr())
+print("one Python scalar:", base[1, 2].item())
+print("many Python values:", view.tolist())
+`,
+    referenceCode: `import torch
+
+base = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+view = base[:, 1:3]
+
+print("shape:", base.shape)
+print("ndim:", base.ndim)
+print("numel:", base.numel())
+print("element size:", base.element_size(), "bytes")
+print("base stride:", base.stride())
+print("view stride:", view.stride())
+print(
+    "share storage:",
+    base.untyped_storage().data_ptr() == view.untyped_storage().data_ptr(),
+)
+
+# item() is scalar conversion, not raw-storage access.
+print("one Python scalar:", base[1, 2].item())
+print("many Python values:", view.tolist())
+`,
+    notes:
+      'A tensor is metadata plus a view over storage. Use `item()` for exactly one value, `tolist()` for a small tensor, and `untyped_storage().data_ptr()` only when you need to reason about aliasing.',
+  },
+
+  indexing: {
+    title: 'Index and slice by dimension',
+    description: 'Try negative indices, a different step, or a different boolean mask.',
+    initialCode: `import torch
+
+x = torch.arange(20).reshape(4, 5)
+indices = torch.tensor([0, 3])
+
+print("one element:", x[1, 2].item())
+print("one row:\\n", x[1])
+print("rows 0:2, columns 1:4:\\n", x[0:2, 1:4])
+print("every other column:\\n", x[:, ::2])
+print("advanced row selection:\\n", x[indices])
+
+# Assignment through a slice changes x in-place.
+x[:2, 0] = -1
+print("after slice assignment:\\n", x)
+`,
+    referenceCode: `import torch
+
+x = torch.arange(20).reshape(4, 5)
+indices = torch.tensor([0, 3], dtype=torch.int64)
+
+print("one element:", x[1, 2].item())
+print("one row:\\n", x[1])
+print("rows 0:2, columns 1:4:\\n", x[0:2, 1:4])
+print("every other column:\\n", x[:, ::2])
+print("advanced row selection:\\n", x[indices])
+
+# Basic indexing/slicing returns a view. Assignment is in-place.
+x[:2, 0] = -1
+print("after slice assignment:\\n", x)
+`,
+    notes:
+      'Basic slices such as `x[:, 1:4]` are views; advanced indexing such as `x[indices]` produces a copy. Assignment through either form mutates the destination tensor.',
+  },
+
+  joining: {
+    title: 'Join and reshape tensors',
+    description: 'Change `dim` and predict the resulting shape before running the code.',
+    initialCode: `import torch
+
+a = torch.tensor([[1, 2], [3, 4]])
+b = torch.tensor([[5, 6], [7, 8]])
+
+cat_rows = torch.cat((a, b), dim=0)
+cat_columns = torch.cat((a, b), dim=1)
+stacked = torch.stack((a, b), dim=0)
+reshaped = a.reshape(1, 4)
+
+print("cat dim=0:", cat_rows.shape, "\\n", cat_rows)
+print("cat dim=1:", cat_columns.shape, "\\n", cat_columns)
+print("stack dim=0:", stacked.shape, "\\n", stacked)
+print("reshape:", reshaped.shape, "\\n", reshaped)
+`,
+    referenceCode: `import torch
+
+a = torch.tensor([[1, 2], [3, 4]])
+b = torch.tensor([[5, 6], [7, 8]])
+
+# cat joins along an existing dimension.
+cat_rows = torch.cat((a, b), dim=0)       # shape (4, 2)
+cat_columns = torch.cat((a, b), dim=1)    # shape (2, 4)
+
+# stack inserts a new dimension; inputs must have the same shape.
+stacked = torch.stack((a, b), dim=0)      # shape (2, 2, 2)
+
+# view shares data when the size/stride constraint is satisfied.
+flat_view = a.view(4)
+reshaped = a.reshape(1, 4)                # view or copy; do not rely on which
+
+print("cat rows:", cat_rows.shape)
+print("cat columns:", cat_columns.shape)
+print("stacked:", stacked.shape)
+print("flat view:", flat_view.shape)
+print("reshaped:", reshaped.shape)
+`,
+    notes:
+      '`cat` preserves rank and joins an existing dimension; `stack` increases rank by inserting a dimension. `reshape` is flexible, while `view` requires compatible strides.',
+  },
+
+  mutation: {
+    title: 'Mutate explicitly and protect autograd',
+    description: 'Run the example, then replace an in-place operation with an out-of-place one and compare the result.',
+    initialCode: `import torch
+
+x = torch.zeros((2, 3), dtype=torch.float32)
+
+with torch.no_grad():
+    x.add_(1.0)
+    x[0, 1] = 7.0
+    x[:, 2].fill_(4.0)
+
+y = x + 1.0
+print("x after mutation:\\n", x)
+print("y from out-of-place +:\\n", y)
+`,
+    referenceCode: `import torch
+
+x = torch.zeros((2, 3), dtype=torch.float32)
+
+with torch.no_grad():
+    x.add_(1.0)       # underscore marks an in-place operation
+    x[0, 1] = 7.0     # indexing assignment is also in-place
+    x[:, 2].fill_(4.0)
+
+y = x + 1.0           # out-of-place: x is unchanged by this line
+print("x after mutation:\\n", x)
+print("y from out-of-place +:\\n", y)
+`,
+    notes:
+      'In real training code, prefer out-of-place operations unless the memory saving is deliberate and autograd permits the mutation. Never use `.data` as a shortcut around autograd.',
+  },
+};

--- a/src/lib/torch-compat.ts
+++ b/src/lib/torch-compat.ts
@@ -21,11 +21,135 @@ _TORCH_COMPAT_INT_DTYPES = {
     _np.dtype(_np.uint8),
 }
 
+class _CompatStorage:
+    def __init__(self, tensor):
+        self.tensor = tensor
+
+    def data_ptr(self):
+        return _storage_data_ptr(self.tensor)
+
+class _CompatTensor(_np.ndarray):
+    def __new__(cls, value, dtype=None, copy=True):
+        if copy:
+            array = _np.array(value, dtype=dtype, copy=True)
+        else:
+            array = _np.asarray(value, dtype=dtype)
+        return array.view(cls)
+
+    def __array_finalize__(self, _source):
+        pass
+
+    @property
+    def device(self):
+        return 'cpu'
+
+    @property
+    def requires_grad(self):
+        return False
+
+    @property
+    def is_cuda(self):
+        return False
+
+    def numel(self):
+        return int(self.size)
+
+    def element_size(self):
+        return int(self.dtype.itemsize)
+
+    def stride(self):
+        return tuple(int(byte_stride // self.itemsize) for byte_stride in self.strides)
+
+    def is_contiguous(self):
+        return bool(self.flags['C_CONTIGUOUS'])
+
+    def contiguous(self):
+        return self if self.is_contiguous() else _tensor(self, copy=True)
+
+    def clone(self):
+        return _tensor(self, copy=True)
+
+    def detach(self):
+        return self
+
+    def requires_grad_(self, _requires_grad=True):
+        return self
+
+    def to(self, dtype=None, device=None, **_kwargs):
+        if dtype is None or _np.dtype(dtype) == self.dtype:
+            return self
+        return _tensor(self, dtype=dtype, copy=True)
+
+    def view(self, *shape):
+        return self.reshape(*shape)
+
+    def add_(self, value):
+        self[...] = _np.asarray(self) + value
+        return self
+
+    def sub_(self, value):
+        self[...] = _np.asarray(self) - value
+        return self
+
+    def mul_(self, value):
+        self[...] = _np.asarray(self) * value
+        return self
+
+    def div_(self, value):
+        self[...] = _np.asarray(self) / value
+        return self
+
+    def zero_(self):
+        self[...] = 0
+        return self
+
+    def fill_(self, value):
+        self[...] = value
+        return self
+
+    def copy_(self, source):
+        self[...] = _np.asarray(source, dtype=self.dtype)
+        return self
+
+    def data_ptr(self):
+        return int(self.__array_interface__['data'][0])
+
+    def storage_offset(self):
+        return int((self.data_ptr() - _storage_data_ptr(self)) // self.itemsize)
+
+    def untyped_storage(self):
+        return _CompatStorage(self)
+
+    def storage(self):
+        return self.untyped_storage()
+
+def _storage_root(value):
+    root = value
+    while isinstance(getattr(root, 'base', None), _np.ndarray):
+        root = root.base
+    return _np.asarray(root)
+
+def _storage_data_ptr(value):
+    return int(_storage_root(value).__array_interface__['data'][0])
+
+def _tensor(value, dtype=None, copy=True):
+    if isinstance(value, _CompatTensor) and dtype is None and not copy:
+        return value
+    return _CompatTensor(value, dtype=dtype, copy=copy)
+
+def _wrap(value):
+    if isinstance(value, _np.ndarray) and not isinstance(value, _CompatTensor):
+        return value.view(_CompatTensor)
+    return value
+
 def _asarray(value, dtype=None):
     return _np.asarray(value, dtype=dtype)
 
 def _shape(size):
     return (int(size),) if isinstance(size, (int, _np.integer)) else tuple(int(v) for v in size)
+
+def _shape_args(sizes):
+    return _shape(sizes[0]) if len(sizes) == 1 else tuple(int(v) for v in sizes)
 
 def _axis(dim):
     return dim
@@ -40,11 +164,11 @@ def _stable_softmax(value, dim=-1):
     maximum = _np.max(safe_value, axis=dim, keepdims=True)
     exponentiated = _np.exp(safe_value - maximum) * finite
     denominator = _np.sum(exponentiated, axis=dim, keepdims=True)
-    return _np.where(
+    return _wrap(_np.where(
         denominator > 0,
         exponentiated / _safe_denominator(denominator),
         _np.zeros_like(exponentiated),
-    )
+    ))
 
 def _log_softmax(value, dim=-1):
     value = _asarray(value, dtype=_np.float64)
@@ -53,7 +177,7 @@ def _log_softmax(value, dim=-1):
     maximum = _np.max(safe_value, axis=dim, keepdims=True)
     shifted = safe_value - maximum
     denominator = _np.sum(_np.exp(shifted) * finite, axis=dim, keepdims=True)
-    return shifted - _np.log(_safe_denominator(denominator))
+    return _wrap(shifted - _np.log(_safe_denominator(denominator)))
 
 def _sum(value, dim=None, keepdim=False):
     return _np.sum(value, axis=_axis(dim), keepdims=keepdim)
@@ -75,7 +199,7 @@ def _norm(value, p=2, dim=None, keepdim=False):
 def _arange(start, end=None, step=1, dtype=None, **_kwargs):
     if end is None:
         start, end = 0, start
-    return _np.arange(start, end, step, dtype=dtype)
+    return _wrap(_np.arange(start, end, step, dtype=dtype))
 
 def _flatten(value, start_dim=0, end_dim=-1):
     value = _np.asarray(value)
@@ -84,19 +208,19 @@ def _flatten(value, start_dim=0, end_dim=-1):
     prefix = value.shape[:start_dim]
     suffix = value.shape[end_dim + 1:]
     middle = int(_np.prod(value.shape[start_dim:end_dim + 1]))
-    return value.reshape(prefix + (middle,) + suffix)
+    return _wrap(value.reshape(prefix + (middle,) + suffix))
 
 def _gather(value, dim, index):
     value = _np.asarray(value)
     index = _np.asarray(index, dtype=_np.int64)
-    return _np.take_along_axis(value, index, axis=dim)
+    return _wrap(_np.take_along_axis(value, index, axis=dim))
 
 def _topk(value, k, dim=-1, largest=True, sorted=True):
     value = _np.asarray(value)
     order = _np.argsort(-value if largest else value, axis=dim, kind='stable')
     indices = _np.take(order, _np.arange(k), axis=dim)
     values = _np.take_along_axis(value, indices, axis=dim)
-    return _types.SimpleNamespace(values=values, indices=indices)
+    return _types.SimpleNamespace(values=_wrap(values), indices=_wrap(indices))
 
 def _cross_entropy(logits, targets, reduction='mean'):
     log_probs = _log_softmax(logits, dim=-1)
@@ -123,7 +247,7 @@ class _NullContext:
 
 torch = _types.ModuleType('torch')
 torch.__path__ = []
-torch.Tensor = _np.ndarray
+torch.Tensor = _CompatTensor
 torch.float16 = _np.float16
 torch.float32 = _np.float32
 torch.float64 = _np.float64
@@ -134,22 +258,24 @@ torch.int64 = _np.int64
 torch.long = _np.int64
 torch.uint8 = _np.uint8
 torch.bool = _np.bool_
-torch.as_tensor = _asarray
-torch.tensor = lambda value, dtype=None, **_kwargs: _np.array(value, dtype=dtype)
-torch.from_numpy = lambda value: _np.asarray(value)
-torch.clone = lambda value: _np.array(value, copy=True)
-torch.zeros = lambda size, dtype=_np.float32, **_kwargs: _np.zeros(_shape(size), dtype=dtype)
-torch.ones = lambda size, dtype=_np.float32, **_kwargs: _np.ones(_shape(size), dtype=dtype)
-torch.empty = lambda size, dtype=_np.float32, **_kwargs: _np.empty(_shape(size), dtype=dtype)
-torch.full = lambda size, fill_value, dtype=None, **_kwargs: _np.full(_shape(size), fill_value, dtype=dtype)
-torch.zeros_like = lambda value, **_kwargs: _np.zeros_like(value)
-torch.ones_like = lambda value, **_kwargs: _np.ones_like(value)
-torch.empty_like = lambda value, **_kwargs: _np.empty_like(value)
-torch.full_like = lambda value, fill_value, **_kwargs: _np.full_like(value, fill_value)
+torch.as_tensor = lambda value, dtype=None, **_kwargs: _tensor(value, dtype=dtype, copy=False)
+torch.tensor = lambda value, dtype=None, **_kwargs: _tensor(value, dtype=dtype, copy=True)
+torch.from_numpy = lambda value: _tensor(value, copy=False)
+torch.clone = lambda value: _tensor(value, copy=True)
+torch.zeros = lambda *size, dtype=_np.float32, **_kwargs: _tensor(_np.zeros(_shape_args(size), dtype=dtype), copy=False)
+torch.ones = lambda *size, dtype=_np.float32, **_kwargs: _tensor(_np.ones(_shape_args(size), dtype=dtype), copy=False)
+torch.empty = lambda *size, dtype=_np.float32, **_kwargs: _tensor(_np.empty(_shape_args(size), dtype=dtype), copy=False)
+torch.full = lambda size, fill_value, dtype=None, **_kwargs: _tensor(_np.full(_shape(size), fill_value, dtype=dtype), copy=False)
+torch.rand = lambda *size, dtype=_np.float32, **_kwargs: _tensor(_np.random.rand(*_shape_args(size)).astype(dtype), copy=False)
+torch.randn = lambda *size, dtype=_np.float32, **_kwargs: _tensor(_np.random.randn(*_shape_args(size)).astype(dtype), copy=False)
+torch.zeros_like = lambda value, **_kwargs: _tensor(_np.zeros_like(value), copy=False)
+torch.ones_like = lambda value, **_kwargs: _tensor(_np.ones_like(value), copy=False)
+torch.empty_like = lambda value, **_kwargs: _tensor(_np.empty_like(value), copy=False)
+torch.full_like = lambda value, fill_value, **_kwargs: _tensor(_np.full_like(value, fill_value), copy=False)
 torch.arange = _arange
-torch.tril = lambda value, diagonal=0: _np.tril(value, diagonal=diagonal)
-torch.eye = lambda n, m=None, dtype=_np.float32, **_kwargs: _np.eye(n, m if m is not None else n, dtype=dtype)
-torch.linspace = lambda start, end, steps, **_kwargs: _np.linspace(start, end, steps)
+torch.tril = lambda value, diagonal=0: _wrap(_np.tril(value, diagonal=diagonal))
+torch.eye = lambda n, m=None, dtype=_np.float32, **_kwargs: _tensor(_np.eye(n, m if m is not None else n, dtype=dtype), copy=False)
+torch.linspace = lambda start, end, steps, **_kwargs: _tensor(_np.linspace(start, end, steps), copy=False)
 torch.exp = _np.exp
 torch.log = _np.log
 torch.sin = _np.sin
@@ -169,17 +295,18 @@ torch.min = _amin
 torch.norm = _norm
 torch.argmax = lambda value, dim=None, keepdim=False: _np.argmax(value, axis=_axis(dim))
 torch.argmin = lambda value, dim=None, keepdim=False: _np.argmin(value, axis=_axis(dim))
-torch.matmul = _np.matmul
-torch.mm = _np.matmul
-torch.bmm = _np.matmul
-torch.transpose = lambda value, dim0, dim1: _np.swapaxes(value, dim0, dim1)
-torch.permute = lambda value, dims: _np.transpose(value, axes=tuple(dims))
-torch.reshape = _np.reshape
+torch.matmul = lambda left, right: _wrap(_np.matmul(left, right))
+torch.mm = torch.matmul
+torch.bmm = torch.matmul
+torch.transpose = lambda value, dim0, dim1: _wrap(_np.swapaxes(value, dim0, dim1))
+torch.permute = lambda value, dims: _wrap(_np.transpose(value, axes=tuple(dims)))
+torch.reshape = lambda value, shape: _wrap(_np.reshape(value, _shape(shape)))
 torch.flatten = _flatten
-torch.unsqueeze = lambda value, dim: _np.expand_dims(value, axis=dim)
-torch.squeeze = lambda value, dim=None: _np.squeeze(value, axis=dim)
-torch.cat = lambda values, dim=0: _np.concatenate(values, axis=dim)
-torch.stack = lambda values, dim=0: _np.stack(values, axis=dim)
+torch.unsqueeze = lambda value, dim: _wrap(_np.expand_dims(value, axis=dim))
+torch.squeeze = lambda value, dim=None: _wrap(_np.squeeze(value, axis=dim))
+torch.cat = lambda values, dim=0: _wrap(_np.concatenate(values, axis=dim))
+torch.concat = torch.cat
+torch.stack = lambda values, dim=0: _wrap(_np.stack(values, axis=dim))
 torch.where = _np.where
 torch.broadcast_to = _np.broadcast_to
 torch.isfinite = _np.isfinite
@@ -190,13 +317,28 @@ torch.unique = lambda value, sorted=True, **_kwargs: _np.unique(value)
 torch.argsort = lambda value, dim=-1, descending=False, stable=False: _np.argsort(-value if descending else value, axis=dim, kind='stable' if stable else None)
 torch.topk = _topk
 torch.gather = _gather
-torch.index_select = lambda value, dim, index: _np.take(value, _np.asarray(index, dtype=_np.int64), axis=dim)
+torch.index_select = lambda value, dim, index: _wrap(_np.take(value, _np.asarray(index, dtype=_np.int64), axis=dim))
+torch.numel = lambda value: int(_np.asarray(value).size)
+torch.equal = lambda left, right: bool(_np.array_equal(left, right))
 torch.softmax = _stable_softmax
 torch.log_softmax = _log_softmax
 torch.logsumexp = _logsumexp
 torch.manual_seed = lambda seed: _np.random.seed(seed)
 torch.no_grad = _NullContext
 torch.inference_mode = _NullContext
+
+class _Device(str):
+    def __new__(cls, value):
+        return str.__new__(cls, value)
+
+    def __repr__(self):
+        return "device(type='" + str(self) + "')"
+
+torch.device = _Device
+
+_cuda = _types.ModuleType('torch.cuda')
+_cuda.is_available = lambda: False
+torch.cuda = _cuda
 
 _nn = _types.ModuleType('torch.nn')
 _nn.__path__ = []
@@ -215,4 +357,5 @@ _sys.modules['torch'] = torch
 _sys.modules['torch.nn'] = _nn
 _sys.modules['torch.nn.functional'] = _functional
 _sys.modules['torch.linalg'] = _linalg
+_sys.modules['torch.cuda'] = _cuda
 `;

--- a/src/pages/revision_notes.astro
+++ b/src/pages/revision_notes.astro
@@ -6,10 +6,28 @@ import SectionHeader from '../components/SectionHeader.astro';
 <PostLayout title="Revision Notes" showSectionsNav={false}>
   <SectionHeader
     eyebrow="Revision Notes"
-    title="CS336: Language Modeling from Scratch"
-    description="Course notes, references, and implementation details from CS336."
-    meta="2 lessons"
+    title="PyTorch and CS336"
+    description="Course notes, references, and implementation details for PyTorch and language modeling."
+    meta="3 notes"
   />
+
+  <section class="resource-list">
+    <div class="resource-list__header">
+      <h2>PyTorch</h2>
+      <a href="https://docs.pytorch.org/docs/2.13/tensors.html">Documentation</a>
+    </div>
+    <ul>
+      <li>
+        <div>
+          <strong>Tensor fundamentals</strong>
+          <p>Construction, factories, metadata, views, indexing, joining, reshaping, and mutation.</p>
+        </div>
+        <span>
+          <a href="/revision notes/2026/08/09/pytorch-tensor-revision-notes.html">My notes</a>
+        </span>
+      </li>
+    </ul>
+  </section>
 
   <section class="resource-list">
     <div class="resource-list__header">


### PR DESCRIPTION
Adds a source-linked PyTorch tensor revision note with construction, factory ops, storage and scalar semantics, indexing, slicing, joining, reshaping, mutation, and rapid recall. Each example pairs a collapsed real-PyTorch reference block with an editable Pyodide runner; the browser compatibility layer now supports the required tensor metadata and in-place idioms.\n\nTests: npm run ci\nBrowser QA: six examples run without stderr; reference blocks start closed; desktop side-by-side and 390px responsive layouts checked.