### PR TITLE
Expand PyTorch revision reading path

### DIFF
--- a/src/content/posts/pytorch-autograd-and-training.md
+++ b/src/content/posts/pytorch-autograd-and-training.md
@@ -1,0 +1,55 @@
+---
+title: PyTorch Autograd and Training
+date: '2026-08-10T04:00:00.000Z'
+section: revision-notes
+postSlug: pytorch-autograd-and-training
+legacyPath: /revision notes/2026/08/10/pytorch-autograd-and-training.html
+tags:
+  - PyTorch
+summary: A focused route through autograd graphs, gradient accumulation, modules, optimization, evaluation, and checkpointing.
+---
+
+# PyTorch Autograd and Training
+
+## Quick overview
+
+Training is a controlled sequence: construct registered state, run a forward computation, reduce to a loss, differentiate, process gradients, update parameters, and evaluate under a separate module mode. This note makes the boundaries between those steps explicit.
+
+This is the second part of the [PyTorch Revision Notes](/revision%20notes/2026/08/09/pytorch-tensor-revision-notes.html). Start with [Tensor mechanics](/revision%20notes/2026/08/10/pytorch-tensor-mechanics.html) if shape, storage, or device behavior is unclear.
+
+## Backward is a vector-Jacobian product
+
+PyTorch records operations when grad mode is enabled and at least one input requires gradients. A scalar output can call `.backward()` directly. A non-scalar output needs an upstream gradient, because backward computes a vector-Jacobian product rather than materializing a full Jacobian.
+
+```python
+x = torch.tensor([1.0, 2.0], requires_grad=True)
+y = x ** 2
+y.backward(torch.ones_like(y))
+print(x.grad)  # tensor([2., 4.])
+```
+
+Only leaf tensors accumulate into `.grad` by default. Non-leaf gradients require `retain_grad()`, and gradients accumulate across backward calls until they are cleared. `torch.autograd.grad` is preferable when gradients should be returned as values rather than accumulated as state.
+
+## Gradient modes do different jobs
+
+`detach()` removes a tensor from the graph but normally shares storage. `torch.no_grad()` temporarily prevents graph construction and is useful for updates or preprocessing. `torch.inference_mode()` removes more autograd tracking for isolated inference. `model.eval()` changes mode-dependent module behavior such as Dropout and BatchNorm; it does not disable gradients.
+
+## The training invariant
+
+The ordinary update is `zero_grad → forward → loss → backward → optional clipping or scaling → optimizer.step`. Use `optimizer.zero_grad(set_to_none=True)` when the distinction between “no gradient” and “zero gradient” is useful. Construct the optimizer after parameters are materialized and placed on the intended device.
+
+AMP changes the order around gradient processing: autocast covers forward and loss, `GradScaler` scales the loss for float16, and gradients must be unscaled before clipping or inspection. Evaluation sets `model.eval()` and disables autograd separately.
+
+## State and checkpoints
+
+`nn.Module` registers parameters, buffers, and child modules into a state tree. Use `ModuleList` and `ModuleDict` instead of ordinary Python containers when state must move, serialize, or reach the optimizer. Save `state_dict()` rather than pickling an entire module; resumable training may also require optimizer, scheduler, scaler, step, configuration, RNG, and sampler state.
+
+## Retrieval hook
+
+When a training result is wrong, inspect the boundary in order: did the model receive the intended batch, did the loss depend on the parameters, did gradients arrive, were they scaled or clipped correctly, and did the optimizer update the same registered parameters?
+
+## Source links
+
+- [Autograd mechanics](https://docs.pytorch.org/docs/2.13/notes/autograd.html)
+- [PyTorch Interview Preparation: autograd basics](https://github.com/rohanmistry231/PyTorch-Interview-Preparation/blob/main/PyTorch%20Fundamentals/01%20Core%20PyTorch%20Foundations/02%20Autograd/autograd_basics.py)
+- [PyTorch Interview Preparation](https://github.com/rohanmistry231/PyTorch-Interview-Preparation)

--- a/src/content/posts/pytorch-systems-and-scale.md
+++ b/src/content/posts/pytorch-systems-and-scale.md
@@ -1,0 +1,47 @@
+---
+title: PyTorch Systems and Scale
+date: '2026-08-10T04:00:00.000Z'
+section: revision-notes
+postSlug: pytorch-systems-and-scale
+legacyPath: /revision notes/2026/08/10/pytorch-systems-and-scale.html
+tags:
+  - PyTorch
+summary: A focused route through data loading, compilation, devices, memory, distributed execution, profiling, and deployment boundaries.
+---
+
+# PyTorch Systems and Scale
+
+## Quick overview
+
+Once tensor and training contracts are correct, performance work is a systems problem. Data loading, device transfers, compilation, memory lifetime, communication, and serialization each add a boundary that must be measured rather than inferred from isolated FLOPs.
+
+This is the third part of the [PyTorch Revision Notes](/revision%20notes/2026/08/09/pytorch-tensor-revision-notes.html). Use [Autograd and training](/revision%20notes/2026/08/10/pytorch-autograd-and-training.html) first when the issue is a wrong gradient or update.
+
+## Data and device boundaries
+
+`Dataset` defines sample access; `DataLoader` defines ordering, batching, collation, workers, and optional pinned-memory staging. Begin debugging with `num_workers=0`, then add workers only after dataset state and sharding are correct. Pinned memory can help CPU-to-CUDA transfer overlap when paired with `non_blocking=True`, but it consumes a limited host resource.
+
+Select a device once, place model state deliberately, and move each batch at the boundary. CUDA work is asynchronous with respect to the host, so `item()`, printing, and CPU conversions can synchronize unexpectedly.
+
+## Compile only after the eager program is understood
+
+`torch.compile` captures regions of Python into graphs and specializes them under guards. Warm up before benchmarking. Graph breaks, recompilations, dynamic shapes, and unsupported extensions can erase a kernel-level speedup. Use compiler logs and representative traces before changing private configuration knobs.
+
+## Memory and distributed execution
+
+Distinguish live tensor memory from allocator-reserved memory. Activation checkpointing, lower precision, shorter sequences, sharding, and fewer retained graph references address different causes of memory pressure. In distributed training, DDP replicates parameters and reduces gradients; FSDP shards model state and gathers parameters around computation. Every rank must execute collectives in compatible order.
+
+## Measure the executed system
+
+Use profiler schedules, CUDA events, allocator snapshots, and statistically controlled microbenchmarks. Report end-to-end step time, input staging, synchronization, peak memory, and communication—not only the fastest isolated kernel. A faster operation does not improve training if the data pipeline or collective waits dominate.
+
+## Retrieval hook
+
+Profile in this order: input readiness, model execution, synchronization, memory movement, and communication. The first boundary that consumes the budget determines the next optimization.
+
+## Source links
+
+- [PyTorch compile programming model](https://docs.pytorch.org/docs/2.13/user_guide/torch_compiler/compile/programming_model.html)
+- [CUDA semantics](https://docs.pytorch.org/docs/2.13/notes/cuda.html)
+- [Distributed communication](https://docs.pytorch.org/docs/2.13/distributed.html)
+- [PyTorch Interview Preparation](https://github.com/rohanmistry231/PyTorch-Interview-Preparation)

--- a/src/content/posts/pytorch-tensor-mechanics.md
+++ b/src/content/posts/pytorch-tensor-mechanics.md
@@ -1,0 +1,53 @@
+---
+title: PyTorch Tensor Mechanics
+date: '2026-08-10T04:00:00.000Z'
+section: revision-notes
+postSlug: pytorch-tensor-mechanics
+legacyPath: /revision notes/2026/08/10/pytorch-tensor-mechanics.html
+tags:
+  - PyTorch
+summary: A focused route through tensor construction, metadata, views, indexing, broadcasting, and layout decisions.
+---
+
+# PyTorch Tensor Mechanics
+
+## Quick overview
+
+The fastest way to debug tensor code is to predict the tensor's shape, dtype, device, and aliasing before reading its values. This note follows one object through construction, storage metadata, indexing, broadcasting, and layout changes.
+
+This is the first part of the [PyTorch Revision Notes](/revision%20notes/2026/08/09/pytorch-tensor-revision-notes.html). Continue with [Autograd and training](/revision%20notes/2026/08/10/pytorch-autograd-and-training.html) once the tensor contract is clear.
+
+## Construction is a copy or sharing decision
+
+`torch.tensor(data)` copies its input and creates a fresh leaf by default. `torch.as_tensor` avoids a copy where possible, `torch.from_numpy` intentionally shares CPU storage with a NumPy array, and `torch.frombuffer` exposes a Python buffer. The choice is part of the tensor's correctness contract because mutation, dtype conversion, and device placement can change what is shared.
+
+Factory functions make allocation intent explicit. The `*_like` family starts from an existing tensor's shape and, by default, its dtype, layout, and device; pass overrides when those properties should differ. `torch.empty` allocates without initializing values, so every element must be overwritten before it is read.
+
+## Metadata maps indices to storage
+
+A strided tensor is a logical array described by shape, strides, and storage offset. For index $(i_0, \ldots, i_{n-1})$, its storage position is
+
+$$
+\text{storage\_offset} + \sum_{k=0}^{n-1} i_k\,\text{stride}_k.
+$$
+
+This is why a slice or transpose can be cheap: it can change metadata without moving values. The same mechanism creates non-contiguity and aliasing. `view` requires compatible strides; `reshape` may return a view or make a copy; `clone` copies while preserving gradient connectivity; and `detach` removes the autograd edge while normally sharing storage.
+
+## Indexing and broadcasting change the logical view
+
+Integer indexing removes a dimension, slicing preserves it, `None` inserts one, and advanced indexing copies selected values. Assignment through either basic or advanced indexing mutates the destination. Broadcasting aligns dimensions from the right; dimensions are compatible when equal or when one is `1`. `expand` represents the larger logical shape with zero strides, so it should not be treated as independent writable storage.
+
+## Layout is an API contract
+
+Dense `torch.strided` tensors are the default, but channels-last, sparse, quantized, nested, and jagged layouts change operator support and memory behavior. Inspect layout and contiguity at boundaries where a downstream operator depends on them. Use a specialized layout only when its supported operator sequence and measured workload justify the additional invariants.
+
+## Retrieval hook
+
+Before changing tensor code, write down: `shape → dtype → device → layout → strides → aliasing`. That sequence exposes most silent copies, invalid broadcasts, and in-place view bugs.
+
+## Source links
+
+- [PyTorch 2.13 tensors](https://docs.pytorch.org/docs/2.13/tensors.html)
+- [Tensor attributes](https://docs.pytorch.org/docs/2.13/tensor_attributes.html)
+- [Tensor views](https://docs.pytorch.org/docs/2.13/tensor_view.html)
+- [PyTorch Interview Preparation](https://github.com/rohanmistry231/PyTorch-Interview-Preparation)

--- a/src/content/posts/pytorch-tensor-revision-notes.mdx
+++ b/src/content/posts/pytorch-tensor-revision-notes.mdx
@@ -387,6 +387,7 @@ Use this as a retrieval map. The public namespace is too large for a useful flat
 ## Source links
 
 - [PyTorch 2.13 documentation](https://docs.pytorch.org/docs/2.13/)
+- [PyTorch Interview Preparation](https://github.com/rohanmistry231/PyTorch-Interview-Preparation) — an additional checklist of fundamentals, intermediate patterns, distributed training, deployment, and interview questions.
 - [Tensors](https://docs.pytorch.org/docs/2.13/tensors.html), [tensor attributes](https://docs.pytorch.org/docs/2.13/tensor_attributes.html), and [tensor views](https://docs.pytorch.org/docs/2.13/tensor_view.html)
 - [Broadcasting semantics](https://docs.pytorch.org/docs/2.13/notes/broadcasting.html) and [numerical accuracy](https://docs.pytorch.org/docs/2.13/notes/numerical_accuracy.html)
 - [Autograd mechanics](https://docs.pytorch.org/docs/2.13/notes/autograd.html) and [extending autograd](https://docs.pytorch.org/docs/2.13/notes/extending.html)

--- a/src/lib/pytorch-revision-examples.ts
+++ b/src/lib/pytorch-revision-examples.ts
@@ -159,25 +159,27 @@ print("L2 norm:", torch.norm(logits, p=2, dim=-1))
   },
 
   autograd: {
-    title: 'Gradient flow and finite-difference checks',
+    title: 'Autograd: backward, accumulation, and gradient modes',
     initialCode: `import torch
 
-def objective(x):
-    return torch.sum(torch.sin(x) * x ** 2)
+scalar = torch.tensor(3.0, requires_grad=True)
+scalar_output = scalar ** 2
+scalar_output.backward()
+print("d(scalar ** 2) / dscalar:", scalar.grad)
 
-x = torch.tensor([0.2, -0.4, 0.8], dtype=torch.float64)
-epsilon = 1e-6
-numerical_grad = torch.zeros_like(x)
+vector = torch.tensor([1.0, 2.0], requires_grad=True)
+vector_output = vector ** 2
+vector_output.backward(torch.ones_like(vector_output))
+print("vector-Jacobian product:", vector.grad)
 
-for index in range(x.shape[0]):
-    step = torch.zeros_like(x)
-    step[index] = epsilon
-    numerical_grad[index] = (objective(x + step) - objective(x - step)) / (2 * epsilon)
+vector.grad.zero_()
+second_output = (vector ** 2).sum()
+second_output.backward()
+print("after clearing and backward:", vector.grad)
 
-analytic_grad = 2 * x * torch.sin(x) + x ** 2 * torch.cos(x)
-print("finite difference:", numerical_grad)
-print("analytic:", analytic_grad)
-print("close:", torch.allclose(numerical_grad, analytic_grad, rtol=1e-5, atol=1e-7))
+with torch.no_grad():
+    vector -= 0.1 * vector.grad
+print("updated without recording the update:", vector)
 `,
   },
 

--- a/src/pages/revision_notes.astro
+++ b/src/pages/revision_notes.astro
@@ -8,7 +8,7 @@ import SectionHeader from '../components/SectionHeader.astro';
     eyebrow="Revision Notes"
     title="PyTorch and CS336"
     description="Course notes, references, and implementation details for PyTorch and language modeling."
-    meta="3 notes"
+    meta="6 notes"
   />
 
   <section class="resource-list">
@@ -24,6 +24,9 @@ import SectionHeader from '../components/SectionHeader.astro';
         </div>
         <span>
           <a href="/revision notes/2026/08/09/pytorch-tensor-revision-notes.html">My notes</a>
+          <a href="/revision notes/2026/08/10/pytorch-tensor-mechanics.html">Tensor mechanics</a>
+          <a href="/revision notes/2026/08/10/pytorch-autograd-and-training.html">Autograd and training</a>
+          <a href="/revision notes/2026/08/10/pytorch-systems-and-scale.html">Systems and scale</a>
         </span>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- add focused Tensor Mechanics, Autograd and Training, and Systems and Scale revision notes
- make the autograd playground demonstrate backward, vector-Jacobian products, accumulation, and no-grad updates
- link the upstream PyTorch Interview Preparation repository as a source and add the new notes to the Revision Notes index
- preserve the existing PyTorch revision-note URL

## Validation
- npm run ci

## Source
- https://github.com/rohanmistry231/PyTorch-Interview-Preparation