### PR TITLE
Expand PyTorch revision notes

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -5043,58 +5043,228 @@ html {
 
 .revision-code-pair {
   display: grid;
-  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+  grid-template-columns: minmax(0, 1fr);
   align-items: start;
-  gap: 1rem;
-  margin: 2rem 0;
+  gap: 0.8rem;
+  margin: 1.35rem 0 1.75rem;
 }
 
-.revision-code-pair__reference,
 .revision-code-pair__runner {
   min-width: 0;
-}
-
-.revision-code-pair__reference {
-  overflow: hidden;
-  border: 1px solid var(--code-border-color);
-  border-radius: 18px;
-  background: var(--panel-bg);
-}
-
-.revision-code-pair__reference > summary {
-  padding: 1rem 1.1rem;
-  color: var(--text-color);
-  font-family: var(--font-mono);
-  font-size: 0.84rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-
-.revision-code-pair__reference > summary:focus-visible {
-  outline: 2px solid var(--accent-color);
-  outline-offset: -2px;
-}
-
-.revision-code-pair__reference[open] > summary {
-  border-bottom: 1px solid var(--code-border-color);
-}
-
-.revision-code-pair__reference pre {
-  max-height: 34rem;
-  margin: 0;
-  overflow: auto;
-  padding: 1rem 1.1rem;
-  background: var(--code-block-bg-dark, var(--background-secondary));
-}
-
-.revision-code-pair__reference code {
-  white-space: pre;
 }
 
 .revision-code-pair__runner .python-playground {
   height: 100%;
   box-sizing: border-box;
   margin: 0;
+}
+
+/* Revision notes use the same compact, code-first workspace as Code practice. */
+.python-playground--compact {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  min-width: 0;
+  height: auto;
+  min-height: 23rem;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--code-border-color);
+  border-radius: 12px;
+  background: var(--panel-bg);
+  box-shadow: none;
+  color: var(--text-color);
+}
+
+:root[data-theme="dark"] .python-playground--compact {
+  border-color: var(--code-border-color);
+  background: var(--panel-bg);
+  box-shadow: none;
+  color: var(--text-color);
+}
+
+.python-playground__workspace-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  min-width: 0;
+  padding: 0.48rem 0.55rem 0.48rem 0.72rem;
+  border-bottom: 1px solid var(--code-border-color);
+}
+
+.python-playground__workspace-identity,
+.python-playground__workspace-controls {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.python-playground__workspace-controls {
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 0.35rem;
+}
+
+.python-playground__workspace-title,
+.python-playground--compact .python-playground__status {
+  margin: 0;
+  font-family: var(--font-mono);
+}
+
+.python-playground__workspace-title {
+  overflow: hidden;
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.python-playground--compact .python-playground__status {
+  color: var(--text-secondary-color);
+  font-size: 0.66rem;
+  white-space: nowrap;
+}
+
+.python-playground--compact .python-playground__status--ready {
+  color: #168d67;
+}
+
+:root[data-theme="dark"] .python-playground--compact .python-playground__status--ready {
+  color: #78dcb2;
+}
+
+.python-playground--compact .python-playground__status--error {
+  color: #c44444;
+}
+
+.python-playground__button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 1.9rem;
+  padding: 0.32rem 0.48rem;
+  border: 1px solid var(--button-border);
+  border-radius: 7px;
+  background: var(--button-bg);
+  box-shadow: none;
+  color: var(--text-color);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.python-playground__button:hover:not(:disabled) {
+  border-color: var(--accent-color);
+}
+
+.python-playground__button:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.python-playground__button--primary {
+  border-color: rgba(22, 141, 103, 0.5);
+  background: #168d67;
+  color: #f4fffb;
+}
+
+:root[data-theme="dark"] .python-playground__button--primary {
+  border-color: rgba(122, 240, 182, 0.5);
+  background: #147454;
+  color: #f4fffb;
+}
+
+.python-playground__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.46;
+}
+
+.python-playground__button kbd {
+  padding: 0.08rem 0.2rem;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.12);
+  color: inherit;
+  font-family: inherit;
+  font-size: 0.55rem;
+  white-space: nowrap;
+}
+
+.python-playground--compact .python-playground__editor-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.python-playground__editor-shell {
+  min-width: 0;
+  height: clamp(21rem, 38vw, 29rem);
+  overflow: hidden;
+}
+
+.python-playground__code-editor,
+.python-playground__code-editor .cm-editor,
+.python-playground__code-editor .cm-scroller {
+  height: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.python-playground__code-editor {
+  font-size: 0.74rem;
+}
+
+.python-playground__code-editor .cm-scroller {
+  overflow: auto;
+  line-height: 1.42;
+}
+
+.python-playground__code-editor .cm-content,
+.python-playground__code-editor .cm-gutter {
+  padding-top: 0.52rem;
+  padding-bottom: 0.52rem;
+}
+
+.python-playground__code-editor .cm-gutters {
+  border-right: 1px solid var(--code-border-color);
+}
+
+.python-playground__compact-output {
+  min-width: 0;
+  padding: 0.45rem 0.65rem;
+  border-top: 1px solid var(--code-border-color);
+  background: var(--background-secondary);
+}
+
+.python-playground__compact-output p,
+.python-playground__compact-output pre {
+  margin: 0;
+  font-family: var(--font-mono);
+}
+
+.python-playground__compact-output p {
+  margin-bottom: 0.25rem;
+  color: var(--text-secondary-color);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.python-playground__compact-output pre {
+  max-height: 8rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.72rem;
+  line-height: 1.38;
 }
 
 .code-practice-lab {
@@ -5676,6 +5846,20 @@ html {
 
   .revision-code-pair {
     grid-template-columns: 1fr;
+  }
+
+  .python-playground__workspace-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .python-playground__workspace-controls {
+    width: 100%;
+  }
+
+  .python-playground__editor-shell {
+    height: min(27rem, 58vh);
+    min-height: 19rem;
   }
 
   .code-practice-lab__hero-header,

--- a/src/components/PythonPlayground.tsx
+++ b/src/components/PythonPlayground.tsx
@@ -1,4 +1,21 @@
-import React, { startTransition, useEffect, useRef, useState } from 'react';
+import React, {
+  startTransition,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Prec } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
+import CodeMirror from '@uiw/react-codemirror';
+import { githubDark, githubLight } from '@uiw/codemirror-theme-github';
+import {
+  codeEditorExtensions,
+  createCodeEditorThemeObserver,
+  createRunCodeKeyBindings,
+  getCodeEditorThemeName,
+} from '../lib/code-editor';
 import { loadPyodideRuntime } from '../lib/pyodide-loader';
 import type { PyodideRuntime } from '../lib/pyodide-loader';
 import type { PythonPlaygroundProps } from '../lib/python-playground';
@@ -18,28 +35,67 @@ export default function PythonPlayground({
   samples,
   walkthroughSteps = [],
   notes,
+  compact = false,
 }: PythonPlaygroundProps) {
   const containerRef = useRef<HTMLElement | null>(null);
   const runtimeRef = useRef<PyodideRuntime | null>(null);
+  const loadingRef = useRef(false);
+  const isRunningRef = useRef(false);
+  const runHandlerRef = useRef<() => void>(() => {});
+  const generatedEditorId = useId();
+  const editorId = `${createHeadingId(title)}-${generatedEditorId.replace(/:/g, '')}`;
   const [code, setCode] = useState(initialCode);
   const [output, setOutput] = useState('');
   const [errorOutput, setErrorOutput] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
-  const [statusMessage, setStatusMessage] = useState('Python runtime will load when this block scrolls into view.');
+  const [statusMessage, setStatusMessage] = useState(
+    compact ? 'Loading Python…' : 'Python runtime will load when this block scrolls into view.',
+  );
   const [isRunning, setIsRunning] = useState(false);
+  const [hasRun, setHasRun] = useState(false);
   const [selectedSample, setSelectedSample] = useState(0);
   const [activeStep, setActiveStep] = useState(0);
+  const [editorTheme, setEditorTheme] = useState(() =>
+    getCodeEditorThemeName(
+      typeof document === 'undefined' ? 'light' : document.documentElement.getAttribute('data-theme'),
+    ),
+  );
+
+  const runShortcutExtension = useMemo(
+    () =>
+      Prec.highest([
+        keymap.of(createRunCodeKeyBindings(() => runHandlerRef.current())),
+        EditorView.domEventHandlers({
+          keydown(event) {
+            if (event.key !== 'Enter' || (!event.ctrlKey && !event.metaKey)) {
+              return false;
+            }
+
+            event.preventDefault();
+            runHandlerRef.current();
+            return true;
+          },
+        }),
+      ]),
+    [],
+  );
+  const editorExtensions = useMemo(
+    () => [...codeEditorExtensions, runShortcutExtension],
+    [runShortcutExtension],
+  );
+  const editorThemeExtension = editorTheme === 'dark' ? githubDark : githubLight;
 
   useEffect(() => {
     let didCancel = false;
 
     async function bootstrapRuntime() {
-      if (runtimeRef.current || status === 'loading') {
+      if (runtimeRef.current || loadingRef.current) {
         return;
       }
 
+      loadingRef.current = true;
       setStatus('loading');
-      setStatusMessage('Preparing the in-browser Python runtime...');
+      setStatusMessage(compact ? 'Loading Python…' : 'Preparing the in-browser Python runtime...');
 
       try {
         const runtime = await loadPyodideRuntime();
@@ -48,15 +104,16 @@ export default function PythonPlayground({
         }
         runtimeRef.current = runtime;
         setStatus('ready');
-        setStatusMessage('Python is ready. Edit the code and run it.');
+        setStatusMessage(compact ? 'Ready' : 'Python is ready. Edit the code and run it.');
       } catch (error) {
         if (didCancel) {
           return;
         }
         setStatus('error');
-        setStatusMessage(
-          error instanceof Error ? error.message : 'The Python runtime failed to load.',
-        );
+        setStatusMessage(compact ? 'Unavailable' : 'The Python runtime failed to load.');
+        setErrorOutput(error instanceof Error ? error.message : 'The Python runtime failed to load.');
+      } finally {
+        loadingRef.current = false;
       }
     }
 
@@ -97,17 +154,33 @@ export default function PythonPlayground({
       didCancel = true;
       observer.disconnect();
     };
+  }, [compact]);
+
+  useEffect(() => {
+    setEditorTheme(
+      getCodeEditorThemeName(
+        typeof document === 'undefined' ? 'light' : document.documentElement.getAttribute('data-theme'),
+      ),
+    );
+
+    return createCodeEditorThemeObserver(setEditorTheme);
   }, []);
 
   const currentStep = walkthroughSteps[activeStep];
 
   async function handleRun() {
-    if (!runtimeRef.current) {
-      setStatusMessage('Python is still loading. Try again in a moment.');
+    if (isRunningRef.current) {
       return;
     }
 
+    if (!runtimeRef.current) {
+      setStatusMessage(status === 'error' ? 'Unavailable' : 'Loading Python…');
+      return;
+    }
+
+    isRunningRef.current = true;
     setIsRunning(true);
+    setHasRun(true);
     setOutput('');
     setErrorOutput('');
 
@@ -120,6 +193,7 @@ export default function PythonPlayground({
     } catch (error) {
       setErrorOutput(error instanceof Error ? error.message : 'Unknown execution error.');
     } finally {
+      isRunningRef.current = false;
       setIsRunning(false);
     }
   }
@@ -128,6 +202,7 @@ export default function PythonPlayground({
     setCode(initialCode);
     setOutput('');
     setErrorOutput('');
+    setHasRun(false);
     setSelectedSample(0);
     setActiveStep(0);
   }
@@ -137,7 +212,80 @@ export default function PythonPlayground({
     setCode(samples[index]?.code ?? initialCode);
     setOutput('');
     setErrorOutput('');
+    setHasRun(false);
     setActiveStep(0);
+  }
+
+  runHandlerRef.current = () => {
+    void handleRun();
+  };
+
+  if (compact) {
+    return (
+      <section
+        className="python-playground python-playground--compact"
+        ref={containerRef}
+        aria-label={`${title} editable Python scratchpad`}
+      >
+        <header className="python-playground__workspace-header">
+          <div className="python-playground__workspace-identity">
+            <p className="python-playground__workspace-title">{title}</p>
+            <p
+              className={`python-playground__status python-playground__status--${status}`}
+              aria-live="polite"
+            >
+              {statusMessage}
+            </p>
+          </div>
+          <div className="python-playground__workspace-controls">
+            <button
+              className="python-playground__button python-playground__button--primary"
+              type="button"
+              aria-label="Run code"
+              aria-keyshortcuts="Control+Enter Meta+Enter"
+              onClick={() => void handleRun()}
+              disabled={status !== 'ready' || isRunning}
+            >
+              <span>{isRunning ? 'Running…' : 'Run'}</span>
+              {!isRunning && <kbd>Ctrl / Cmd + Enter</kbd>}
+            </button>
+            <button
+              className="python-playground__button"
+              type="button"
+              onClick={handleReset}
+            >
+              Reset
+            </button>
+          </div>
+        </header>
+
+        <label className="python-playground__editor-label" htmlFor={editorId}>
+          {title} Python editor
+        </label>
+        <div className="python-playground__editor-shell">
+          <CodeMirror
+            id={editorId}
+            className="python-playground__code-editor"
+            aria-label={`${title} Python editor`}
+            basicSetup={false}
+            extensions={editorExtensions}
+            theme={editorThemeExtension}
+            height="100%"
+            editable
+            indentWithTab={false}
+            value={code}
+            onChange={(value) => setCode(value)}
+          />
+        </div>
+
+        {hasRun && (
+          <div className="python-playground__compact-output" aria-live="polite">
+            <p>{errorOutput ? 'Errors' : 'Output'}</p>
+            <pre>{errorOutput || output || 'Program finished with no output.'}</pre>
+          </div>
+        )}
+      </section>
+    );
   }
 
   return (
@@ -182,11 +330,11 @@ export default function PythonPlayground({
           <span className="python-playground__prompt">python lesson.py</span>
         </div>
 
-        <label className="python-playground__editor-label" htmlFor={title}>
+        <label className="python-playground__editor-label" htmlFor={editorId}>
           Editable Python snippet
         </label>
         <textarea
-          id={title}
+          id={editorId}
           className="python-playground__editor"
           spellCheck={false}
           value={code}

--- a/src/components/RevisionCodePair.astro
+++ b/src/components/RevisionCodePair.astro
@@ -4,12 +4,11 @@ import PythonPlayground from './PythonPlayground';
 interface Props {
   title: string;
   initialCode: string;
-  referenceCode: string;
   description?: string;
   notes?: string;
 }
 
-const { title, initialCode, referenceCode, description, notes } = Astro.props;
+const { title, initialCode, description, notes } = Astro.props;
 const samples = [
   {
     label: 'Starting example',
@@ -20,11 +19,6 @@ const samples = [
 ---
 
 <section class="revision-code-pair" aria-label={`${title} code example`}>
-  <details class="revision-code-pair__reference">
-    <summary>Reference code</summary>
-    <pre><code>{referenceCode}</code></pre>
-  </details>
-
   <div class="revision-code-pair__runner">
     <PythonPlayground
       client:visible
@@ -32,6 +26,7 @@ const samples = [
       initialCode={initialCode}
       samples={samples}
       notes={notes}
+      compact
     />
   </div>
 </section>

--- a/src/content/posts/pytorch-tensor-revision-notes.mdx
+++ b/src/content/posts/pytorch-tensor-revision-notes.mdx
@@ -1,107 +1,403 @@
 ---
-title: PyTorch Tensor Revision Notes
+title: PyTorch Revision Notes
 date: '2026-08-09T04:00:00.000Z'
 section: revision-notes
 postSlug: pytorch-tensor-revision-notes
 legacyPath: /revision notes/2026/08/09/pytorch-tensor-revision-notes.html
 tags:
   - PyTorch
-summary: A source-linked reference for constructing, inspecting, indexing, joining, reshaping, and mutating PyTorch tensors.
+summary: A dense PyTorch 2.13 reference spanning tensors, autograd, modules, data loading, training, compilation, accelerators, distributed execution, and debugging.
 ---
 import RevisionCodePair from '../../components/RevisionCodePair.astro';
-import { pytorchTensorExamples } from '../../lib/pytorch-revision-examples';
+import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
 
-# PyTorch Tensor Revision Notes
+# PyTorch Revision Notes
 
 ## Quick overview
 
-According to the [PyTorch 2.13 tensor documentation](https://docs.pytorch.org/docs/2.13/tensors.html), a `torch.Tensor` is a multi-dimensional matrix whose elements have one data type. The useful refinement is that a regular tensor is also a strided view over storage: its shape, dtype, strides, storage offset, and device determine how an index maps to the backing buffer; `torch.tensor(data, dtype=..., device=...)` constructs a new tensor by copying `data`.
+According to the [PyTorch 2.13 tensor documentation](https://docs.pytorch.org/docs/2.13/tensors.html), a `torch.Tensor` is a multi-dimensional matrix whose elements have one data type. The more useful systems definition is a logical n-dimensional array described by dtype, device, layout, shape, strides, and storage offset; for the common strided layout, that metadata maps each logical index to a backing storage allocation.
 
-This note builds the mental model needed to predict tensor shapes, values, aliasing, and mutation. It covers construction, factory functions, metadata, scalar extraction, indexing, slicing, joining, reshaping, and in-place operations.
+PyTorch builds the rest of its programming model around that object. Autograd records tensor operations into a dynamic reverse-mode graph; `nn.Module` registers parameters, buffers, and child modules into a state tree; `Dataset` and `DataLoader` construct batches; optimizers consume accumulated parameter gradients; and compiler or distributed layers change execution without changing the mathematical model.
 
-The interactive panel is on the right of each example. It runs through Pyodide with a small NumPy-backed compatibility layer because the compiled PyTorch runtime is not shipped to the browser. The panel supports the tensor idioms used here, but it is not full PyTorch: there is no CUDA execution, autograd engine, or `nn.Module` implementation. The collapsed block on the left is the actual PyTorch reference code.
+This page targets PyTorch 2.13. Each exercise is a compact editable workspace. The browser runtime uses a NumPy-backed subset for tensor algebra, registration, state, and data-loading probes; it does not emulate autograd, accelerator kernels, `torch.compile`, or distributed collectives, whose real runtime behavior is specified in the surrounding API notes.
 
-## 1. Constructing tensors
+## Tensor construction and interoperability
 
-`torch.tensor(data)` accepts a scalar, list, nested sequence, NumPy array, or another tensor. It always copies the input data and creates a tensor with no autograd history by default. That copy is a semantic boundary: later changes to a NumPy source array or input tensor do not change the result.
+`torch.tensor(data, dtype=..., device=...)` always copies `data` and creates a fresh leaf with no autograd history by default. Use `torch.as_tensor` when preserving an existing tensor or avoiding a copy is acceptable, `torch.from_numpy` for shared CPU storage with a NumPy array, `torch.frombuffer` for a Python buffer, and DLPack for zero-copy exchange with another framework that implements the protocol. Sharing is a correctness decision: mutation through either object can affect the other.
 
-When avoiding a copy is intentional, use the API that says so. `torch.as_tensor(data)` preserves existing tensor history and avoids copies where possible; `torch.from_numpy(array)` creates a CPU tensor sharing storage with a NumPy array. A shared tensor is useful for interoperability, but it also means that a write through either object can change the other.
+Factory functions communicate intent and placement better than constructing on CPU and converting later. The `*_like` family inherits shape and normally dtype, layout, and device; pass overrides explicitly when those properties should differ. `torch.empty` leaves values uninitialized, so reading before every element is overwritten is a correctness bug, not merely noisy output.
 
-`dtype` controls how each element is represented, while `device` controls where the storage lives, usually `cpu`, `cuda`, or `mps`. Pass them to the constructor or a factory function instead of constructing first and silently relying on later conversions. Tensors do not generally move between devices automatically, so model parameters and inputs must be placed deliberately.
+<RevisionCodePair {...pytorchRevisionExamples.construction} />
 
-<RevisionCodePair {...pytorchTensorExamples.construction} />
+<RevisionCodePair {...pytorchRevisionExamples.factories} />
 
-The example uses `device="cpu"` so it remains executable in the browser. In a real program, a common explicit choice is `device = torch.device("cuda" if torch.cuda.is_available() else "cpu")`, followed by `torch.zeros((2, 3), dtype=torch.float32, device=device)`.
+The first NumPy contrast is easy to miss: NumPy normally infers `float64` for floating arrays, while PyTorch's default floating dtype is normally `float32`. NumPy arrays are CPU objects; a tensor also carries a device and may represent accelerator-resident memory. A conversion that looks numerically trivial can therefore allocate, copy, synchronize, or change gradient history.
 
-## 2. Creation ops: zeros, ones, and random values
+| Intent | PyTorch | NumPy | Distinction |
+| --- | --- | --- | --- |
+| Copy input | `torch.tensor(x)` | `np.array(x, copy=True)` | PyTorch result is a fresh leaf by default. |
+| Reuse input when possible | `torch.as_tensor(x)` / `torch.asarray(x)` | `np.asarray(x)` | Check dtype, device, writability, and sharing. |
+| Share NumPy CPU storage | `torch.from_numpy(a)` | already an `ndarray` | Mutations can cross the boundary. |
+| Allocate by shape | `zeros`, `ones`, `full`, `empty` | same names | PyTorch accepts `device` and tracks layout. |
+| Range | `arange`, `linspace`, `logspace` | same names | Prefer `linspace` when count matters for floating steps. |
+| Random source | `Generator` plus factory `generator=` | `np.random.Generator` | A generator isolates RNG state from global calls. |
 
-Factory functions express the intended initialization directly. `zeros` and `ones` create constant tensors; `full` chooses another fill value; `rand` samples uniformly from $[0, 1)$; and `randn` samples from a standard normal distribution. `arange` is useful for integer-like sequences, while `linspace` chooses a fixed number of evenly spaced points. `empty` allocates the requested shape without initializing the elements, so it is only safe when every position will be overwritten before it is read.
+### Tensor metadata and conversions
 
-The `*_like` family copies shape, dtype, and usually device from an existing tensor: `zeros_like(x)`, `ones_like(x)`, and `empty_like(x)` are often clearer than repeating metadata manually. Random factories consume a pseudorandom generator; call `torch.manual_seed` when a reproducible debugging example matters, and remember that reproducibility across devices and releases has additional constraints.
+The properties to inspect first are `shape`, `ndim`, `dtype`, `device`, `layout`, `requires_grad`, and `is_leaf`. `numel()` counts logical elements and `element_size()` reports bytes per element; their product estimates the logical payload but not allocator reservation, sparse indices, alignment, or storage retained by another view.
 
-<RevisionCodePair {...pytorchTensorExamples.creationOps} />
+`tensor.to(device=..., dtype=..., non_blocking=..., copy=...)` is the general conversion API. It returns the original tensor when nothing changes unless `copy=True`, so code must not assume a fresh allocation. Convenience methods such as `cpu()`, `cuda()`, `float()`, `half()`, and `bfloat16()` are narrower spellings. For modules, `module.to(...)` recursively mutates parameters and buffers in place and returns the module.
 
-The important prediction is the shape before the values. A call such as `torch.rand((2, 3))` creates six independent logical elements, whereas `torch.rand(2, 3, 1)` creates a rank-three tensor with shape `(2, 3, 1)`.
+`item()` converts exactly one tensor element to a Python scalar; it does not expose storage. `tolist()` recursively converts values to Python objects. `numpy()` is a CPU interoperability boundary and may share storage; the safe diagnostic idiom for a gradient-tracked accelerator tensor is `x.detach().cpu().numpy()`. Both `item()` and a device-to-host conversion can force accelerator synchronization, so keep them out of hot inner loops.
 
-## 3. A tensor is metadata plus a view over storage
+## Shapes, strides, storage, and aliasing
 
-A dense PyTorch tensor is not a nested Python list. Its storage is a contiguous one-dimensional buffer of bytes; tensor metadata gives the dtype, shape, stride, and storage offset needed to interpret that buffer. Multiple tensors can therefore refer to the same storage while exposing different shapes or index-to-memory mappings. This is why a slice or transpose can be cheap, and also why a write through a view can modify the original tensor.
+A strided tensor is metadata over storage. For index $(i_0, \ldots, i_{n-1})$, the logical storage position is
 
-The scalar boundary needs a precise description. `x.item()` does not “get the underlying storage”; it converts a tensor containing exactly one element into a standard Python number and is not differentiable. Use `x.tolist()` for a small tensor of Python values, `x.numpy()` for CPU interoperability when the storage permits it, and `x.detach().cpu().numpy()` when the tensor may require gradients or live on an accelerator. Use `untyped_storage().data_ptr()` when the question is whether two tensors share storage, not when the question is what values they contain.
+$$
+\text{storage\_offset} + \sum_{k=0}^{n-1} i_k\,\text{stride}_k.
+$$
 
-<RevisionCodePair {...pytorchTensorExamples.inspectStorage} />
+That equation explains cheap slices, transposes, broadcasts, and many reshapes: they can change metadata without moving values. It also explains non-contiguity and aliasing. Two tensors can have different shapes and strides while sharing the same storage and version counter.
 
-The view in the example has a different shape and stride but the same storage identity as `base`. For dense tensors, the logical byte count is commonly reasoned about as `numel() * element_size()`, while a view can cover only part of a larger storage. `stride()` tells you how many storage elements the next index in each dimension skips; it is the bridge between an abstract shape and memory traffic.
+<RevisionCodePair {...pytorchRevisionExamples.views} />
 
-## 4. Indexing and slicing
+`view` requires a shape compatible with current size and stride. `reshape` returns a view when possible and copies otherwise, so code must not depend on its aliasing behavior. `transpose`, `permute`, `movedim`, `narrow`, `select`, `squeeze`, and `unsqueeze` generally produce views. `contiguous(memory_format=...)` materializes the requested layout only when needed; `clone` always copies values while preserving gradient connectivity, and `detach` breaks gradient history but still shares storage.
 
-Tensor indexing follows Python and NumPy conventions: indices start at zero, negative indices count from the end, `:` selects a range, and a step such as `::2` skips elements. For a tensor `x` with shape `(B, T, D)`, `x[b]` removes the first dimension, `x[:, t]` selects one position for every batch item, and `x[..., -1]` selects the last feature without spelling out the leading dimensions.
+Memory format is a separate optimization axis from shape. Dense NCHW tensors normally use `torch.contiguous_format`; convolution workloads may benefit from `torch.channels_last` or `channels_last_3d` when the operators and hardware support them. Inspect with `is_contiguous(memory_format=...)` and convert deliberately with `to(memory_format=...)`.
 
-Basic indexing and slicing generally return views. Advanced indexing—integer index tensors, lists of indices, or boolean masks—returns a new tensor containing the selected values. Assignment through either basic or advanced indexing is still an in-place write to the destination. The distinction matters when you mutate the result and expect the source to change.
-
-<RevisionCodePair {...pytorchTensorExamples.indexing} />
-
-When debugging a shape error, print the shape after every indexing step rather than reasoning only from the source shape. Indexing with an integer removes a dimension; slicing preserves it; inserting `None` or calling `unsqueeze` adds a dimension of size one.
-
-## 5. Joining, stacking, and reshaping
-
-`torch.cat` joins tensors along an existing dimension. All non-concatenated dimensions must match, so concatenating two `(B, T, D)` tensors along `T` produces `(B, T_1 + T_2, D)`. `torch.stack` requires every input to have the same shape and inserts a new dimension, so stacking two `(B, T, D)` tensors along dimension zero produces `(2, B, T, D)`.
-
-This is the fastest shape check: ask whether the operation should preserve rank. If yes, start with `cat`; if the operation represents a new batch, time, ensemble, or sample axis, start with `stack`. `split` and `chunk` are the corresponding ways to divide a tensor along an existing dimension.
-
-`view` changes shape without copying when the requested shape is compatible with the current strides. `reshape` is more permissive: it returns a view when possible and makes a copy otherwise, so code should not depend on aliasing through `reshape`. `transpose` and `permute` rearrange dimensions and commonly create non-contiguous views; call `contiguous()` when a downstream operation requires contiguous storage.
-
-<RevisionCodePair {...pytorchTensorExamples.joining} />
-
-The output shapes are determined by the operation, not by the values. Predict them first, then use `.shape` to confirm the prediction. This habit catches most errors in batched linear algebra before the numerical result becomes distracting.
-
-## 6. Mutating operations and autograd
-
-Most tensor expressions are out-of-place: `y = x + 1` allocates a result and leaves `x` unchanged. Methods ending in an underscore—`add_`, `zero_`, `fill_`, `copy_`, and many others—mutate their receiver and return it. Indexing assignment such as `x[:, 0] = 0` is also in-place, even though the syntax does not end in an underscore.
-
-In-place updates can save memory, but they can also invalidate values that autograd saved for backward. Mutating a leaf tensor that requires gradients is often prohibited; when an intentional parameter or buffer update is needed outside the gradient calculation, use `with torch.no_grad():`. Prefer out-of-place expressions in ordinary `forward` code unless the memory and autograd consequences are understood. `.data` is not a safe substitute for `no_grad`.
-
-<RevisionCodePair {...pytorchTensorExamples.mutation} />
-
-The interview-level distinction is simple: the absence of an underscore does not prove that an operation is pure—index assignment is the counterexample—while the presence of an underscore is an explicit request to mutate existing storage.
-
-## 7. Rapid recall
-
-| Question | Short answer | Common trap |
+| Operation | Usually aliases input? | Key consequence |
 | --- | --- | --- |
-| What is a tensor? | A typed, strided multi-dimensional view over storage on a device. | Treating it as a Python list with nested shape semantics. |
-| Does `torch.tensor(x)` share `x`? | No; it copies `x` and creates a fresh leaf by default. | Using it when `as_tensor` or `from_numpy` was intended. |
-| What does `item()` do? | Converts a one-element tensor to a Python scalar. | Calling it on a tensor with many elements or confusing it with storage access. |
-| `cat` or `stack`? | `cat` joins an existing dimension; `stack` inserts a new one. | Forgetting that `stack` requires equal input shapes. |
-| `view` or `reshape`? | `view` requires compatible strides; `reshape` may copy. | Assuming every reshape aliases the input. |
-| What does `_` mean? | The operation mutates the receiver in-place. | Breaking autograd by mutating a saved or gradient-tracked tensor. |
-| How do devices interact? | Move explicitly with `.to(device)` and keep participating tensors compatible. | Assuming PyTorch will move ordinary tensors automatically. |
+| Basic slice, `select`, `transpose`, `permute` | Yes | Mutation can reach the base tensor. |
+| Advanced integer or boolean indexing | No | Selected values are copied. |
+| `view` | Yes or errors | Requires compatible strides. |
+| `reshape` | Maybe | Never rely on sharing. |
+| `expand` | Yes, often zero strides | Do not write assuming independent elements. |
+| `repeat` | No | Values are physically repeated. |
+| `detach` | Yes | No autograd edge, but storage is shared. |
+| `clone` | No | New storage; gradient still flows through the clone op. |
+
+## Indexing, selection, and mutation
+
+Basic indexing follows Python semantics: integer indexing removes a dimension, slicing preserves it, `None` inserts a singleton dimension, `...` fills unspecified dimensions, and negative indices count from the end. Advanced indexing uses integer tensors, lists, or boolean masks and returns copied values. Assignment through either syntax mutates the destination, even though the syntax has no trailing underscore.
+
+`gather` and `scatter` are dimension-explicit indexed data movement; `index_select` selects one dimension; `take_along_dim` follows an index tensor shaped for broadcasting; `masked_select` flattens selected values; `where` chooses elementwise without mutating; and `index_put_` generalizes indexed assignment. Predict the index tensor's required rank and the output shape before thinking about values.
+
+<RevisionCodePair {...pytorchRevisionExamples.indexing} />
+
+Methods ending in `_` mutate their receiver: `add_`, `mul_`, `copy_`, `zero_`, `fill_`, `scatter_`, and initialization functions are common examples. The `out=` argument also writes to supplied storage. In-place operations interact with aliases and autograd's version counters, so prefer out-of-place expressions in `forward` unless memory pressure justifies the extra reasoning.
+
+## Shape transforms and broadcasting
+
+PyTorch and NumPy broadcast from trailing dimensions. Two dimensions are compatible when they are equal or either is one; missing leading dimensions behave as ones. `torch.broadcast_shapes` checks the resulting shape without allocating, `broadcast_tensors` returns broadcast views, and `expand` exposes a larger logical shape through zero strides. Broadcasting avoids copies but can still create expensive downstream computation.
+
+<RevisionCodePair {...pytorchRevisionExamples.shapes} />
+
+`cat` concatenates along an existing dimension and preserves rank; all other dimensions must match. `stack` inserts a new dimension and requires equal input shapes. `split` partitions by size or explicit sections, `chunk` requests a number of chunks but can return fewer, and `unbind` removes a dimension into a tuple of views.
+
+For model code, shape contracts should be visible. Prefer names such as `batch, tokens, channels, height, width`, annotate arguments with `torch.Tensor`, and assert invariants at subsystem boundaries. Shape-aware libraries such as jaxtyping are useful only when they are an intentional dependency; ordinary runtime checks remain executable everywhere.
+
+## Elementwise operations, reductions, and linear algebra
+
+Unary and binary operations dispatch by dtype, device, and layout. Type promotion determines the result dtype, but Python scalars, zero-dimensional tensors, and in-place operations have special rules. In-place operations cannot cast a result into an incompatible receiver dtype, while an out-of-place expression may promote. Inspect `torch.result_type` or `torch.promote_types` when mixed precision is not obvious.
+
+<RevisionCodePair {...pytorchRevisionExamples.linalg} />
+
+`matmul` implements rank-dependent matrix multiplication: vector dot product, matrix-vector, matrix-matrix, or batched broadcasted matrix multiply. `mm` is strictly 2-D and `bmm` strictly 3-D without batch broadcasting. `einsum` makes contraction axes explicit and is excellent for specification, but the clearest expression is not automatically the fastest kernel; benchmark representative shapes.
+
+The `torch.linalg` namespace owns modern linear algebra: `solve` instead of explicitly inverting a matrix, `lstsq` for least squares, `svd` and `eigh` for decompositions, `vector_norm` and `matrix_norm` for explicit norm semantics, and `cond` for conditioning. Factorization can dominate both runtime and numerical error, so choose dtype and algorithm from the problem's stability requirements.
+
+<RevisionCodePair {...pytorchRevisionExamples.reductions} />
+
+Reductions accept `dim` and `keepdim` where NumPy uses `axis` and `keepdims`. Keeping reduced dimensions often makes later broadcasting clearer. Prefer stable fused formulations: `logsumexp` over `log(exp(x).sum())`, `log_softmax` over `softmax(x).log()`, and `cross_entropy` over manually composing probabilities and logarithms.
+
+| Family | APIs to recall |
+| --- | --- |
+| Pointwise math | `abs`, `clamp`, `where`, `lerp`, `sigmoid`, `tanh`, `exp`, `log`, `sqrt`, `rsqrt` |
+| Reductions | `sum`, `mean`, `prod`, `amax`, `amin`, `argmax`, `var`, `std`, `quantile`, `logsumexp` |
+| Sorting and selection | `sort`, `argsort`, `topk`, `kthvalue`, `unique`, `bincount`, `searchsorted` |
+| Comparison | `equal`, `allclose`, `isclose`, `isfinite`, `isnan`, `isinf` |
+| Linear algebra | `matmul`, `einsum`, `linalg.solve`, `linalg.svd`, `linalg.eigh`, `linalg.qr`, `linalg.norm` |
+| Signal and special math | `torch.fft`, `torch.special`, `torch.distributions` |
+
+### Sparse, quantized, and other layouts
+
+`torch.strided` is the ordinary dense layout. Sparse COO, CSR, CSC, BSR, and BSC tensors store indices plus values and expose layout-specific invariants; support varies by operator, autograd path, and device. Coalesce COO tensors before relying on unique sorted indices. Use sparse layouts only when the density and supported operator sequence beat dense kernels.
+
+Quantized tensors encode values with scale and zero point, while quantization workflows may use eager, FX, or export-based APIs depending on backend and deployment path. Nested or jagged tensors represent ragged shapes without padding, but operator coverage remains more constrained than dense strided tensors. Treat layout as part of an API contract, not an internal detail.
+
+## Autograd's dynamic graph
+
+PyTorch records a directed acyclic graph of `Function` nodes while operations execute. The graph is recreated each iteration, so ordinary Python control flow can change the graph. An operation is recorded when grad mode is enabled and at least one input requires gradients. Backward traverses saved dependencies and applies vector-Jacobian products.
+
+Leaves are user-created tensors with no `grad_fn`. Only leaf tensors with `requires_grad=True` accumulate into `.grad` by default; call `retain_grad()` only when a non-leaf gradient must be inspected. Gradients accumulate rather than overwrite, which is why training loops clear them explicitly.
+
+<RevisionCodePair {...pytorchRevisionExamples.autograd} />
+
+`Tensor.backward(gradient=None, retain_graph=False, create_graph=False)` is a side-effect API that accumulates into leaves. The implicit gradient is valid only for a scalar output. `torch.autograd.grad(outputs, inputs, grad_outputs=...)` returns requested gradients and is better for higher-order or functional code. `create_graph=True` records the derivative computation; `retain_graph=True` merely keeps the current graph and is rarely the correct first fix.
+
+Views share an autograd version counter with their base. If backward needs a saved value and an in-place operation changed it, autograd raises a version-mismatch error rather than silently differentiating the wrong program. `torch.autograd.detect_anomaly` adds traceback and NaN diagnostics but is intentionally slow. `gradcheck` and `gradgradcheck` use finite differences in double precision to validate custom derivatives.
+
+### Gradient modes are independent of module mode
+
+| Mechanism | Records autograd? | Can outputs later enter a grad graph? | Changes Dropout/BatchNorm? |
+| --- | --- | --- | --- |
+| Default grad mode | Yes when an input requires grad | Yes | No |
+| `torch.no_grad()` | No | Yes | No |
+| `torch.inference_mode()` | No, with more tracking removed | Generally no | No |
+| `model.eval()` | Unchanged | Unchanged | Yes, for modules with mode-dependent behavior |
+
+Use `no_grad` for parameter updates or preprocessing whose outputs may later participate in grad mode. Try `inference_mode` for evaluation paths that remain isolated from autograd. Always set `train()` and `eval()` explicitly when module behavior depends on mode; neither method disables gradients.
+
+`detach` returns a storage-sharing tensor without an autograd edge; `detach_` cannot detach views in place. Freezing parameters with `module.requires_grad_(False)` prevents their operations from being recorded when no other input requires grad, but it does not remove them from the optimizer's parameter groups or change module mode.
+
+### Hooks, custom derivatives, and saved tensors
+
+Tensor hooks observe or replace a gradient as it is computed. Post-accumulate hooks run after a leaf's `.grad` is updated. Module forward pre-hooks can modify inputs, forward hooks can inspect or replace outputs, and full backward hooks operate at module boundaries; every registration returns a removable handle. Hooks are operational instrumentation, not a substitute for explicit data flow.
+
+Subclass `torch.autograd.Function` when an operation calls non-PyTorch code or needs a custom derivative. Implement static `forward` and `backward`, save tensors with `ctx.save_for_backward`, store non-tensor metadata directly on `ctx`, mark non-differentiable outputs, and validate with gradcheck. Compatibility with `torch.func` transforms may also require `setup_context`, `jvp`, or a `vmap` rule.
+
+Saved-tensor hooks can pack and unpack intermediates, including CPU offload strategies, but the hooks must preserve value, dtype, device, and shape semantics. They trade memory against transfer or recomputation and belong behind measurement.
+
+## Composable function transforms
+
+`torch.func` provides function transforms rather than mutable tape APIs. `grad` returns a gradient function; `vmap` vectorizes a function over selected input dimensions; `jacrev` and `jacfwd` choose reverse- or forward-mode Jacobian construction; `vjp` and `jvp` compute products without materializing a full Jacobian; `hessian` composes modes; and `functionalize` removes intermediate mutation and aliasing when possible.
+
+<RevisionCodePair {...pytorchRevisionExamples.functionalTransforms} />
+
+`functional_call` runs a module with supplied parameter and buffer mappings, turning state into explicit function inputs. That enables per-sample gradients, ensembling, meta-learning, and parameter-space Jacobians. Choose reverse mode when outputs are few relative to inputs, forward mode when inputs are few relative to outputs, and products when a full Jacobian would be wasteful.
+
+## `nn.Module` as a registered state tree
+
+`nn.Module` is a Python object with registration semantics. Assigning an `nn.Parameter` registers trainable state; assigning a child `Module` registers a subtree; `register_buffer` records non-parameter tensor state; ordinary attributes remain ordinary Python state. Recursive APIs such as `parameters()`, `state_dict()`, `to()`, `train()`, and distributed wrappers traverse this tree.
+
+<RevisionCodePair {...pytorchRevisionExamples.modules} />
+
+Call `model(inputs)`, not `model.forward(inputs)`. `Module.__call__` runs hook machinery and then delegates to `forward`. Call `super().__init__()` before assigning registered members. A plain Python list or dictionary of modules is invisible to registration, device movement, checkpointing, and optimizers.
+
+| State kind | How to create it | In `parameters()` | In `state_dict()` | Moved by `to()` |
+| --- | --- | --- | --- | --- |
+| Parameter | `nn.Parameter` or layer assignment | Yes | Yes | Yes |
+| Persistent buffer | `register_buffer(..., persistent=True)` | No | Yes | Yes |
+| Non-persistent buffer | `persistent=False` | No | No | Yes |
+| Child module | assign an `nn.Module` | Its state recurses | Its state recurses | Yes |
+| Plain tensor attribute | ordinary assignment | No | No | No |
+
+`named_parameters`, `named_buffers`, `named_modules`, and `named_children` provide qualified names. `modules()` includes the module itself recursively; `children()` yields immediate children only. `get_submodule("encoder.layers.3")` resolves one path in time proportional to nesting depth and is preferable to scanning all modules for a known target.
+
+### Containers and execution structure
+
+`ModuleList` and `ModuleDict` register modules while leaving execution order to `forward`. `ParameterList` and `ParameterDict` do the same for free parameters. `Sequential` both registers modules and defines straight-line composition. Use named submodules or dictionaries when checkpoint keys must remain stable across refactors.
+
+<RevisionCodePair {...pytorchRevisionExamples.containers} />
+
+Registration occurs on assignment, so replacing a child or parameter changes the state tree. Weight tying assigns or reuses the same parameter object in multiple computations; deduplication in named traversal and optimizer construction then matters. Lazy modules defer shape-dependent initialization until the first input, while the meta device can create shape-only modules without allocating real storage.
+
+### Layer, functional, initialization, and loss APIs
+
+The `nn` namespace groups stateful layers and losses; `torch.nn.functional` exposes stateless operations whose parameters are explicit. A `Linear` module owns weight and bias, while `F.linear` consumes them. Prefer modules when state, mode, hooks, or serialization matter and functional calls for simple stateless composition.
+
+| Area | Core APIs |
+| --- | --- |
+| Dense and convolution | `Linear`, `Bilinear`, `Conv1d/2d/3d`, transposed convolutions |
+| Sequence and attention | `Embedding`, `RNN`, `LSTM`, `GRU`, `MultiheadAttention`, `Transformer*` |
+| Normalization | `BatchNorm*`, `LayerNorm`, `GroupNorm`, `RMSNorm` |
+| Regularization | `Dropout*`, `AlphaDropout`, `Embedding` options, parametrizations |
+| Activations | `ReLU`, `GELU`, `SiLU`, `Mish`, `Softmax`, `GLU` |
+| Pooling and padding | `MaxPool*`, `AvgPool*`, adaptive pooling, `pad` |
+| Losses | `CrossEntropyLoss`, `BCEWithLogitsLoss`, `MSELoss`, `KLDivLoss`, ranking losses |
+| Initialization | `nn.init.kaiming_*`, `xavier_*`, `orthogonal_`, `trunc_normal_`, `calculate_gain` |
+| Utilities | `clip_grad_norm_`, `parameters_to_vector`, `parametrize`, pruning and weight norm utilities |
+
+Know the contracts, not only names. `CrossEntropyLoss` expects unnormalized logits and class indices for the common classification path; `BCEWithLogitsLoss` fuses sigmoid with a stable binary objective; BatchNorm owns running buffers and changes behavior by mode; LayerNorm normalizes trailing dimensions and does not use running statistics.
+
+## State dictionaries and serialization
+
+A module `state_dict` is the stable boundary for parameters and persistent buffers. The returned mapping is shallow and its values refer to live state, so clone values when taking an in-memory snapshot that must survive later updates. `load_state_dict(strict=True)` requires exact keys; `strict=False` returns missing and unexpected keys that should be logged and reviewed, not discarded silently.
+
+Save architecture configuration and state rather than pickling a whole module. A resumable training checkpoint normally includes model state, optimizer state, scheduler state, AMP scaler state, epoch or global step, RNG states, and data-sampler position when exact continuation matters. Move optimizer state to the intended device deliberately after loading.
+
+`torch.save` uses a ZIP-based checkpoint format and preserves storage sharing. `torch.load(..., map_location=..., weights_only=True)` narrows unpickling behavior and is the default when no custom pickle module is supplied in modern PyTorch; it reduces remote-code-execution surface but is not a complete security sandbox. Never load an untrusted legacy pickle with unrestricted unpickling.
+
+For large checkpoints, `mmap=True` lazily maps storages, `FakeTensorMode` inspects metadata without allocating payloads, and distributed checkpoint APIs coordinate sharded state. State-dict pre/post hooks, load hooks, and `get_extra_state` support controlled schema migrations; version those migrations like any other persisted interface.
+
+## Datasets, samplers, collation, and workers
+
+A map-style `Dataset` implements `__getitem__` and normally `__len__`. An `IterableDataset` owns iteration and is appropriate for streams, generated data, or sources without random indexing. `DataLoader` combines fetch order, batching, collation, multiprocessing, and optional pinned-memory staging.
+
+<RevisionCodePair {...pytorchRevisionExamples.data} />
+
+For map-style datasets, `shuffle=True` selects a random sampler and is mutually exclusive with an explicit `sampler`. A `batch_sampler` yields lists of indices and replaces `batch_size`, `shuffle`, `sampler`, and `drop_last`. `collate_fn` turns a list of samples into one batch; default collation recursively stacks tensors in matching mappings, tuples, and sequences.
+
+`num_workers=0` is the debugging baseline with direct tracebacks. Multiple workers are processes with replicated Python dataset state; shard iterable datasets with `get_worker_info` to prevent duplicates. `persistent_workers=True` avoids process restart across epochs, `prefetch_factor` controls batches queued per worker, and `timeout` exposes stalls. With the spawn start method, dataset and worker functions must be picklable.
+
+Pinned host memory can make CPU-to-CUDA copies asynchronous when the transfer uses `non_blocking=True`. It is not free: pinning consumes a constrained host resource and only helps when transfer overlaps useful work. Custom batch classes can implement `pin_memory()` so DataLoader pinning reaches their tensors.
+
+## Training and evaluation invariants
+
+The canonical update is clear gradients, forward, scalar loss, backward, optional gradient processing, and optimizer step. Evaluation sets module mode and disables autograd separately. Inputs, targets, parameters, and relevant buffers must agree on device; loss accumulation should stay on device until a deliberate reporting boundary.
+
+<RevisionCodePair {...pytorchRevisionExamples.training} />
+
+`optimizer.zero_grad(set_to_none=True)` avoids writing zeros and lets backward assign fresh gradient storage. It also distinguishes a parameter that received no gradient (`grad is None`, optimizer normally skips it) from one whose gradient is numerically zero. Unexpected `None` gradients should trigger a connectivity investigation, not automatic replacement with zeros.
+
+Avoid `loss.item()`, Python conditionals on accelerator tensors, printing values, or CPU conversions every iteration; each can synchronize the device. Aggregate detached tensors on-device and convert at a reporting cadence. For accurate wall-clock CUDA timing, use CUDA events or synchronize around the measured region.
+
+### Optimizers, parameter groups, and schedulers
+
+An optimizer owns references to parameters plus state such as momentum or moving averages. Construct it after final device placement and parameter materialization. Parameter collections must have deterministic order; build explicit parameter groups for different learning rates, weight decay, or optimizer options, and assert every trainable parameter appears exactly once.
+
+`SGD` exposes momentum and Nesterov dynamics; `Adam` couples L2-style weight decay with moments, while `AdamW` decouples weight decay from the adaptive update. `Adafactor` reduces second-moment memory, `SparseAdam` handles sparse gradients for supported cases, and `LBFGS` requires a closure that can reevaluate the objective. Optimizer choices still depend on the model and objective; the API does not erase algorithmic assumptions.
+
+Schedulers normally step after the optimizer update. Batch-level schedules such as `OneCycleLR` step per optimizer step; epoch schedules step at the intended epoch boundary; `ReduceLROnPlateau` consumes the validation metric. Serialize scheduler and optimizer state together because counters and momentum are part of the training trajectory.
+
+### Accumulation, AMP, clipping, and checkpointing
+
+<RevisionCodePair {...pytorchRevisionExamples.optimization} />
+
+Gradient accumulation adds microbatch gradients into the same `.grad` buffers. Divide each microbatch loss by the accumulation count when matching the mean-gradient scale, step only at the effective-batch boundary, and account for a short final accumulation window. Under DDP, `no_sync()` can avoid redundant all-reduces on non-step microbatches.
+
+Autocast chooses an operator-specific dtype; it is not a blanket cast of the model or inputs. Wrap forward and loss, then leave the context before backward. `torch.amp.GradScaler("cuda")` is primarily needed for float16's limited exponent range; unscale before clipping or inspecting gradients. Bfloat16 often does not require scaling because it retains float32-like exponent range, though numerical validation still governs the choice.
+
+`clip_grad_norm_` computes a global norm as if gradients were concatenated and mutates gradients in place. Clip after AMP unscale and before `step`. Gradient clipping can bound instability but can also hide a bad objective, learning rate, or data batch; log the pre-clipped norm.
+
+Activation checkpointing trades compute for saved-activation memory by recomputing a region during backward. Use `torch.utils.checkpoint.checkpoint(..., use_reentrant=False)` unless a compatibility requirement dictates otherwise, keep the recomputed function semantically identical, and understand RNG preservation. This is distinct from serialization checkpoints.
+
+EMA and SWA maintain alternate parameter averages. `torch.optim.swa_utils.AveragedModel` can implement both; BatchNorm statistics may need recomputation with `update_bn` before evaluation. Treat averaged weights as separately versioned model state.
+
+## Compilation and export
+
+`torch.compile` asks TorchDynamo to capture Python frames into FX graphs, AOTAutograd to stage backward graphs where relevant, and a backend such as Inductor to generate code. Eager semantics remain the reference. Compilation can fuse pointwise work and reduce launch overhead, but compile time, guards, graph breaks, and shape specialization can erase the gain.
+
+Start with `compiled = torch.compile(model)` or `model.compile()` and benchmark steady state after warmup on representative shapes. Use `fullgraph=True` while auditing graph breaks. A graph break ends one compiled region and resumes tracing later; common causes include unsupported Python, data-dependent scalar extraction, printing, and opaque extension code.
+
+Guards encode assumptions about types, shapes, globals, and object identity. A failed guard can trigger recompilation; repeated specialization can hit the cache limit and fall back to eager. Use `TORCH_LOGS="graph_breaks,recompiles,guards"` or `TORCH_TRACE` plus `tlparse` to diagnose the program before applying private configuration knobs.
+
+Dynamic shapes permit symbolic dimensions, not arbitrary value-dependent Python. `torch._dynamo.mark_dynamic` can declare expected variation; custom operators provide a supported opaque boundary when Dynamo and the backend need explicit schemas, fake/meta implementations, and autograd rules. `torch.compiler.disable` excludes a problematic function deliberately.
+
+`torch.export.export` produces an ahead-of-time graph plus shape constraints for deployment or transformation. It is stricter than eager execution and serves a different purpose from `torch.compile`'s runtime optimization. TorchScript remains relevant to legacy systems, but new compiler and export work should start from the current PyTorch 2 APIs.
+
+## Devices, asynchronous execution, and memory
+
+CPU, CUDA, MPS, XPU, and other backends implement different operator and dtype coverage. The portable pattern selects a device, constructs or transfers model state once, moves batches at the boundary, and keeps intermediate work on-device. Use `torch.device` or accelerator APIs for explicit placement; avoid scattering unconditional `.cuda()` calls through model code.
+
+CUDA execution is asynchronous with respect to the host. Operations on one stream are ordered, while distinct streams require explicit dependencies through events, `wait_stream`, or `record_stream` when allocator lifetime crosses streams. Host-visible reads such as `item()` synchronize. Accurate benchmarks need warmup and synchronization or CUDA events.
+
+The caching allocator separates memory occupied by live tensors (`memory_allocated`) from memory reserved in allocator segments (`memory_reserved`). `empty_cache()` releases unused cached blocks for other applications but cannot free live tensor storage or increase memory available to tensors beyond what deleting references already enables. Use `memory_stats`, `memory_summary`, and `memory_snapshot` before tuning allocator configuration.
+
+Common memory levers are smaller batches, lower-precision activations, activation checkpointing, shorter sequences, fused kernels, avoiding retained graphs, clearing references, and sharding. Memory leaks are often Python references to tensors with graph history, such as appending raw losses to a list.
+
+## Distributed execution
+
+Use one process per accelerator. `torchrun` supplies rank metadata; `init_process_group` initializes communication; `rank` identifies a global process, `local_rank` selects a local device, and `world_size` is the process count. Every rank must execute collectives in compatible order or the job can hang.
+
+`DistributedDataParallel` replicates model state and all-reduces gradient buckets during backward. Construct the optimizer from the wrapped model's parameters, use a `DistributedSampler` for map-style data, and call `sampler.set_epoch(epoch)` so shuffling changes across epochs. `no_sync` suppresses gradient synchronization for intentional accumulation. Prefer DDP over single-process `DataParallel`.
+
+FSDP shards parameters, gradients, and optimizer state, gathering parameter material around computation. Wrapping policy, mixed precision, prefetch, state-dict type, and initialization determine memory and communication behavior. Build the optimizer after wrapping. Tensor parallelism shards individual operations; pipeline parallelism splits layers into stages; `DeviceMesh` names multidimensional process layouts so data, tensor, and pipeline dimensions compose.
+
+The primitive layer includes `all_reduce`, `all_gather`, `reduce_scatter`, `broadcast`, `scatter`, `gather`, `all_to_all`, point-to-point send/receive, process groups, and asynchronous work handles. NCCL is the common CUDA backend and Gloo the common CPU backend. Diagnose hangs with rank-local logs, timeouts, `TORCH_DISTRIBUTED_DEBUG`, and collective consistency before blaming the network.
+
+Distributed checkpointing saves and loads sharded state without assembling a full checkpoint on one rank. Model and optimizer state-dict APIs must agree with the parallel wrapper and mesh; resharding across a new world size is a checkpoint-format capability, not something to assume.
+
+## Reproducibility, diagnostics, and performance
+
+A seed fixes an RNG sequence, not an experiment across arbitrary releases and hardware. Seed PyTorch, Python, and NumPy; use explicit `torch.Generator` objects where local control matters; seed DataLoader workers from `torch.initial_seed()`; and serialize RNG states for exact continuation. `torch.use_deterministic_algorithms(True)` requests deterministic kernels or errors, often with a performance cost.
+
+Set `torch.backends.cudnn.benchmark` from the workload: benchmarking may improve stable-shape convolution performance but can select different algorithms across runs. Deterministic-algorithm selection and cuDNN benchmarking are distinct controls. Record PyTorch, CUDA, driver, hardware, compiler, and environment versions with an experiment.
+
+`torch.profiler.profile` captures CPU operators and device kernels. Use a wait/warmup/active schedule for long jobs, call `prof.step()` once per iteration, annotate regions with `record_function`, and inspect self time, total time, shapes, memory, and launch gaps. `record_shapes` and stack traces add overhead and can perturb reference counts, so profile representative windows rather than entire training runs.
+
+For debugging, combine:
+
+- `torch.testing.assert_close` for values with explicit tolerances and shape/dtype/device checks;
+- `detect_anomaly` for a short failing autograd path;
+- gradient and activation hooks with removable handles;
+- `torch._dynamo.explain` and compiler logs for graph capture;
+- allocator snapshots for CUDA fragmentation and lifetime;
+- `torch.utils.benchmark` for statistically controlled microbenchmarks;
+- `pytest` tests that cover train/eval mode, CPU and accelerator placement, mixed precision, serialization round trips, and dynamic shapes.
+
+Optimize from a trace. Typical wins come from larger vectorized kernels, fewer host synchronizations, fused pointwise work, correct input staging, suitable precision, compile-stable shapes, and communication overlap. A faster isolated kernel does not guarantee a faster step when input, synchronization, memory, or collectives dominate.
+
+## PyTorch and NumPy API map
+
+The libraries intentionally look similar, but PyTorch adds devices, autograd, module state, layouts, and asynchronous execution. Translate the semantic contract, not only the spelling.
+
+| Intent | PyTorch | NumPy | Watch |
+| --- | --- | --- | --- |
+| Array object | `torch.Tensor` | `np.ndarray` | Tensor carries device and autograd metadata. |
+| Default float | usually `float32` | usually `float64` | Constructor inference can change memory and stability. |
+| Axis argument | `dim=` | `axis=` | `keepdim` versus `keepdims`. |
+| Cast or move | `x.to(dtype=..., device=...)` | `x.astype(dtype)` | PyTorch may transfer devices asynchronously. |
+| Concatenate | `torch.cat` | `np.concatenate` | Existing dimension. |
+| Add new stack axis | `torch.stack` | `np.stack` | Inputs must have equal shape. |
+| Reshape | `reshape` / `view` | `reshape` / `view` | Sharing guarantees differ by API and strides. |
+| Transpose | `transpose` / `permute` / `mT` | `swapaxes` / `transpose` / `T` | PyTorch `T` is deprecated for non-2-D semantics. |
+| Clamp | `torch.clamp` | `np.clip` | In-place `clamp_` mutates. |
+| Select by condition | `torch.where` | `np.where` | One-argument nonzero forms differ. |
+| Matrix multiply | `@` / `matmul` | same | PyTorch adds device kernels and gradients. |
+| Contraction | `torch.einsum` | `np.einsum` | Path and kernel performance can differ. |
+| Copy/share bridge | `from_numpy` / `numpy` | same object side | Negative strides and unsupported dtypes can force rejection or copying. |
+| Testing | `torch.testing.assert_close` | `np.testing.assert_allclose` | Specify tolerance policy. |
+
+## API atlas
+
+Use this as a retrieval map. The public namespace is too large for a useful flat dump; these are the surfaces that organize day-to-day reasoning and direct you to the narrower reference.
+
+| Namespace | Working surface |
+| --- | --- |
+| `torch` | factories, pointwise ops, reductions, indexing, shape transforms, random, serialization, compile |
+| `Tensor` | metadata, views, conversions, mutation, device transfer, autograd flags and hooks |
+| `torch.linalg` | solves, decompositions, norms, conditioning |
+| `torch.fft` / `torch.special` | Fourier transforms and special mathematical functions |
+| `torch.sparse` | sparse layouts, conversions, validation, sparse operators |
+| `torch.nn` | `Module`, parameters, containers, layers, losses, initialization, utilities |
+| `torch.nn.functional` | stateless layer and loss operations with explicit tensors |
+| `torch.autograd` | backward engine, `grad`, `Function`, grad mode, graph and saved-tensor hooks |
+| `torch.func` | `grad`, `vmap`, Jacobians, JVP/VJP, functional module calls, functionalization |
+| `torch.optim` | optimizers, parameter groups, state, schedulers, SWA and EMA helpers |
+| `torch.utils.data` | datasets, samplers, batching, collation, workers, pinned memory |
+| `torch.amp` | autocast and gradient scaling across supported device types |
+| `torch.cuda` / accelerator namespaces | devices, streams, events, memory, graphs, communication helpers |
+| `torch.compiler` / `torch._dynamo` | compile control, graph-break and recompile diagnostics |
+| `torch.export` | constrained ahead-of-time graph capture and serialization |
+| `torch.distributed` | process groups, collectives, DDP, FSDP, DeviceMesh, sharded checkpoints |
+| `torch.profiler` / `torch.utils.benchmark` | operator traces, device kernels, memory, microbenchmarks |
+| `torch.testing` | tensor-aware assertions and comparison diagnostics |
+
+## Rapid recall
+
+| Question | Staff-level answer |
+| --- | --- |
+| Does `torch.tensor(x)` share data? | No. It copies and creates a fresh leaf by default. |
+| Why can a transpose be cheap? | It changes shape and strides while sharing storage. |
+| Why can `reshape` be dangerous for alias assumptions? | It may return a view or allocate a copy. |
+| Does `detach` copy? | No. It removes the autograd edge but shares storage. |
+| Where do gradients accumulate? | Leaf parameters with `requires_grad=True`, unless non-leaves explicitly retain them. |
+| Does `eval()` disable gradients? | No. Module mode and grad mode are orthogonal. |
+| Why use `model(x)` instead of `forward(x)`? | `__call__` runs module hook and call machinery. |
+| Why does a Python list of layers fail? | It does not register child modules; use `ModuleList` or explicit attributes. |
+| Parameter or buffer? | Optimize parameters; persist and move non-optimized tensor state as buffers. |
+| Why `set_to_none=True`? | Lower writes and an observable distinction between no gradient and zero gradient. |
+| When does AMP clip? | After `scaler.unscale_(optimizer)` and before `scaler.step`. |
+| Why can `item()` hurt throughput? | It may synchronize asynchronous accelerator work with the host. |
+| Allocated versus reserved CUDA memory? | Live tensor bytes versus allocator-managed segments. |
+| What causes compile recompilation? | A guard fails because an assumption about input or Python state changed. |
+| DDP versus FSDP? | DDP replicates parameters and reduces gradients; FSDP shards model states and gathers around compute. |
+| What belongs in a resumable checkpoint? | Model, optimizer, scheduler, scaler, step, configuration, RNG, and sampler progress as needed. |
 
 ## Source links
 
-- [PyTorch 2.13 tensor documentation](https://docs.pytorch.org/docs/2.13/tensors.html)
-- [Tensor attributes: dtype, device, layout, and strides](https://docs.pytorch.org/docs/2.13/tensor_attributes.html)
-- [Tensor views and aliasing](https://docs.pytorch.org/docs/2.13/tensor_view.html)
-- [`torch.Tensor.item`](https://docs.pytorch.org/docs/2.13/generated/torch.Tensor.item.html)
-- [Creation ops](https://docs.pytorch.org/docs/2.13/torch.html#creation-ops)
-- [Indexing, slicing, joining, and mutating ops](https://docs.pytorch.org/docs/2.13/torch.html#indexing-slicing-joining-mutating-ops)
+- [PyTorch 2.13 documentation](https://docs.pytorch.org/docs/2.13/)
+- [Tensors](https://docs.pytorch.org/docs/2.13/tensors.html), [tensor attributes](https://docs.pytorch.org/docs/2.13/tensor_attributes.html), and [tensor views](https://docs.pytorch.org/docs/2.13/tensor_view.html)
+- [Broadcasting semantics](https://docs.pytorch.org/docs/2.13/notes/broadcasting.html) and [numerical accuracy](https://docs.pytorch.org/docs/2.13/notes/numerical_accuracy.html)
+- [Autograd mechanics](https://docs.pytorch.org/docs/2.13/notes/autograd.html) and [extending autograd](https://docs.pytorch.org/docs/2.13/notes/extending.html)
+- [`nn.Module`](https://docs.pytorch.org/docs/2.13/generated/torch.nn.Module.html), [`ModuleList`](https://docs.pytorch.org/docs/2.13/generated/torch.nn.ModuleList.html), and [`torch.nn`](https://docs.pytorch.org/docs/2.13/nn.html)
+- [`torch.func`](https://docs.pytorch.org/docs/2.13/func.html)
+- [`torch.utils.data`](https://docs.pytorch.org/docs/2.13/data.html)
+- [Optimizers and schedulers](https://docs.pytorch.org/docs/2.13/optim.html), [AMP](https://docs.pytorch.org/docs/2.13/amp.html), and [activation checkpointing](https://docs.pytorch.org/docs/2.13/checkpoint.html)
+- [`torch.compile`](https://docs.pytorch.org/docs/2.13/generated/torch.compile.html) and its [programming model](https://docs.pytorch.org/docs/2.13/user_guide/torch_compiler/compile/programming_model.html)
+- [CUDA semantics](https://docs.pytorch.org/docs/2.13/notes/cuda.html) and [the profiler](https://docs.pytorch.org/docs/2.13/profiler.html)
+- [Distributed communication](https://docs.pytorch.org/docs/2.13/distributed.html) and [FSDP](https://docs.pytorch.org/docs/2.13/fsdp.html)
+- [Serialization semantics](https://docs.pytorch.org/docs/2.13/notes/serialization.html) and [reproducibility](https://docs.pytorch.org/docs/2.13/notes/randomness.html)
+- [NumPy array creation](https://numpy.org/doc/stable/user/basics.creation.html), [broadcasting](https://numpy.org/doc/stable/user/basics.broadcasting.html), and [indexing](https://numpy.org/doc/stable/user/basics.indexing.html)

--- a/src/lib/python-playground.ts
+++ b/src/lib/python-playground.ts
@@ -17,4 +17,5 @@ export interface PythonPlaygroundProps {
   samples: PlaygroundSample[];
   walkthroughSteps?: WalkthroughStep[];
   notes?: string;
+  compact?: boolean;
 }

--- a/src/lib/pytorch-revision-examples.ts
+++ b/src/lib/pytorch-revision-examples.ts
@@ -1,255 +1,353 @@
-export interface PytorchTensorExample {
+export interface PytorchRevisionExample {
   title: string;
   initialCode: string;
-  referenceCode: string;
-  description: string;
+  description?: string;
   notes?: string;
 }
 
-export const pytorchTensorExamples: Record<string, PytorchTensorExample> = {
+export const pytorchRevisionExamples: Record<string, PytorchRevisionExample> = {
   construction: {
-    title: 'Construct, copy, and place a tensor',
-    description: 'Edit the source value or dtype, then run the snippet again.',
+    title: 'Construction and NumPy interop',
     initialCode: `import numpy as np
 import torch
 
 source = np.array([[1, 2], [3, 4]], dtype=np.float32)
+
 copied = torch.tensor(source, dtype=torch.float32, device="cpu")
 shared = torch.as_tensor(source)
+from_numpy = torch.from_numpy(source)
 
 source[0, 0] = 99
 
-print("copied:", copied.tolist())
-print("shared:", shared.tolist())
-print("dtype:", copied.dtype)
-print("device:", copied.device)
+print("torch.tensor copied:", copied.tolist())
+print("as_tensor shares:", shared.tolist())
+print("from_numpy shares:", from_numpy.tolist())
+print("dtype / device:", copied.dtype, copied.device)
 `,
-    referenceCode: `import numpy as np
-import torch
-
-source = np.array([[1, 2], [3, 4]], dtype=np.float32)
-
-# torch.tensor always copies its input data.
-copied = torch.tensor(source, dtype=torch.float32, device="cpu")
-
-# These APIs can share CPU storage when the input permits it.
-shared = torch.as_tensor(source)
-shared_from_numpy = torch.from_numpy(source)
-
-source[0, 0] = 99
-
-print("copied:", copied.tolist())
-print("as_tensor:", shared.tolist())
-print("from_numpy:", shared_from_numpy.tolist())
-print("dtype:", copied.dtype)
-print("device:", copied.device)
-`,
-    notes:
-      'The browser runner uses NumPy underneath, so its copy/share behavior mirrors the example but it does not allocate CUDA tensors.',
   },
 
-  creationOps: {
-    title: 'Create zeros, ones, and random tensors',
-    description: 'The seed makes the random examples repeatable in this small exercise.',
-    initialCode: `import torch
+  factories: {
+    title: 'Factories, dtype, device, and randomness',
+    initialCode: `import numpy as np
+import torch
 
 torch.manual_seed(7)
 
-factories = {
-    "zeros": torch.zeros((2, 3)),
-    "ones": torch.ones((2, 3)),
-    "full": torch.full((2, 3), 7),
-    "rand": torch.rand((2, 3)),
-    "randn": torch.randn((2, 3)),
+items = {
+    "zeros": torch.zeros(2, 3, dtype=torch.float32),
+    "ones_like": torch.ones_like(torch.zeros(2, 3)),
+    "full": torch.full((2, 3), 7, dtype=torch.int64),
+    "rand": torch.rand(2, 3),
+    "randn": torch.randn(2, 3),
+    "randint": torch.randint(0, 10, (2, 3)),
     "arange": torch.arange(6).reshape(2, 3),
+    "linspace": torch.linspace(0, 1, 5),
     "eye": torch.eye(3),
 }
 
-for name, value in factories.items():
-    print(name, "shape:", value.shape)
-    print(value)
+for name, value in items.items():
+    print(f"{name:10s}", value.shape, value.dtype)
+
+print("NumPy default float:", np.zeros((1,)).dtype)
+print("Torch default float:", torch.zeros(1).dtype)
 `,
-    referenceCode: `import torch
-
-torch.manual_seed(7)
-
-zeros = torch.zeros((2, 3), dtype=torch.float32)
-ones = torch.ones((2, 3), dtype=torch.float32)
-full = torch.full((2, 3), fill_value=7, dtype=torch.int64)
-uniform = torch.rand((2, 3), dtype=torch.float32)       # [0, 1)
-normal = torch.randn((2, 3), dtype=torch.float32)       # N(0, 1)
-sequence = torch.arange(6, dtype=torch.int64).reshape(2, 3)
-identity = torch.eye(3, dtype=torch.float32)
-empty = torch.empty((2, 3))  # allocated, but not initialized
-
-for name, value in {
-    "zeros": zeros,
-    "ones": ones,
-    "full": full,
-    "uniform": uniform,
-    "normal": normal,
-    "sequence": sequence,
-    "identity": identity,
-}.items():
-    print(name, "shape:", value.shape)
-    print(value)
-`,
-    notes: 'Try changing the factory shape. `empty` is useful when every element will be overwritten, but never read it before initialization.',
   },
 
-  inspectStorage: {
-    title: 'Inspect shape, scalar values, and storage views',
-    description: 'Change the slice and observe the shape, stride, and storage relationship.',
+  views: {
+    title: 'Storage, strides, views, and mutation',
     initialCode: `import torch
 
-base = torch.arange(12, dtype=torch.float32).reshape(3, 4)
-view = base[:, 1:3]
+base = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+view = base[:, :, ::2]
+transposed = torch.permute(base, (0, 2, 1))
 
-print("shape:", base.shape)
-print("ndim:", base.ndim)
-print("numel:", base.numel())
-print("element size:", base.element_size(), "bytes")
-print("base stride:", base.stride())
-print("view stride:", view.stride())
-print("share storage:", base.untyped_storage().data_ptr() == view.untyped_storage().data_ptr())
-print("one Python scalar:", base[1, 2].item())
-print("many Python values:", view.tolist())
+print("base:", base.shape, base.stride(), base.is_contiguous())
+print("view:", view.shape, view.stride(), view.is_contiguous())
+print("permute:", transposed.shape, transposed.stride(), transposed.is_contiguous())
+print("same storage:", base.untyped_storage().data_ptr() == view.untyped_storage().data_ptr())
+
+view[0, 0, 0] = -1
+print("mutation reached base:", base[0, 0, 0].item())
+print("scalar / list:", base[0, 0, 1].item(), view[0].tolist())
 `,
-    referenceCode: `import torch
-
-base = torch.arange(12, dtype=torch.float32).reshape(3, 4)
-view = base[:, 1:3]
-
-print("shape:", base.shape)
-print("ndim:", base.ndim)
-print("numel:", base.numel())
-print("element size:", base.element_size(), "bytes")
-print("base stride:", base.stride())
-print("view stride:", view.stride())
-print(
-    "share storage:",
-    base.untyped_storage().data_ptr() == view.untyped_storage().data_ptr(),
-)
-
-# item() is scalar conversion, not raw-storage access.
-print("one Python scalar:", base[1, 2].item())
-print("many Python values:", view.tolist())
-`,
-    notes:
-      'A tensor is metadata plus a view over storage. Use `item()` for exactly one value, `tolist()` for a small tensor, and `untyped_storage().data_ptr()` only when you need to reason about aliasing.',
   },
 
   indexing: {
-    title: 'Index and slice by dimension',
-    description: 'Try negative indices, a different step, or a different boolean mask.',
+    title: 'Indexing, masks, gather, and scatter',
     initialCode: `import torch
 
 x = torch.arange(20).reshape(4, 5)
-indices = torch.tensor([0, 3])
+rows = torch.tensor([0, 3], dtype=torch.int64)
+gather_index = torch.tensor([[0, 2], [1, 4], [0, 3], [2, 2]])
 
-print("one element:", x[1, 2].item())
-print("one row:\\n", x[1])
-print("rows 0:2, columns 1:4:\\n", x[0:2, 1:4])
-print("every other column:\\n", x[:, ::2])
-print("advanced row selection:\\n", x[indices])
+basic = x[1:3, ::2]
+advanced = x[rows]
+gathered = torch.gather(x, dim=1, index=gather_index)
+mask = x % 3 == 0
 
-# Assignment through a slice changes x in-place.
+print("basic view:\\n", basic)
+print("advanced copy:\\n", advanced)
+print("gathered:\\n", gathered)
+print("masked values:", x[mask].tolist())
+
 x[:2, 0] = -1
-print("after slice assignment:\\n", x)
+print("slice assignment:\\n", x)
 `,
-    referenceCode: `import torch
-
-x = torch.arange(20).reshape(4, 5)
-indices = torch.tensor([0, 3], dtype=torch.int64)
-
-print("one element:", x[1, 2].item())
-print("one row:\\n", x[1])
-print("rows 0:2, columns 1:4:\\n", x[0:2, 1:4])
-print("every other column:\\n", x[:, ::2])
-print("advanced row selection:\\n", x[indices])
-
-# Basic indexing/slicing returns a view. Assignment is in-place.
-x[:2, 0] = -1
-print("after slice assignment:\\n", x)
-`,
-    notes:
-      'Basic slices such as `x[:, 1:4]` are views; advanced indexing such as `x[indices]` produces a copy. Assignment through either form mutates the destination tensor.',
   },
 
-  joining: {
-    title: 'Join and reshape tensors',
-    description: 'Change `dim` and predict the resulting shape before running the code.',
-    initialCode: `import torch
+  shapes: {
+    title: 'Shape transforms and broadcasting',
+    initialCode: `import numpy as np
+import torch
 
-a = torch.tensor([[1, 2], [3, 4]])
-b = torch.tensor([[5, 6], [7, 8]])
+x = torch.arange(24).reshape(2, 3, 4)
+bias = torch.arange(4)
 
-cat_rows = torch.cat((a, b), dim=0)
-cat_columns = torch.cat((a, b), dim=1)
-stacked = torch.stack((a, b), dim=0)
-reshaped = a.reshape(1, 4)
+print("broadcast result:", (x + bias).shape)
+print("unsqueeze:", torch.unsqueeze(x, 1).shape)
+print("squeeze:", torch.squeeze(torch.unsqueeze(x, 1), 1).shape)
+print("flatten middle:", torch.flatten(x, 1, 2).shape)
+print("transpose:", torch.transpose(x, 1, 2).shape)
+print("permute:", torch.permute(x, (2, 0, 1)).shape)
 
-print("cat dim=0:", cat_rows.shape, "\\n", cat_rows)
-print("cat dim=1:", cat_columns.shape, "\\n", cat_columns)
-print("stack dim=0:", stacked.shape, "\\n", stacked)
-print("reshape:", reshaped.shape, "\\n", reshaped)
+a = torch.ones(2, 3)
+b = torch.zeros(2, 3)
+print("cat:", torch.cat((a, b), dim=0).shape)
+print("stack:", torch.stack((a, b), dim=0).shape)
+print("NumPy agrees:", np.stack((a, b), axis=0).shape)
 `,
-    referenceCode: `import torch
-
-a = torch.tensor([[1, 2], [3, 4]])
-b = torch.tensor([[5, 6], [7, 8]])
-
-# cat joins along an existing dimension.
-cat_rows = torch.cat((a, b), dim=0)       # shape (4, 2)
-cat_columns = torch.cat((a, b), dim=1)    # shape (2, 4)
-
-# stack inserts a new dimension; inputs must have the same shape.
-stacked = torch.stack((a, b), dim=0)      # shape (2, 2, 2)
-
-# view shares data when the size/stride constraint is satisfied.
-flat_view = a.view(4)
-reshaped = a.reshape(1, 4)                # view or copy; do not rely on which
-
-print("cat rows:", cat_rows.shape)
-print("cat columns:", cat_columns.shape)
-print("stacked:", stacked.shape)
-print("flat view:", flat_view.shape)
-print("reshaped:", reshaped.shape)
-`,
-    notes:
-      '`cat` preserves rank and joins an existing dimension; `stack` increases rank by inserting a dimension. `reshape` is flexible, while `view` requires compatible strides.',
   },
 
-  mutation: {
-    title: 'Mutate explicitly and protect autograd',
-    description: 'Run the example, then replace an in-place operation with an out-of-place one and compare the result.',
+  linalg: {
+    title: 'Matmul, einsum, and linear algebra',
+    initialCode: `import numpy as np
+import torch
+
+batch, tokens, width, out = 2, 3, 4, 5
+x = torch.arange(batch * tokens * width, dtype=torch.float32).reshape(batch, tokens, width)
+w = torch.arange(width * out, dtype=torch.float32).reshape(width, out)
+
+matmul = torch.matmul(x, w)
+einsum = torch.einsum("btd,do->bto", x, w)
+
+print("matmul:", matmul.shape)
+print("einsum:", einsum.shape)
+print("same values:", torch.allclose(matmul, einsum))
+print("dot:", torch.dot(torch.arange(4), torch.arange(4)).item())
+print("outer:\\n", torch.outer(torch.arange(3), torch.arange(2)))
+print("NumPy matmul agrees:", np.allclose(matmul, np.matmul(x, w)))
+`,
+  },
+
+  reductions: {
+    title: 'Reductions and numerical stability',
     initialCode: `import torch
 
-x = torch.zeros((2, 3), dtype=torch.float32)
+logits = torch.tensor([[1000.0, 1001.0, 999.0], [-1000.0, -999.0, -1001.0]])
 
-with torch.no_grad():
-    x.add_(1.0)
-    x[0, 1] = 7.0
-    x[:, 2].fill_(4.0)
+probabilities = torch.softmax(logits, dim=-1)
+log_probabilities = torch.log_softmax(logits, dim=-1)
+normalizer = torch.logsumexp(logits, dim=-1)
+top = torch.topk(logits, k=2, dim=-1)
 
-y = x + 1.0
-print("x after mutation:\\n", x)
-print("y from out-of-place +:\\n", y)
+print("softmax row sums:", torch.sum(probabilities, dim=-1))
+print("logsumexp:", normalizer)
+print("top values:\\n", top.values)
+print("top indices:\\n", top.indices)
+print("L2 norm:", torch.norm(logits, p=2, dim=-1))
 `,
-    referenceCode: `import torch
+  },
 
-x = torch.zeros((2, 3), dtype=torch.float32)
+  autograd: {
+    title: 'Gradient flow and finite-difference checks',
+    initialCode: `import torch
 
-with torch.no_grad():
-    x.add_(1.0)       # underscore marks an in-place operation
-    x[0, 1] = 7.0     # indexing assignment is also in-place
-    x[:, 2].fill_(4.0)
+def objective(x):
+    return torch.sum(torch.sin(x) * x ** 2)
 
-y = x + 1.0           # out-of-place: x is unchanged by this line
-print("x after mutation:\\n", x)
-print("y from out-of-place +:\\n", y)
+x = torch.tensor([0.2, -0.4, 0.8], dtype=torch.float64)
+epsilon = 1e-6
+numerical_grad = torch.zeros_like(x)
+
+for index in range(x.shape[0]):
+    step = torch.zeros_like(x)
+    step[index] = epsilon
+    numerical_grad[index] = (objective(x + step) - objective(x - step)) / (2 * epsilon)
+
+analytic_grad = 2 * x * torch.sin(x) + x ** 2 * torch.cos(x)
+print("finite difference:", numerical_grad)
+print("analytic:", analytic_grad)
+print("close:", torch.allclose(numerical_grad, analytic_grad, rtol=1e-5, atol=1e-7))
 `,
-    notes:
-      'In real training code, prefer out-of-place operations unless the memory saving is deliberate and autograd permits the mutation. Never use `.data` as a shortcut around autograd.',
+  },
+
+  modules: {
+    title: 'Module registration and buffers',
+    initialCode: `import torch
+from torch import nn
+
+torch.manual_seed(3)
+
+class Projector(nn.Module):
+    def __init__(self, width):
+        super().__init__()
+        self.proj = nn.Linear(width, width)
+        self.scale = nn.Parameter(torch.ones(width))
+        self.register_buffer("running_total", torch.zeros(width))
+        self.unregistered = [nn.Linear(width, width)]
+
+    def forward(self, x):
+        return self.proj(x) * self.scale
+
+model = Projector(4)
+x = torch.ones(2, 4)
+
+print("output shape:", model(x).shape)
+print("parameters:", [name for name, _ in model.named_parameters()])
+print("buffers:", [name for name, _ in model.named_buffers()])
+print("children:", [name for name, _ in model.named_children()])
+print("state dict:", list(model.state_dict()))
+`,
+  },
+
+  containers: {
+    title: 'Module containers, mode, and state',
+    initialCode: `import torch
+from torch import nn
+
+torch.manual_seed(5)
+
+class MLP(nn.Module):
+    def __init__(self, width, depth):
+        super().__init__()
+        self.layers = nn.ModuleList([nn.Linear(width, width) for _ in range(depth)])
+        self.dropout = nn.Dropout(p=0.5)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = nn.functional.relu(layer(x))
+        return self.dropout(x)
+
+model = MLP(width=4, depth=3)
+inputs = torch.ones(2, 4)
+
+model.train()
+train_output = model(inputs)
+model.eval()
+eval_output = model(inputs)
+
+checkpoint = model.state_dict()
+result = model.load_state_dict(checkpoint, strict=True)
+
+print("registered layers:", [name for name, _ in model.named_modules()])
+print("state keys:", list(checkpoint))
+print("mode:", model.training, model.dropout.training)
+print("train/eval shapes:", train_output.shape, eval_output.shape)
+print("load result:", result.missing_keys, result.unexpected_keys)
+`,
+  },
+
+  data: {
+    title: 'Dataset, DataLoader, and collation',
+    initialCode: `import torch
+from torch.utils.data import DataLoader, Dataset
+
+class Pairs(Dataset):
+    def __init__(self):
+        self.features = torch.arange(30, dtype=torch.float32).reshape(10, 3)
+        self.targets = torch.arange(10, dtype=torch.int64)
+
+    def __len__(self):
+        return self.targets.shape[0]
+
+    def __getitem__(self, index):
+        return {"features": self.features[index], "target": self.targets[index]}
+
+torch.manual_seed(11)
+loader = DataLoader(Pairs(), batch_size=4, shuffle=True, drop_last=False)
+
+for batch_index, batch in enumerate(loader):
+    print(batch_index, batch["features"].shape, batch["target"].tolist())
+`,
+  },
+
+  training: {
+    title: 'Training-loop invariants',
+    initialCode: `import torch
+
+torch.manual_seed(13)
+x = torch.linspace(-1, 1, 16).reshape(16, 1)
+target = 3 * x + 2
+
+weight = torch.randn(1, 1)
+bias = torch.zeros(1)
+learning_rate = 0.2
+
+for step in range(12):
+    prediction = torch.matmul(x, weight) + bias
+    residual = prediction - target
+    loss = torch.mean(residual ** 2)
+
+    grad_weight = 2 * torch.matmul(torch.transpose(x, 0, 1), residual) / x.shape[0]
+    grad_bias = 2 * torch.mean(residual, dim=0)
+
+    with torch.no_grad():
+        weight.sub_(learning_rate * grad_weight)
+        bias.sub_(learning_rate * grad_bias)
+
+print("loss:", float(loss))
+print("weight / bias:", weight.item(), bias.item())
+`,
+  },
+
+  optimization: {
+    title: 'Accumulation, AMP, clipping, and schedulers',
+    initialCode: `import torch
+
+# Loss scaling keeps tiny float16 gradients representable.
+gradient = torch.tensor([2e-8, -7e-8, 4e-5], dtype=torch.float16)
+scale = 1024.0
+scaled = gradient * scale
+unscaled = scaled / scale
+
+print("original float16:", gradient)
+print("scaled:", scaled)
+print("unscaled:", unscaled)
+
+# Accumulating four microbatches requires dividing each loss by four.
+microbatch_losses = torch.tensor([1.2, 0.8, 1.0, 1.4])
+effective_loss = torch.sum(microbatch_losses / 4)
+print("effective mean loss:", effective_loss.item())
+`,
+  },
+
+  functionalTransforms: {
+    title: 'Vectorization and per-sample gradients',
+    initialCode: `import torch
+
+def loss(weight, example, target):
+    prediction = torch.sum(weight * example)
+    return (prediction - target) ** 2
+
+weight = torch.tensor([0.3, -0.2, 0.8], dtype=torch.float64)
+examples = torch.tensor([[1.0, 2.0, 3.0], [3.0, 1.0, -1.0]])
+targets = torch.tensor([1.0, -2.0])
+
+epsilon = 1e-6
+per_sample = []
+for example, target in zip(examples, targets):
+    gradient = torch.zeros_like(weight)
+    for index in range(weight.shape[0]):
+        step = torch.zeros_like(weight)
+        step[index] = epsilon
+        gradient[index] = (
+            loss(weight + step, example, target)
+            - loss(weight - step, example, target)
+        ) / (2 * epsilon)
+    per_sample.append(gradient)
+
+print("per-sample gradient shape:", torch.stack(per_sample).shape)
+print(torch.stack(per_sample))
+`,
   },
 };

--- a/src/lib/torch-compat.ts
+++ b/src/lib/torch-compat.ts
@@ -4,7 +4,8 @@
  * Pyodide does not ship the compiled PyTorch runtime. The snippets still use
  * real PyTorch names and tensor idioms, but this compatibility layer maps the
  * subset used by the practice problems to NumPy arrays. It is not a drop-in
- * replacement for PyTorch: there is no autograd, CUDA, nn.Module, or compiler.
+ * replacement for PyTorch: module and data-loader support is pedagogical, and
+ * there is no autograd engine, accelerator runtime, compiler, or distributed backend.
  */
 export const TORCH_COMPAT_PACKAGE = 'torch';
 
@@ -74,6 +75,24 @@ class _CompatTensor(_np.ndarray):
 
     def requires_grad_(self, _requires_grad=True):
         return self
+
+    def dim(self):
+        return int(self.ndim)
+
+    def ndimension(self):
+        return int(self.ndim)
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return _np.asarray(self)
+
+    def float(self):
+        return self.to(dtype=_np.float32)
+
+    def long(self):
+        return self.to(dtype=_np.int64)
 
     def to(self, dtype=None, device=None, **_kwargs):
         if dtype is None or _np.dtype(dtype) == self.dtype:
@@ -222,6 +241,24 @@ def _topk(value, k, dim=-1, largest=True, sorted=True):
     values = _np.take_along_axis(value, indices, axis=dim)
     return _types.SimpleNamespace(values=_wrap(values), indices=_wrap(indices))
 
+def _sort(value, dim=-1, descending=False, stable=False):
+    value = _np.asarray(value)
+    order = _np.argsort(
+        -value if descending else value,
+        axis=dim,
+        kind='stable' if stable else None,
+    )
+    values = _np.take_along_axis(value, order, axis=dim)
+    return _types.SimpleNamespace(values=_wrap(values), indices=_wrap(order))
+
+def _randint(low, high=None, size=None, dtype=_np.int64, **_kwargs):
+    if high is None:
+        low, high = 0, low
+    return _tensor(_np.random.randint(low, high, size=_shape(size), dtype=dtype), copy=False)
+
+def _randperm(n, dtype=_np.int64, **_kwargs):
+    return _tensor(_np.random.permutation(int(n)).astype(dtype), copy=False)
+
 def _cross_entropy(logits, targets, reduction='mean'):
     log_probs = _log_softmax(logits, dim=-1)
     targets = _np.asarray(targets, dtype=_np.int64)
@@ -268,6 +305,8 @@ torch.empty = lambda *size, dtype=_np.float32, **_kwargs: _tensor(_np.empty(_sha
 torch.full = lambda size, fill_value, dtype=None, **_kwargs: _tensor(_np.full(_shape(size), fill_value, dtype=dtype), copy=False)
 torch.rand = lambda *size, dtype=_np.float32, **_kwargs: _tensor(_np.random.rand(*_shape_args(size)).astype(dtype), copy=False)
 torch.randn = lambda *size, dtype=_np.float32, **_kwargs: _tensor(_np.random.randn(*_shape_args(size)).astype(dtype), copy=False)
+torch.randint = _randint
+torch.randperm = _randperm
 torch.zeros_like = lambda value, **_kwargs: _tensor(_np.zeros_like(value), copy=False)
 torch.ones_like = lambda value, **_kwargs: _tensor(_np.ones_like(value), copy=False)
 torch.empty_like = lambda value, **_kwargs: _tensor(_np.empty_like(value), copy=False)
@@ -298,6 +337,9 @@ torch.argmin = lambda value, dim=None, keepdim=False: _np.argmin(value, axis=_ax
 torch.matmul = lambda left, right: _wrap(_np.matmul(left, right))
 torch.mm = torch.matmul
 torch.bmm = torch.matmul
+torch.einsum = lambda equation, *operands: _wrap(_np.einsum(equation, *operands))
+torch.outer = lambda left, right: _wrap(_np.outer(left, right))
+torch.dot = lambda left, right: _wrap(_np.dot(left, right))
 torch.transpose = lambda value, dim0, dim1: _wrap(_np.swapaxes(value, dim0, dim1))
 torch.permute = lambda value, dims: _wrap(_np.transpose(value, axes=tuple(dims)))
 torch.reshape = lambda value, shape: _wrap(_np.reshape(value, _shape(shape)))
@@ -316,10 +358,14 @@ torch.any = lambda value, dim=None, keepdim=False: _np.any(value, axis=_axis(dim
 torch.unique = lambda value, sorted=True, **_kwargs: _np.unique(value)
 torch.argsort = lambda value, dim=-1, descending=False, stable=False: _np.argsort(-value if descending else value, axis=dim, kind='stable' if stable else None)
 torch.topk = _topk
+torch.sort = _sort
 torch.gather = _gather
 torch.index_select = lambda value, dim, index: _wrap(_np.take(value, _np.asarray(index, dtype=_np.int64), axis=dim))
 torch.numel = lambda value: int(_np.asarray(value).size)
 torch.equal = lambda left, right: bool(_np.array_equal(left, right))
+torch.allclose = lambda left, right, rtol=1e-5, atol=1e-8, **_kwargs: bool(_np.allclose(left, right, rtol=rtol, atol=atol))
+torch.isclose = lambda left, right, rtol=1e-5, atol=1e-8, **_kwargs: _wrap(_np.isclose(left, right, rtol=rtol, atol=atol))
+torch.nan_to_num = lambda value, nan=0.0, posinf=None, neginf=None: _wrap(_np.nan_to_num(value, nan=nan, posinf=posinf, neginf=neginf))
 torch.softmax = _stable_softmax
 torch.log_softmax = _log_softmax
 torch.logsumexp = _logsumexp
@@ -342,12 +388,377 @@ torch.cuda = _cuda
 
 _nn = _types.ModuleType('torch.nn')
 _nn.__path__ = []
+
+class _Parameter(_CompatTensor):
+    def __new__(cls, value, requires_grad=True):
+        obj = _np.array(value, copy=True).view(cls)
+        obj._compat_requires_grad = bool(requires_grad)
+        return obj
+
+    def __array_finalize__(self, source):
+        self._compat_requires_grad = getattr(source, '_compat_requires_grad', True)
+
+    @property
+    def requires_grad(self):
+        return self._compat_requires_grad
+
+    def requires_grad_(self, requires_grad=True):
+        self._compat_requires_grad = bool(requires_grad)
+        return self
+
+class _Module:
+    def __init__(self):
+        object.__setattr__(self, '_parameters', {})
+        object.__setattr__(self, '_buffers', {})
+        object.__setattr__(self, '_non_persistent_buffers', set())
+        object.__setattr__(self, '_modules', {})
+        object.__setattr__(self, 'training', True)
+
+    def __setattr__(self, name, value):
+        if name.startswith('_') or '_modules' not in self.__dict__:
+            object.__setattr__(self, name, value)
+            return
+        if isinstance(value, _Parameter):
+            self._parameters[name] = value
+            self._modules.pop(name, None)
+        elif isinstance(value, _Module):
+            self._modules[name] = value
+            self._parameters.pop(name, None)
+        object.__setattr__(self, name, value)
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+    def forward(self, *_args, **_kwargs):
+        raise NotImplementedError
+
+    def register_parameter(self, name, parameter):
+        setattr(self, name, parameter)
+
+    def register_buffer(self, name, tensor, persistent=True):
+        tensor = None if tensor is None else _tensor(tensor, copy=False)
+        self._buffers[name] = tensor
+        if not persistent:
+            self._non_persistent_buffers.add(name)
+        object.__setattr__(self, name, tensor)
+
+    def add_module(self, name, module):
+        setattr(self, name, module)
+
+    def named_parameters(self, prefix='', recurse=True):
+        for name, parameter in self._parameters.items():
+            if parameter is not None:
+                yield (prefix + ('.' if prefix else '') + name, parameter)
+        if recurse:
+            for module_name, module in self._modules.items():
+                child_prefix = prefix + ('.' if prefix else '') + module_name
+                yield from module.named_parameters(child_prefix, recurse=True)
+
+    def parameters(self, recurse=True):
+        for _, parameter in self.named_parameters(recurse=recurse):
+            yield parameter
+
+    def named_buffers(self, prefix='', recurse=True):
+        for name, buffer in self._buffers.items():
+            if buffer is not None:
+                yield (prefix + ('.' if prefix else '') + name, buffer)
+        if recurse:
+            for module_name, module in self._modules.items():
+                child_prefix = prefix + ('.' if prefix else '') + module_name
+                yield from module.named_buffers(child_prefix, recurse=True)
+
+    def buffers(self, recurse=True):
+        for _, buffer in self.named_buffers(recurse=recurse):
+            yield buffer
+
+    def named_children(self):
+        yield from self._modules.items()
+
+    def children(self):
+        yield from self._modules.values()
+
+    def named_modules(self, memo=None, prefix=''):
+        memo = set() if memo is None else memo
+        if id(self) in memo:
+            return
+        memo.add(id(self))
+        yield prefix, self
+        for name, module in self._modules.items():
+            child_prefix = prefix + ('.' if prefix else '') + name
+            yield from module.named_modules(memo, child_prefix)
+
+    def modules(self):
+        for _, module in self.named_modules():
+            yield module
+
+    def get_submodule(self, target):
+        module = self
+        if target:
+            for atom in target.split('.'):
+                module = getattr(module, atom)
+                if not isinstance(module, _Module):
+                    raise AttributeError(target)
+        return module
+
+    def train(self, mode=True):
+        self.training = bool(mode)
+        for module in self.children():
+            module.train(mode)
+        return self
+
+    def eval(self):
+        return self.train(False)
+
+    def requires_grad_(self, requires_grad=True):
+        for parameter in self.parameters():
+            parameter.requires_grad_(requires_grad)
+        return self
+
+    def state_dict(self):
+        state = {}
+        for name, parameter in self.named_parameters():
+            state[name] = parameter.clone()
+        for name, buffer in self.named_buffers():
+            owner, _, local_name = name.rpartition('.')
+            module = self.get_submodule(owner) if owner else self
+            if local_name not in module._non_persistent_buffers:
+                state[name] = buffer.clone()
+        return state
+
+    def load_state_dict(self, state_dict, strict=True):
+        live = dict(self.named_parameters()) | dict(self.named_buffers())
+        missing = [name for name in live if name not in state_dict]
+        unexpected = [name for name in state_dict if name not in live]
+        for name, value in state_dict.items():
+            if name in live:
+                live[name].copy_(value)
+        if strict and (missing or unexpected):
+            raise RuntimeError('missing=' + repr(missing) + ', unexpected=' + repr(unexpected))
+        return _types.SimpleNamespace(missing_keys=missing, unexpected_keys=unexpected)
+
+    def to(self, *_args, **_kwargs):
+        return self
+
+    def apply(self, fn):
+        for child in self.children():
+            child.apply(fn)
+        fn(self)
+        return self
+
+class _ModuleList(_Module):
+    def __init__(self, modules=None):
+        super().__init__()
+        for module in modules or []:
+            self.append(module)
+
+    def append(self, module):
+        self.add_module(str(len(self._modules)), module)
+        return self
+
+    def __len__(self):
+        return len(self._modules)
+
+    def __iter__(self):
+        return iter(self._modules.values())
+
+    def __getitem__(self, index):
+        return list(self._modules.values())[index]
+
+class _ModuleDict(_Module):
+    def __init__(self, modules=None):
+        super().__init__()
+        for name, module in (modules or {}).items():
+            self.add_module(name, module)
+
+    def __getitem__(self, key):
+        return self._modules[key]
+
+    def __iter__(self):
+        return iter(self._modules)
+
+    def items(self):
+        return self._modules.items()
+
+class _ParameterList(_Module):
+    def __init__(self, values=None):
+        super().__init__()
+        for value in values or []:
+            self.append(value)
+
+    def append(self, value):
+        parameter = value if isinstance(value, _Parameter) else _Parameter(value)
+        self.register_parameter(str(len(self._parameters)), parameter)
+        return self
+
+    def __len__(self):
+        return len(self._parameters)
+
+    def __iter__(self):
+        return iter(self._parameters.values())
+
+    def __getitem__(self, index):
+        return list(self._parameters.values())[index]
+
+class _ParameterDict(_Module):
+    def __init__(self, values=None):
+        super().__init__()
+        for name, value in (values or {}).items():
+            parameter = value if isinstance(value, _Parameter) else _Parameter(value)
+            self.register_parameter(name, parameter)
+
+    def __getitem__(self, key):
+        return self._parameters[key]
+
+    def items(self):
+        return self._parameters.items()
+
+class _Sequential(_Module):
+    def __init__(self, *modules):
+        super().__init__()
+        for module in modules:
+            self.add_module(str(len(self._modules)), module)
+
+    def forward(self, value):
+        for module in self._modules.values():
+            value = module(value)
+        return value
+
+    def __iter__(self):
+        return iter(self._modules.values())
+
+class _Linear(_Module):
+    def __init__(self, in_features, out_features, bias=True):
+        super().__init__()
+        scale = 1.0 / max(1, int(in_features)) ** 0.5
+        self.weight = _Parameter(_np.random.uniform(-scale, scale, (out_features, in_features)))
+        self.bias = _Parameter(_np.random.uniform(-scale, scale, out_features)) if bias else None
+
+    def forward(self, value):
+        output = _np.matmul(value, self.weight.T)
+        if self.bias is not None:
+            output = output + self.bias
+        return _wrap(output)
+
+class _ReLU(_Module):
+    def forward(self, value):
+        return _wrap(_np.maximum(value, 0))
+
+class _Dropout(_Module):
+    def __init__(self, p=0.5):
+        super().__init__()
+        self.p = float(p)
+
+    def forward(self, value):
+        if not self.training or self.p == 0:
+            return value
+        keep = _np.random.random(_np.asarray(value).shape) >= self.p
+        return _wrap(_np.asarray(value) * keep / (1.0 - self.p))
+
+class _Identity(_Module):
+    def forward(self, value):
+        return value
+
+_nn.Module = _Module
+_nn.Parameter = _Parameter
+_nn.ModuleList = _ModuleList
+_nn.ModuleDict = _ModuleDict
+_nn.ParameterList = _ParameterList
+_nn.ParameterDict = _ParameterDict
+_nn.Sequential = _Sequential
+_nn.Linear = _Linear
+_nn.ReLU = _ReLU
+_nn.Dropout = _Dropout
+_nn.Identity = _Identity
 _functional = _types.ModuleType('torch.nn.functional')
 _functional.softmax = _stable_softmax
 _functional.log_softmax = _log_softmax
 _functional.cross_entropy = _cross_entropy
+_functional.relu = lambda value, inplace=False: _wrap(_np.maximum(value, 0))
+_functional.linear = lambda value, weight, bias=None: _wrap(_np.matmul(value, weight.T) + (0 if bias is None else bias))
 _nn.functional = _functional
 torch.nn = _nn
+
+class _Dataset:
+    pass
+
+class _IterableDataset(_Dataset):
+    pass
+
+class _TensorDataset(_Dataset):
+    def __init__(self, *tensors):
+        if tensors and any(len(tensor) != len(tensors[0]) for tensor in tensors[1:]):
+            raise ValueError('all tensors must have the same first dimension')
+        self.tensors = tensors
+
+    def __len__(self):
+        return 0 if not self.tensors else len(self.tensors[0])
+
+    def __getitem__(self, index):
+        return tuple(_wrap(tensor[index]) for tensor in self.tensors)
+
+def _default_collate(batch):
+    first = batch[0]
+    if isinstance(first, tuple):
+        return tuple(_wrap(_np.stack(values, axis=0)) for values in zip(*batch))
+    if isinstance(first, dict):
+        return {key: _wrap(_np.stack([item[key] for item in batch], axis=0)) for key in first}
+    return _wrap(_np.stack(batch, axis=0))
+
+class _DataLoader:
+    def __init__(
+        self,
+        dataset,
+        batch_size=1,
+        shuffle=False,
+        sampler=None,
+        batch_sampler=None,
+        collate_fn=None,
+        drop_last=False,
+        **_kwargs,
+    ):
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.sampler = sampler
+        self.batch_sampler = batch_sampler
+        self.collate_fn = collate_fn or _default_collate
+        self.drop_last = drop_last
+
+    def __iter__(self):
+        if self.batch_sampler is not None:
+            batches = self.batch_sampler
+        else:
+            indices = list(self.sampler) if self.sampler is not None else list(range(len(self.dataset)))
+            if self.shuffle:
+                _np.random.shuffle(indices)
+            if self.batch_size is None:
+                for index in indices:
+                    yield self.dataset[index]
+                return
+            batches = [indices[start:start + self.batch_size] for start in range(0, len(indices), self.batch_size)]
+        for indices in batches:
+            if self.drop_last and len(indices) < self.batch_size:
+                continue
+            yield self.collate_fn([self.dataset[index] for index in indices])
+
+    def __len__(self):
+        if self.batch_sampler is not None:
+            return len(self.batch_sampler)
+        if self.batch_size is None:
+            return len(self.dataset)
+        size = len(self.dataset) // self.batch_size
+        return size if self.drop_last or len(self.dataset) % self.batch_size == 0 else size + 1
+
+_utils = _types.ModuleType('torch.utils')
+_utils.__path__ = []
+_data = _types.ModuleType('torch.utils.data')
+_data.Dataset = _Dataset
+_data.IterableDataset = _IterableDataset
+_data.TensorDataset = _TensorDataset
+_data.DataLoader = _DataLoader
+_data.default_collate = _default_collate
+_utils.data = _data
+torch.utils = _utils
 
 _linalg = _types.ModuleType('torch.linalg')
 _linalg.norm = _norm
@@ -358,4 +769,6 @@ _sys.modules['torch.nn'] = _nn
 _sys.modules['torch.nn.functional'] = _functional
 _sys.modules['torch.linalg'] = _linalg
 _sys.modules['torch.cuda'] = _cuda
+_sys.modules['torch.utils'] = _utils
+_sys.modules['torch.utils.data'] = _data
 `;

--- a/src/pages/revision_notes.astro
+++ b/src/pages/revision_notes.astro
@@ -14,13 +14,13 @@ import SectionHeader from '../components/SectionHeader.astro';
   <section class="resource-list">
     <div class="resource-list__header">
       <h2>PyTorch</h2>
-      <a href="https://docs.pytorch.org/docs/2.13/tensors.html">Documentation</a>
+      <a href="https://docs.pytorch.org/docs/2.13/">Documentation</a>
     </div>
     <ul>
       <li>
         <div>
-          <strong>Tensor fundamentals</strong>
-          <p>Construction, factories, metadata, views, indexing, joining, reshaping, and mutation.</p>
+          <strong>PyTorch core and systems</strong>
+          <p>Tensors, autograd, modules, data loading, training, compilation, accelerators, distributed execution, and debugging.</p>
         </div>
         <span>
           <a href="/revision notes/2026/08/09/pytorch-tensor-revision-notes.html">My notes</a>


### PR DESCRIPTION
## Summary
- expand the tensor note into a staff-level PyTorch 2.13 revision reference covering tensors, autograd, modules, data loading, training, compilation, devices, distributed execution, and debugging
- replace the reference/runnable split with 14 compact runnable-only CodeMirror workspaces
- add a browser-compatible teaching layer for tensor, module, container, and data-loading drills, with NumPy comparisons throughout

## Validation
- npm run ci
- all 14 browser exercises executed successfully
- desktop and 390 px responsive QA
- all linked PyTorch and NumPy sources returned HTTP 200