### PR TITLE
Rewrite PyTorch notes in plain technical prose

### DIFF
--- a/src/content/posts/pytorch-autograd-and-training.mdx
+++ b/src/content/posts/pytorch-autograd-and-training.mdx
@@ -6,7 +6,7 @@ postSlug: pytorch-autograd-and-training
 legacyPath: /revision notes/2026/08/10/pytorch-autograd-and-training.html
 tags:
   - PyTorch
-summary: Follow tensors through the dynamic autograd graph, registered module state, gradient accumulation, optimization, evaluation, and checkpoints.
+summary: Derive how PyTorch records operations, computes gradients, registers model state, updates parameters, loads data, and saves training state.
 ---
 import RevisionCodePair from '../../components/RevisionCodePair.astro';
 import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
@@ -15,22 +15,22 @@ import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
 
 ## From tensors to gradients
 
-[Part I](/revision%20notes/2026/08/09/pytorch-tensor-revision-notes.html) treated a tensor as metadata over storage. Training adds one question: how did the loss depend on this tensor? PyTorch answers by recording tensor operations during the forward pass and replaying their local derivatives in reverse.
+[Part I](/revision%20notes/2026/08/09/pytorch-tensor-revision-notes.html) described how a tensor maps logical indices to stored values. Training also needs the sequence of operations that produced each value. When grad mode is active and an input requires gradients, PyTorch records those operations during the forward pass. Backward traverses the recorded graph in reverse and applies the chain rule.
 
-That single mechanism connects autograd, `nn.Module`, optimizers, gradient modes, and checkpoints. Autograd computes derivatives with respect to leaf tensors; modules register the leaves and persistent state that define a model; optimizers mutate those leaves; checkpoints serialize enough state to continue the same trajectory. By the end of this part, those APIs should feel like one system rather than separate features.
+The rest of the training API organizes state around this graph. `nn.Module` registers parameters and buffers. A loss reduces model outputs to the objective being differentiated. Backward accumulates gradients on leaf tensors, and an optimizer uses those gradients to update parameters. A checkpoint stores the state needed to reproduce or continue this process.
 
 ## The autograd graph
 
-When grad mode is enabled and at least one input requires gradients, PyTorch records an operation as a `Function` node. The output points to that node through `grad_fn`, and the node remembers the dependencies or saved tensors needed by its backward rule. Ordinary Python control flow can change which operations run, so the graph is rebuilt on every forward pass.
+Each recorded tensor operation creates a node whose backward rule knows how to propagate an incoming gradient to its inputs. The output tensor refers to that node through `grad_fn`. The node may also save tensors from the forward pass when its derivative depends on their values. Because PyTorch records the operations that actually execute, Python branches and loops can produce a different graph on each forward pass.
 
-Consider a linear model followed by mean-squared error:
+For a linear model with mean-squared error,
 
 $$
 \hat{y} = Xw + b, \qquad
 L = \frac{1}{B}\sum_{i=1}^{B}(\hat{y}_i-y_i)^2.
 $$
 
-The forward pass produces a scalar loss from parameters `w` and `b`. Backward starts with $\partial L / \partial L = 1$ and repeatedly applies the chain rule:
+The forward pass maps the parameters $w$ and $b$ to the scalar $L$. Backward begins with $\partial L / \partial L = 1$ and applies the local derivatives in reverse order:
 
 $$
 \frac{\partial L}{\partial \hat{y}} = \frac{2}{B}(\hat{y}-y), \qquad
@@ -38,11 +38,11 @@ $$
 \frac{\partial L}{\partial b} = \sum_i\frac{\partial L}{\partial \hat{y}_i}.
 $$
 
-Autograd does not symbolically derive one giant formula. Each recorded operation receives an upstream vector and applies its local vector-Jacobian product. This is reverse-mode differentiation: efficient when one scalar objective depends on many parameters.
+PyTorch does not construct one symbolic expression for the full derivative. Each node computes a vector-Jacobian product for its own operation. Reverse-mode differentiation is efficient for neural-network training because one scalar loss usually depends on many parameters.
 
 ## Vector-Jacobian products
 
-`loss.backward()` is shorthand for `loss.backward(torch.ones_like(loss))`, which works naturally when `loss` has one element. A non-scalar output needs an explicit `gradient` argument because there is no unique derivative of a vector output without choosing how its components are weighted.
+For a scalar `loss`, `loss.backward()` supplies an upstream gradient of one. A tensor with more than one element requires an explicit `gradient` argument because its components can be combined in different ways.
 
 ```python
 x = torch.tensor([1.0, 2.0], requires_grad=True)
@@ -51,78 +51,79 @@ y.backward(torch.tensor([1.0, 1.0]))
 print(x.grad)  # tensor([2., 4.])
 ```
 
-The supplied vector selects a vector-Jacobian product. Use `torch.autograd.grad(outputs, inputs, grad_outputs=...)` when gradients should be returned directly instead of accumulated into tensor state. Use `create_graph=True` when the derivative calculation itself must remain differentiable; `retain_graph=True` only preserves the current graph for another traversal and is rarely the right first response to a graph-lifetime error.
+The supplied vector weights the output components and produces a vector-Jacobian product. `torch.autograd.grad(outputs, inputs, grad_outputs=...)` returns gradients directly instead of accumulating them in `.grad`. Set `create_graph=True` when the derivative calculation must itself be differentiated. `retain_graph=True` only prevents the current graph from being released after backward; it does not create the graph needed for higher-order derivatives.
 
-## Leaf tensors and accumulated gradients
+## Leaf tensors and gradients
 
-A leaf is normally a user-created tensor with no `grad_fn`. Leaf tensors with `requires_grad=True` accumulate into `.grad`; intermediate tensors do not retain `.grad` by default because most training loops only need parameter gradients. Call `retain_grad()` when inspecting one specific non-leaf is worth its additional lifetime and memory.
+A user-created tensor with no `grad_fn` is a leaf. If a leaf has `requires_grad=True`, backward adds its gradient to `.grad`. Intermediate tensors do not retain `.grad` by default because parameter gradients are sufficient for the usual training loop. Call `retain_grad()` on a specific intermediate tensor when its gradient is needed for inspection.
 
-Accumulation is intentional. Multiple losses, microbatches, or backward calls can contribute to the same parameter gradient before one optimizer step. The training loop must therefore define its accumulation boundary explicitly. `optimizer.zero_grad(set_to_none=True)` clears that state without writing zeros and preserves a useful distinction: `grad is None` means no gradient arrived, whereas a zero tensor means a gradient path arrived and evaluated to zero.
+Gradients accumulate rather than overwrite. This allows several losses or microbatches to contribute before one optimizer step, but it also means the loop must clear gradients at the correct boundary. `optimizer.zero_grad(set_to_none=True)` removes the current gradient tensors. A later `None` means that no gradient reached the parameter, while a tensor of zeros means that a path reached the parameter and its derivative evaluated to zero.
 
-That distinction is diagnostic. An unexpected `None` gradient points to a disconnected graph, a frozen parameter, an unregistered tensor, or a branch that did not execute. Replacing it with zeros hides the question the program needs to answer.
+An unexpected `None` usually means the parameter was detached, frozen, omitted from the executed branch, or never registered with the model and optimizer. Replacing `None` with zeros removes that diagnostic signal without repairing the graph.
 
 ## In-place operations
 
-A view and its base share storage and an autograd version counter. If backward saved a value and an in-place operation changes it, autograd raises a version-mismatch error instead of differentiating a different program from the one executed forward. The error is evidence that mutation crossed a graph-lifetime boundary.
+Views of the same storage share an autograd version counter. When an operation saves a tensor for backward, PyTorch also records its version. If an in-place operation changes the tensor before backward uses it, the version check fails. This prevents PyTorch from computing a derivative from values that differ from those used in the forward pass.
 
-Prefer out-of-place expressions inside `forward` until the memory benefit of mutation is measured and the derivative rule is understood. For deliberate parameter updates, use an optimizer or `with torch.no_grad():`; `.data` bypasses safety checks and can silently corrupt the relationship between the forward program and its derivatives.
+Use out-of-place operations inside `forward` unless an in-place form has a measured memory benefit and a valid derivative rule. Optimizers update parameters outside graph recording. A manual update should likewise run under `torch.no_grad()`. Avoid `.data`: it bypasses autograd's mutation checks and can produce gradients for a forward computation that no longer exists.
 
 ## Gradient mode and model mode
 
-Four mechanisms are often collapsed into “turn gradients off,” but they change different contracts.
+Autograd state and module mode are separate controls:
 
-| Mechanism | Records operations? | Storage relationship | Changes Dropout or BatchNorm? |
+| Mechanism | Effect on autograd | Storage | Effect on Dropout or BatchNorm |
 | --- | --- | --- | --- |
-| `x.detach()` | The result has no incoming autograd edge. | Normally shares storage with `x`. | No |
-| `torch.no_grad()` | Operations inside are not recorded. | Normal tensor rules still apply. | No |
-| `torch.inference_mode()` | Removes additional autograd tracking for isolated inference. | Outputs should remain outside later grad graphs. | No |
-| `model.eval()` | Does not change grad recording. | No direct effect. | Yes |
+| `x.detach()` | Removes the incoming graph edge from the result | Usually shared with `x` | None |
+| `torch.no_grad()` | Does not record operations in the context | Normal tensor rules | None |
+| `torch.inference_mode()` | Disables autograd bookkeeping more aggressively | Results should stay in inference code | None |
+| `model.eval()` | No effect on graph recording | No direct effect | Selects evaluation behavior |
 
-Use `no_grad` for updates or preprocessing whose results may later re-enter grad mode. Try `inference_mode` for an evaluation path that remains isolated. Always set `train()` or `eval()` when the model contains mode-dependent modules; neither method controls autograd.
+Use `no_grad` for parameter updates and for computations whose results may later be used with autograd. Use `inference_mode` for an isolated inference path after checking compatibility. Call `model.train()` or `model.eval()` whenever the model contains modules whose forward behavior changes by mode. Evaluation usually requires both `model.eval()` and a disabled gradient context.
 
 ## Modules and model state
 
-`nn.Module` gives ordinary Python assignment registration semantics. Assigning an `nn.Parameter` registers trainable state, assigning a child `Module` registers a subtree, and `register_buffer` registers non-optimized tensor state. Recursive methods such as `parameters()`, `state_dict()`, `to()`, `train()`, and distributed wrappers traverse that tree.
+`nn.Module` registers state through attribute assignment. Assigning an `nn.Parameter` registers a trainable tensor. Assigning another `Module` registers a child subtree. `register_buffer` registers tensor state that should move with the module but should not be optimized. Methods such as `parameters()`, `state_dict()`, `to()`, and `train()` traverse this registered tree.
 
-Call `model(inputs)`, not `model.forward(inputs)`, because `Module.__call__` runs hook and call machinery before delegating to `forward`. Call `super().__init__()` before assigning registered members. Store repeated submodules in `ModuleList`, `ModuleDict`, or `Sequential`; a plain Python list is invisible to device movement, serialization, and optimizer construction.
+Call `model(inputs)` rather than `model.forward(inputs)` so that `Module.__call__` can run hooks and other module machinery. Call `super().__init__()` before assigning parameters or child modules. Store repeated modules in `ModuleList`, `ModuleDict`, or `Sequential`; modules stored only in a plain Python list are not visible to device movement, serialization, or parameter discovery.
 
 | State | Optimized? | In `state_dict()`? | Moved by `module.to()`? |
 | --- | --- | --- | --- |
-| `nn.Parameter` | Yes, when passed to the optimizer | Yes | Yes |
+| `nn.Parameter` | Yes, if given to the optimizer | Yes | Yes |
 | Persistent buffer | No | Yes | Yes |
 | Non-persistent buffer | No | No | Yes |
 | Plain tensor attribute | No | No | No |
 
-This tree is the bridge between math and software. `forward` defines how tensors interact; registration defines which values constitute the model across training, evaluation, placement, and recovery.
+`forward` defines the computation. Registration defines which tensors belong to the model across optimization, device placement, serialization, and distributed wrapping. A tensor used by `forward` but absent from the registered tree may compute correctly on one machine and still disappear from the rest of the training system.
 
 ## Loss functions
 
-Every loss has an input contract. `CrossEntropyLoss` normally expects unnormalized class logits and integer class indices. `BCEWithLogitsLoss` combines the sigmoid transformation and binary objective in one stable formulation. `KLDivLoss` distinguishes probabilities from log-probabilities. Passing the right shape with the wrong representation can produce a plausible scalar and still optimize the wrong objective.
+A loss function expects a particular representation, shape, and reduction. `CrossEntropyLoss` usually takes unnormalized class logits and integer class indices. `BCEWithLogitsLoss` takes logits and combines the sigmoid with the binary cross-entropy calculation. `KLDivLoss` distinguishes log-probabilities from probabilities. A loss can return a plausible scalar even when the caller supplied the wrong representation, so shape checks alone are insufficient.
 
-The same principle separates `nn` modules from `torch.nn.functional`. A module owns parameters, buffers, mode, hooks, or serialization identity; a functional call receives all state explicitly. Use the form that makes state ownership visible. A `Linear` module owns weight and bias, while `F.linear(input, weight, bias)` computes the same operation from explicit tensors.
+The distinction between `nn` modules and `torch.nn.functional` is also about state. A module may own parameters, buffers, mode, hooks, and serialization identity. A functional call receives the required state as arguments. `nn.Linear` owns its weight and bias; `F.linear(input, weight, bias)` performs the same calculation with explicit tensors.
 
 ## Training loop
 
-The canonical iteration is
+A standard training iteration has the following order:
 
 ```text
-clear gradients → fetch batch → forward → scalar loss → backward
-→ unscale if needed → inspect or clip → optimizer step → scheduler step if due
+clear gradients → load batch → forward → compute loss → backward
+→ unscale if needed → inspect or clip gradients → optimizer step
+→ scheduler step if due
 ```
 
-Each arrow moves or mutates specific state. The batch crosses a device boundary, the forward pass creates activations and a graph, backward accumulates parameter gradients, and the optimizer consumes those gradients while updating parameters and optimizer state such as momentum. Reordering steps changes the algorithm.
+The order determines which state each operation reads. Forward saves activations for the current parameters. Backward adds gradients computed from those activations. The optimizer reads the gradients and changes the parameters and optimizer state. Moving a step changes the algorithm; for example, clipping before AMP unscaling clips scaled values rather than the gradients used by the optimizer.
 
-Gradient accumulation intentionally repeats forward and backward before stepping. Divide each microbatch loss by the accumulation count when matching a mean-gradient objective, account for a short final window, and under DDP use `no_sync()` only on non-step microbatches. Gradient clipping belongs after AMP unscaling and before the optimizer step; log the pre-clipped norm because clipping can hide a bad learning rate, objective, or batch.
+Gradient accumulation repeats forward and backward over several microbatches before the optimizer step. Divide each microbatch loss by the accumulation count when matching the gradient of a mean over the combined batch, and handle a short final accumulation window explicitly. Under DDP, `no_sync()` should cover only microbatches that do not perform the optimizer step.
 
-Autocast is operator-specific mixed precision, not a blanket cast of the model. Wrap forward and loss, leave the context before backward, and use `GradScaler` primarily for float16 underflow. Bfloat16 retains float32-like exponent range and often does not require scaling, but numerical validation—not the dtype name—decides.
+Autocast selects lower precision for supported operations while retaining higher precision where needed. It should wrap the forward pass and loss, not the optimizer update or backward call. `GradScaler` is mainly used to protect float16 gradients from underflow. Bfloat16 has a wider exponent range and often runs without scaling, but the correct choice depends on numerical tests for the model and hardware.
 
 ## Gradient exercise
 
-The code expands one backward pass into its local derivative calculations. Predict each gradient's sign, run the code, then change the initial `weight` or batch values and compare the new gradients.
+The code writes out the derivative of the linear model above. Predict the signs of `grad_weight` and `grad_bias`, run the code, then change the initial parameter values or input batch.
 
 <RevisionCodePair {...pytorchRevisionExamples.gradientIntuition} />
 
-Real PyTorch replaces the handwritten derivative block with:
+With autograd, the handwritten derivative is replaced by:
 
 ```python
 weight = torch.tensor([[0.0]], requires_grad=True)
@@ -131,21 +132,21 @@ loss = torch.mean((x @ weight + bias - target) ** 2)
 loss.backward()
 ```
 
-The gradients match because both procedures apply the same chain rule. Autograd's value is not different calculus; it reliably composes local derivative rules across a dynamic tensor program.
+Both versions compute the same chain rule. Autograd provides the composition: each recorded operation contributes its local vector-Jacobian product, and backward combines those products along every path from the loss to the parameters.
 
 ## Data loading
 
-A map-style `Dataset` implements indexed sample access; an `IterableDataset` owns iteration for streams or sources without random indexing. `DataLoader` combines sampling, batching, collation, worker processes, and optional pinned-memory staging. `collate_fn` is where a list of samples becomes one batch, so it owns padding, stacking, ragged structure, and batch-level metadata.
+A map-style `Dataset` maps an index to a sample. An `IterableDataset` defines an iteration stream for data that is not naturally indexed. `DataLoader` adds sampling, batching, collation, worker processes, and optional pinned-memory staging. `collate_fn` converts a list of samples into a batch and therefore owns padding, stacking, ragged structure, and batch-level metadata.
 
-Start debugging with `num_workers=0` for direct tracebacks. Multiple workers replicate Python dataset state; iterable datasets must shard with `get_worker_info()` to avoid duplicates. `persistent_workers` saves process startup across epochs, `prefetch_factor` controls queued batches, and pinned memory can support asynchronous CPU-to-CUDA copies when the transfer uses `non_blocking=True`. Each option changes resource use as well as throughput.
+Use `num_workers=0` first when debugging so data errors appear in the main process. With multiple workers, Python dataset state is copied into each worker. An iterable dataset must use `get_worker_info()` to partition the stream and avoid duplicate samples. `persistent_workers` avoids restarting workers each epoch, `prefetch_factor` changes the number of queued batches, and pinned memory can support non-blocking CPU-to-CUDA copies. These settings affect memory and contention as well as throughput.
 
 ## Checkpoints
 
-A module `state_dict` contains parameters and persistent buffers. The returned mapping is shallow and refers to live state, so clone values when an in-memory snapshot must survive later updates. `load_state_dict(strict=True)` requires exact keys; `strict=False` returns missing and unexpected keys that should be reviewed rather than discarded silently.
+`state_dict()` returns references to a module's parameters and persistent buffers. Clone the tensors when an in-memory snapshot must remain unchanged while training continues. `load_state_dict(strict=True)` requires matching keys. With `strict=False`, inspect the returned missing and unexpected keys rather than ignoring them.
 
-A resumable checkpoint may need model, optimizer, scheduler, scaler, global step, configuration, RNG states, and data-sampler progress. Saving only weights restores a function but not necessarily the same training trajectory. Load with an explicit `map_location`, prefer `weights_only=True` where applicable, and never unrestrictedly unpickle an untrusted legacy checkpoint.
+A checkpoint for inference may need only model weights and configuration. Exact training continuation can also require optimizer and scheduler state, AMP scaler state, global step, random-number-generator states, and sampler position. Loading only the weights restores a parameterized function but not the optimizer trajectory or data order. Use an explicit `map_location`, prefer `weights_only=True` when applicable, and do not load an untrusted pickle with unrestricted deserialization.
 
-At this point the model is mathematically and operationally defined: tensors have contracts, autograd produces gradients, modules own state, and the loop advances that state. [Part III: Performance and Scale](/revision%20notes/2026/08/10/pytorch-systems-and-scale.html) asks how the same program behaves when execution becomes asynchronous, compiled, memory-bound, or distributed.
+The training loop above defines the computation and state updates. [Part III: Performance and Scale](/revision%20notes/2026/08/10/pytorch-systems-and-scale.html) examines how the same loop behaves when execution is asynchronous, memory is limited, graphs are compiled, or model state is split across processes.
 
 ## Sources
 

--- a/src/content/posts/pytorch-systems-and-scale.mdx
+++ b/src/content/posts/pytorch-systems-and-scale.mdx
@@ -6,7 +6,7 @@ postSlug: pytorch-systems-and-scale
 legacyPath: /revision notes/2026/08/10/pytorch-systems-and-scale.html
 tags:
   - PyTorch
-summary: Connect eager tensor semantics to accelerators, compilation, memory lifetime, distributed execution, profiling, reproducibility, and export.
+summary: Analyze PyTorch execution through device transfers, streams, memory lifetime, compilation, distributed training, export, and profiling.
 ---
 import RevisionCodePair from '../../components/RevisionCodePair.astro';
 import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
@@ -15,31 +15,31 @@ import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
 
 ## From training code to execution
 
-[Part I](/revision%20notes/2026/08/09/pytorch-tensor-revision-notes.html) established how tensors map logical indices to storage. [Part II](/revision%20notes/2026/08/10/pytorch-autograd-and-training.html) turned tensor operations into a differentiable state-transition protocol. Systems work asks where that protocol waits, allocates, recompiles, communicates, or loses reproducibility.
+[Part I](/revision%20notes/2026/08/09/pytorch-tensor-revision-notes.html) described tensor representation. [Part II](/revision%20notes/2026/08/10/pytorch-autograd-and-training.html) described the forward pass, backward pass, and parameter update. Performance depends on how that work is scheduled: where tensors are stored, when kernels run, how long intermediate values remain live, and when processes exchange data.
 
-The governing rule is simple: optimize the executed system, not an isolated expression. A kernel can use fewer FLOPs and make the step slower through poor memory access; compilation can fuse operations and lose the gain to recompilation; more data workers can increase contention; sharding can reduce memory and expose communication. Every optimization changes a resource boundary, so every claim needs a trace from a representative workload.
+The source code does not show all of these costs. A shorter expression may launch more kernels. A compiled graph may run faster after spending time on compilation. Sharding may reduce memory per device while adding communication. More data workers may increase throughput or create CPU and I/O contention. Measure the complete training or inference step on representative inputs before accepting a local optimization.
 
 ## Devices and data movement
 
-CPU, CUDA, MPS, XPU, and other backends differ in operator and dtype coverage. Select a device deliberately, place model state once, move each batch at the input boundary, and keep intermediate tensors on-device. Scattered `.cuda()` calls hide ownership and make CPU or alternate-accelerator execution harder to reason about.
+PyTorch supports several backends, including CPU, CUDA, MPS, and XPU, with different operator and dtype coverage. Select the device in one place, move registered model state once, and transfer each batch at the input boundary. Intermediate tensors should normally stay on the same device. Scattered `.cuda()` calls make placement hard to audit and tie the code to one backend.
 
-`tensor.to(device=..., dtype=..., non_blocking=..., copy=...)` is the general conversion API. It can return the original tensor when nothing changes, so callers should not assume a fresh allocation. `module.to(...)` recursively mutates registered parameters and buffers and returns the module. This asymmetry follows from Part II: a module is a state tree, while a tensor operation usually returns a value.
+`tensor.to(device=..., dtype=..., non_blocking=..., copy=...)` handles tensor conversion. It may return the original tensor when neither dtype nor device changes. `module.to(...)` instead updates the registered parameters and buffers in the module tree and returns the module. The difference matters when tracking allocation: tensor conversion usually produces a value, while module conversion updates model state.
 
-Pinned host memory can support asynchronous CPU-to-CUDA transfer when `non_blocking=True`, but pinning is not free and asynchronous does not mean automatically overlapped. Useful overlap requires a later host or device operation that can execute while the transfer remains in flight.
+Pinned CPU memory allows CUDA to perform direct memory access for host-to-device copies. With `non_blocking=True`, the Python thread does not wait for the copy to finish. This does not guarantee overlap with useful work: overlap requires independent host work or device work on a stream that can run while the transfer is in progress. Pinning also consumes a limited host resource, so it should be tested with the actual input pipeline.
 
 ## Asynchronous execution
 
-CUDA launches work and returns control to the host before the device necessarily finishes. Operations on one stream execute in order, while independent streams require explicit dependencies through events, `wait_stream`, or `record_stream` when allocator lifetime crosses streams.
+CUDA kernel launches are asynchronous with respect to the host. Python can enqueue several operations before the GPU finishes the first one. Operations on the same CUDA stream execute in order. Work on different streams needs explicit dependencies, and tensors used across streams may need `record_stream` so the caching allocator does not reuse their storage too early.
 
-Host-visible reads collapse that asynchrony. `item()`, printing a device value, transferring to the CPU, or a Python conditional on an accelerator tensor can force the host to wait. These operations are correct, but placing them in every iteration can serialize a pipeline that otherwise overlaps launch and execution.
+Operations that return data to Python or the CPU can force synchronization. Examples include `item()`, printing a CUDA tensor, copying a result to the CPU, and using a tensor value in Python control flow. These operations are sometimes necessary, but placing one in every iteration can prevent the host from running ahead of the device.
 
-Benchmarking must therefore define its synchronization boundary. Warm up kernels and compilation, then use CUDA events or synchronize around the measured region. Host wall-clock time around an asynchronous launch measures dispatch unless the endpoint waits for completion.
+Timing code must include the intended synchronization boundary. Warm up kernel selection and compilation first. Use CUDA events for device time, or synchronize before and after a host-timed region. Timing only the Python call to an asynchronous kernel measures launch overhead rather than completed GPU work.
 
 ## Memory
 
-The caching allocator distinguishes memory occupied by live tensors from memory reserved in allocator segments. `memory_allocated()` tracks the former; `memory_reserved()` tracks the latter. `empty_cache()` releases unused cached blocks for other applications, but it cannot free live tensors or make an oversized live graph fit.
+The CUDA caching allocator keeps freed blocks for reuse. `memory_allocated()` reports memory occupied by live tensors. `memory_reserved()` reports allocator-managed segments, including cached free blocks. `empty_cache()` releases unused cached blocks to other applications, but it cannot release memory held by live tensors and therefore cannot fix a graph whose live state exceeds device capacity.
 
-Peak training memory combines several lifetimes:
+Peak training memory is the sum of values with different lifetimes:
 
 | State | Typical lifetime | Main scaling variable |
 | --- | --- | --- |
@@ -47,75 +47,75 @@ Peak training memory combines several lifetimes:
 | Gradients | Backward through optimizer step | Trainable parameter size |
 | Optimizer state | Whole run after initialization | Parameter size and optimizer |
 | Saved activations | Forward until their backward use | Batch, sequence, width, depth |
-| Temporary kernel workspace | One operation or region | Kernel and input shapes |
-| Communication buffers | Collective lifetime | Bucket and sharding policy |
+| Kernel workspace | One operation or fused region | Kernel and input shapes |
+| Communication buffers | One or more collectives | Bucket and sharding policy |
 
-This decomposition points to different remedies. Lower-precision state reduces bytes per stored value. Activation checkpointing stores fewer forward intermediates and recomputes them during backward. Shorter sequences reduce activation work and can reduce quadratic attention terms. Sharding distributes selected model states. Deleting Python references fixes tensors that outlive their intended scope. One “out of memory” label can therefore describe several different systems failures.
+The correct memory reduction depends on which category sets the peak. Lower-precision parameters and optimizer state reduce bytes per value. Activation checkpointing saves fewer forward tensors and recomputes them during backward. Reducing batch or sequence length lowers activation memory. Sharding distributes selected model state. Removing Python references helps only when those references keep tensors alive longer than intended.
 
-Activation checkpointing preserves the mathematical function while changing the execution graph. Use `torch.utils.checkpoint.checkpoint(..., use_reentrant=False)` unless compatibility requires otherwise, keep the recomputed region semantically identical, and understand RNG preservation. Serialization checkpoints solve recovery; activation checkpoints solve lifetime. Their shared name should not blur their different jobs.
+Activation checkpointing changes tensor lifetime, not model state. `torch.utils.checkpoint.checkpoint(..., use_reentrant=False)` reruns a forward region during backward instead of retaining all of its intermediates. The recomputed region must produce the same result, including any relevant random behavior. This mechanism is unrelated to serialization checkpoints, which store state for later recovery.
 
 ## Memory exercise
 
-The code estimates three memory terms: parameter state, one activation-sized term, and one dense attention-score term. Change one input at a time, predict the result, and rerun it.
+The code estimates parameter storage, one activation-sized term, and one dense attention-score term. Change batch size or sequence length and compare their scaling.
 
 <RevisionCodePair {...pytorchRevisionExamples.systemsIntuition} />
 
-The numbers are not a memory forecast. Real kernels may fuse operations, avoid materializing attention scores, save additional tensors for backward, allocate workspace, or shard only some states. The estimate tells you which hypothesis to test with allocator and profiler evidence.
+The estimate is an upper-level accounting model, not a prediction of allocator output. A fused attention kernel may avoid storing the full score matrix. Backward may save additional tensors. Kernels may allocate temporary workspace, and distributed wrappers may shard only some state. Use the estimate to choose which memory category to inspect in a profiler or allocator snapshot.
 
 ## Compilation
 
-Eager execution is the semantic reference. `torch.compile` asks TorchDynamo to capture Python frames into FX graphs, AOTAutograd to stage backward graphs where needed, and a backend such as Inductor to generate code. The main opportunities are fusion, fewer launches, and backend specialization.
+Eager mode executes one PyTorch operation at a time and remains the reference for program behavior. `torch.compile` captures regions of the Python program into graphs and sends those graphs to a backend. In the default compiler stack, TorchDynamo captures Python frames, AOTAutograd can stage forward and backward graphs, and Inductor generates code. The usual gains come from fusing operations, reducing launch overhead, and specializing kernels for observed inputs.
 
-Capture introduces guards on assumptions such as types, shapes, globals, and object identity. When a guard fails, PyTorch may compile a new specialization. Repeated shape or Python-state variation can spend more time compiling than executing and eventually fall back to eager. A graph break ends one compiled region and resumes tracing later; unsupported Python, data-dependent scalar extraction, printing, and opaque extension code are common causes.
+Captured graphs are valid only while their guards hold. Guards may cover tensor shapes, Python types, global values, and object identity. A failed guard can trigger a new compiled variant. Workloads with frequent shape or Python-state changes may spend substantial time recompiling. A graph break ends one captured region and resumes Python execution; data-dependent scalar extraction, printing, unsupported Python, and opaque extension code are common causes.
 
-Start with `torch.compile(model)`, warm it up, and compare steady-state performance on representative shapes. Use `fullgraph=True` while auditing graph breaks, not as a blind production setting. Inspect `TORCH_LOGS="graph_breaks,recompiles,guards"` or `TORCH_TRACE` with `tlparse` before reaching for private configuration knobs.
+Start with `torch.compile(model)`, include warmup, and compare steady-state time on representative shapes. Use `fullgraph=True` to find graph breaks during investigation, not as an assumption that every program should compile as one graph. `TORCH_LOGS="graph_breaks,recompiles,guards"` and `TORCH_TRACE` with `tlparse` show why capture stopped or a new variant was created.
 
-Dynamic shapes make selected dimensions symbolic; they do not permit arbitrary value-dependent Python inside a graph. `torch._dynamo.mark_dynamic` can declare expected variation. A custom operator provides an explicit opaque boundary when an extension has a schema, fake or meta implementation, and autograd rule that the compiler can reason about.
+Dynamic-shape support makes selected dimensions symbolic, but it does not make arbitrary value-dependent Python capturable. `torch._dynamo.mark_dynamic` can mark dimensions that are expected to vary. Extension code needs a custom-operator schema, a fake or meta implementation, and an autograd rule when the compiler must reason about its shapes and derivatives.
 
 ## Function transforms
 
-`torch.func` treats differentiation and vectorization as function transforms. `grad` returns a gradient function, `vmap` maps a function over a batch dimension, `jacrev` and `jacfwd` construct Jacobians in reverse or forward mode, and `vjp` or `jvp` compute products without materializing the full matrix. Reverse mode is attractive when outputs are few relative to inputs; forward mode when inputs are few relative to outputs.
+`torch.func` exposes differentiation and vectorization as transformations of functions. `grad` returns a function that computes gradients. `vmap` maps a function over a batch dimension. `jacrev` and `jacfwd` compute Jacobians with reverse- or forward-mode differentiation, while `vjp` and `jvp` compute products without materializing the full Jacobian. Reverse mode is usually preferable when outputs are few relative to inputs; forward mode is preferable when inputs are few relative to outputs.
 
-`functional_call` runs a module with explicit parameter and buffer mappings. Making state an input enables per-sample gradients, ensembling, meta-learning, and parameter-space derivatives. `functionalize` removes intermediate mutation and aliasing where possible, which connects this higher-level transform back to the ownership rules from Part I.
+These transforms work best when state is explicit. `functional_call` evaluates a module with supplied parameter and buffer mappings, which supports per-sample gradients, ensembling, and parameter-space derivatives. `functionalize` replaces many intermediate mutations and aliases with functional equivalents so later transformations see a simpler graph.
 
 ## Distributed training
 
-Use one process per accelerator. `torchrun` supplies rank metadata, `init_process_group` creates communication state, `local_rank` selects a local device, and every rank must execute collectives in compatible order. A mismatched order can hang because each process waits for peers performing a different operation.
+Distributed PyTorch usually runs one process per accelerator. `torchrun` starts the processes and supplies rank information. Each process selects its local device and joins a process group with `init_process_group`. All ranks must call collectives in a compatible order; if one rank calls a different collective or skips one, the remaining ranks can wait indefinitely.
 
-DistributedDataParallel replicates parameters and all-reduces gradient buckets during backward. A `DistributedSampler` partitions map-style data, and `sampler.set_epoch(epoch)` changes shuffling consistently across ranks. DDP reduces compute duplication across data while retaining a full model replica on every rank.
+DistributedDataParallel keeps a full model replica on every rank. Each rank processes a different input batch, and DDP all-reduces gradient buckets during backward so every replica applies the same update. `DistributedSampler` partitions a map-style dataset. Calling `sampler.set_epoch(epoch)` changes the shuffle order while preserving a consistent partition across ranks.
 
-FSDP shards parameters, gradients, and optimizer state, gathering parameter material around computation. Its memory and communication depend on wrapping policy, prefetch, mixed precision, initialization, and state-dict type. Build the optimizer after wrapping so it references the managed parameters.
+FullyShardedDataParallel reduces model-state memory per rank by sharding parameters, gradients, and optimizer state. FSDP gathers parameter material around computation and then reshares it, so wrapping policy and execution order determine both memory and communication. Mixed precision, prefetch, initialization, and state-dict format also change the result. Construct the optimizer after wrapping so it refers to the parameters managed by FSDP.
 
-Tensor parallelism shards individual operations; pipeline parallelism assigns layer ranges to stages; `DeviceMesh` names multidimensional process layouts so data, tensor, and pipeline dimensions can compose. These strategies answer different scaling limits. Choose the partition whose communication and memory trade match the model's bottleneck rather than the strategy with the most machinery.
+Tensor parallelism splits individual operations, while pipeline parallelism assigns different layer ranges to different stages. `DeviceMesh` describes multidimensional process layouts that combine data, tensor, and pipeline dimensions. These methods solve different limits: DDP scales data throughput, FSDP reduces replicated state, tensor parallelism divides operations that do not fit on one device, and pipeline parallelism divides depth.
 
-The primitive layer—`all_reduce`, `all_gather`, `reduce_scatter`, `broadcast`, `all_to_all`, and point-to-point communication—reveals what wrappers must coordinate. Diagnose hangs with rank-local logs, timeouts, `TORCH_DISTRIBUTED_DEBUG`, and collective-order checks before assuming the network is at fault.
+The collective operations beneath these wrappers include `all_reduce`, `all_gather`, `reduce_scatter`, `broadcast`, and `all_to_all`. When training hangs, first compare rank-local logs and collective order, set timeouts, and enable `TORCH_DISTRIBUTED_DEBUG`. A network failure is only one possible cause; rank divergence can produce the same visible symptom.
 
 ## Export
 
-`torch.compile` optimizes a running Python program and can return to Python around graph breaks. `torch.export.export` captures an ahead-of-time graph plus shape constraints for deployment or transformation. Export is stricter because its artifact must describe execution without relying on the original Python control flow.
+`torch.compile` optimizes a Python program while it is running and can return to Python around graph breaks. `torch.export.export` creates an ahead-of-time graph with explicit shape constraints for later transformation or deployment. Export accepts less Python dynamism because the artifact must describe execution without the original interpreter.
 
-TorchScript remains relevant to legacy deployments, while current work should begin with the PyTorch 2 compiler and export paths appropriate to the target backend. ONNX, mobile runtimes, and quantization each impose their own supported operator, dtype, and control-flow boundaries. A deployment format should be selected from the consumer's contract, then validated against eager outputs on representative and adversarial inputs.
+TorchScript remains in older deployment systems, while new work should begin with the compiler or export path supported by the target runtime. ONNX, mobile runtimes, and quantization flows each support a particular set of operators, dtypes, shapes, and control flow. Choose the format from the consumer's requirements, then compare its outputs with eager PyTorch on normal and boundary-case inputs.
 
 ## Reproducibility
 
-A seed fixes a generator sequence; it does not freeze kernels, libraries, hardware, process scheduling, or data order across arbitrary environments. Seed PyTorch, Python, and NumPy, use explicit `torch.Generator` objects where local control matters, seed DataLoader workers from `torch.initial_seed()`, and serialize RNG states when exact continuation matters.
+A random seed fixes the sequence produced by a particular generator. It does not by itself fix kernel implementations, library versions, hardware, process scheduling, or data order. Seed PyTorch, Python, and NumPy where each is used. Use explicit `torch.Generator` instances when a component needs independent random state, initialize DataLoader workers from `torch.initial_seed()`, and save RNG states when exact continuation matters.
 
-`torch.use_deterministic_algorithms(True)` requests deterministic implementations or errors, often at a performance cost. `torch.backends.cudnn.benchmark` searches for fast convolution algorithms for observed shapes and is a separate control. Record PyTorch, accelerator toolkit, driver, hardware, compiler, and environment versions with an experiment so a result has a reproducible systems context.
+`torch.use_deterministic_algorithms(True)` requests deterministic implementations and raises an error when a required operation has none. Deterministic algorithms can be slower. `torch.backends.cudnn.benchmark` is a separate option that benchmarks convolution algorithms for observed shapes. Record the PyTorch version, accelerator toolkit, driver, hardware, compiler settings, and relevant environment variables with the experiment.
 
 ## Profiling
 
-`torch.profiler.profile` records CPU operations and accelerator kernels. For a long job, use a wait, warmup, and active schedule; call `prof.step()` once per iteration; annotate meaningful regions with `record_function`; then inspect self time, total time, shapes, memory, and launch gaps. Shape and stack collection add overhead, so profile representative windows rather than the entire run.
+`torch.profiler.profile` records CPU operations and accelerator kernels. For long jobs, use a schedule with wait, warmup, and active phases, and call `prof.step()` once per iteration. Add `record_function` ranges around meaningful application stages. Inspect self time, total time, shapes, memory, and gaps between launches. Shape and stack collection add overhead, so profile a representative window rather than the full run.
 
-Use the narrowest tool that answers the question:
+Different questions require different tools:
 
-- `torch.utils.benchmark` for statistically controlled microbenchmarks;
-- CUDA events for device elapsed time;
-- allocator summaries and snapshots for lifetime and fragmentation;
-- compiler logs for graph breaks and recompilation;
-- rank-local traces for collective imbalance;
-- `torch.testing.assert_close` for numerical comparisons with an explicit tolerance policy.
+- `torch.utils.benchmark` measures CPU code and microbenchmarks with controlled repetitions;
+- CUDA events measure elapsed device time;
+- allocator summaries and snapshots show tensor lifetime and fragmentation;
+- compiler logs show graph breaks, guards, and recompilation;
+- rank-local traces show collective imbalance;
+- `torch.testing.assert_close` checks whether an optimization stays within an explicit numerical tolerance.
 
-Optimization is a loop: measure a representative path, identify the dominant boundary, change one mechanism, and measure the complete path again. The deepest PyTorch intuition is that tensors, gradients, modules, kernels, memory, and communication are not separate layers of trivia. They are successive views of the same executed program.
+Performance work should end with the same measurement that motivated it. Measure a complete representative path, identify the dominant wait or allocation, change one mechanism, and measure the path again. Tensor representation, autograd, kernel scheduling, memory lifetime, and communication all affect the time and memory used by the same model step.
 
 ## Sources
 

--- a/src/content/posts/pytorch-tensor-revision-notes.mdx
+++ b/src/content/posts/pytorch-tensor-revision-notes.mdx
@@ -6,96 +6,96 @@ postSlug: pytorch-tensor-revision-notes
 legacyPath: /revision notes/2026/08/09/pytorch-tensor-revision-notes.html
 tags:
   - PyTorch
-summary: Build a predictive model of PyTorch tensors from storage, metadata, views, indexing, broadcasting, dtype, and layout.
+summary: Understand how PyTorch represents tensors through storage, shape, strides, dtype, device, layout, and autograd metadata.
 ---
 import RevisionCodePair from '../../components/RevisionCodePair.astro';
 import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
 
 # PyTorch I: Tensors
 
-## Tensor model
+## Tensor representation
 
-A tensor is not merely a box of numbers. It is a logical array whose metadata tells PyTorch how to interpret storage and where to execute operations. Shape names the logical axes; strides and storage offset map an index to memory; dtype determines representation and arithmetic; device determines where storage lives; and layout constrains which kernels can consume it.
+For the common dense strided layout, `torch.Tensor` represents an n-dimensional array through a storage allocation and a set of metadata. Shape, strides, and storage offset map logical indices to stored values. Dtype specifies the representation of each value, device places the storage, and layout determines how operators access it. Autograd records additional information when PyTorch must differentiate the operations that produced the tensor.
 
-That definition is useful because most tensor bugs are contract bugs. A model sees the wrong axis, an operation broadcasts farther than intended, a view still aliases its source, or a conversion quietly copies and synchronizes. By the end of this part, you should be able to predict those consequences before running the code.
+The representation explains several common surprises. A transpose can change the apparent dimensions without moving data. A slice can keep a much larger allocation alive. Broadcasting can produce a large logical result from a small stored input. A device transfer can copy data and synchronize execution even though the values do not change. Tensor debugging must therefore inspect the values and the metadata that produced their current interpretation.
 
-This is the first of three connected notes. [Part II](/revision%20notes/2026/08/10/pytorch-autograd-and-training.html) uses this tensor model to explain autograd, modules, and training. [Part III](/revision%20notes/2026/08/10/pytorch-systems-and-scale.html) follows the same tensors through compilation, accelerators, memory, and distributed execution.
+This note develops that representation from storage upward. [Part II](/revision%20notes/2026/08/10/pytorch-autograd-and-training.html) adds autograd, module state, and training. [Part III](/revision%20notes/2026/08/10/pytorch-systems-and-scale.html) follows the same operations through accelerator execution, memory allocation, compilation, and distributed training.
 
 ## Storage and strides
 
-For the common `torch.strided` layout, a logical index $(i_0, \ldots, i_{n-1})$ reaches storage position
+For a dense tensor with `torch.strided` layout, PyTorch maps a logical index $(i_0, \ldots, i_{n-1})$ to a storage position as
 
 $$
 \text{storage\_offset} + \sum_{k=0}^{n-1} i_k\,\text{stride}_k.
 $$
 
-The equation separates the logical tensor from its physical storage. Shape bounds the valid indices, while each stride says how many storage elements to skip when one index advances. A contiguous row-major tensor with shape `(2, 3, 4)` normally has strides `(12, 4, 1)`: move one position along the last axis and storage advances by one; move along the middle axis and it advances by four.
+The shape limits the valid value of each index. The stride for an axis gives the number of storage elements between adjacent positions on that axis. A contiguous tensor with shape `(2, 3, 4)` usually has strides `(12, 4, 1)`: advancing the last index moves one storage element, while advancing the middle index moves four.
 
-Because metadata and storage are separate, several tensors can describe the same allocation. A slice changes the visible range, a transpose swaps shape and strides, and `expand` can assign a zero stride to a repeated logical axis. Those operations can be cheap because values do not move, but their outputs are aliases rather than independent arrays.
+Shape and strides can change without changing the underlying allocation. A slice changes the visible range and may change the storage offset. A transpose reorders shape and strides. `expand` can give an axis a stride of zero, so many logical positions refer to the same stored value. These operations are cheap because they update metadata, but the resulting tensors share storage with their source.
 
 ## Creating tensors
 
-The first construction question is whether the new tensor owns a copy. `torch.tensor(data)` copies its input and creates a fresh leaf by default. `torch.as_tensor(data)` reuses compatible input where possible. `torch.from_numpy(array)` deliberately shares CPU storage with a NumPy array, so a write through either object can reach the other. `torch.frombuffer` exposes a compatible Python buffer under a similar lifetime constraint.
+Tensor construction determines ownership first. `torch.tensor(data)` copies the input. `torch.as_tensor(data)` reuses existing memory when the input representation is compatible. `torch.from_numpy(array)` shares CPU memory with a NumPy array, and `torch.frombuffer` exposes a compatible Python buffer. Shared-memory conversions require the source object to remain valid, and mutation through either view is visible through the other.
 
-The second question is where and how values should be represented. Pass `dtype` and `device` at construction when they are already known. Constructing on the CPU and converting later creates another allocation and, for an accelerator, a transfer. The `*_like` family starts from an existing tensor's shape and normally its dtype, layout, and device, which makes “match this tensor” explicit without repeating metadata.
+Construction also fixes dtype and device. If both are known, pass them to the factory rather than creating a CPU tensor and converting it afterward. The latter performs an extra allocation and may perform a device transfer. The `*_like` factories inherit shape and normally dtype, layout, and device from an existing tensor; explicit keyword arguments override the inherited values.
 
-Factory names communicate initialization intent. `zeros`, `ones`, and `full` initialize every value; `arange` defines a step while `linspace` defines a count; `rand` and `randn` consume random-generator state. `empty` only allocates storage. Its values are undefined until every element has been overwritten, so reading first is a correctness error rather than harmless noise.
+The factory name states how values are initialized. `zeros`, `ones`, and `full` write every element. `arange` specifies an interval and step, while `linspace` specifies the number of samples. `rand` and `randn` draw from a random generator. `empty` allocates without initializing the elements, so every element must be written before the tensor is read.
 
-NumPy and PyTorch look similar at this boundary but have different defaults. NumPy floating arrays normally infer `float64`, while PyTorch's default floating dtype is normally `float32`. NumPy arrays live on the CPU; a tensor can live on an accelerator and carry autograd history. A conversion can therefore change precision, ownership, device, synchronization, and gradient connectivity even when the printed values look unchanged.
+NumPy and PyTorch have different defaults at this boundary. A NumPy array created from Python floating-point values usually uses `float64`; a PyTorch tensor usually uses the current default floating dtype, normally `float32`. NumPy arrays are CPU-resident, while PyTorch tensors may live on an accelerator and carry autograd history. A conversion may therefore change ownership, precision, device, synchronization, or gradient history even when it preserves the values.
 
-| Intent | Preferred operation | What to predict |
+| Intent | Operation | Result |
 | --- | --- | --- |
-| Own a copy | `torch.tensor(x)` or `x.clone()` | New storage; decide dtype and device. |
-| Reuse compatible input | `torch.as_tensor(x)` | Sharing depends on the input and requested conversion. |
-| Share NumPy CPU memory | `torch.from_numpy(a)` | Mutations can cross the boundary. |
-| Match another tensor | `zeros_like`, `ones_like`, `empty_like` | Metadata is inherited unless overridden. |
-| Convert or move | `x.to(dtype=..., device=...)` | May return `x` unchanged or allocate a result. |
+| Copy input data | `torch.tensor(x)` or `x.clone()` | New storage |
+| Reuse compatible data | `torch.as_tensor(x)` | May share storage |
+| Share a NumPy array | `torch.from_numpy(a)` | Shared CPU storage |
+| Match an existing tensor | `zeros_like`, `ones_like`, `empty_like` | Inherits metadata unless overridden |
+| Change dtype or device | `x.to(dtype=..., device=...)` | Returns `x` if no conversion is needed; otherwise allocates |
 
 ## Views and copies
 
-`view` changes shape only when the current size and strides permit that interpretation. `reshape` is more permissive: it returns a view when possible and copies otherwise. Code should therefore depend on `reshape`'s values and shape, not on whether it shares storage. `transpose`, `permute`, `movedim`, `narrow`, `select`, `squeeze`, and `unsqueeze` generally return views.
+`view` returns a new shape only when the existing strides support that interpretation. `reshape` returns a view when possible and copies when necessary. Code that uses `reshape` should not assume either outcome. Operations such as `transpose`, `permute`, `movedim`, `narrow`, `select`, `squeeze`, and `unsqueeze` usually return views.
 
-Three operations mark different boundaries. `contiguous()` materializes a compatible contiguous representation only when needed. `clone()` always copies values but remains connected to autograd. `detach()` removes the autograd edge while normally sharing storage. “Independent values” and “independent gradient history” are different guarantees.
+`contiguous()`, `clone()`, and `detach()` solve different problems. `contiguous()` copies only when the tensor does not already have the requested memory format. `clone()` always copies the values and preserves the autograd connection to the source. `detach()` removes the incoming autograd edge but usually keeps the same storage. A tensor can therefore be independent in storage but connected in the computation graph, or detached from the graph but aliased in storage.
 
-In-place operations expose why aliasing matters. A method ending in `_`, indexing assignment, or an `out=` argument writes into existing storage. If another tensor aliases that storage, it observes the write. Once autograd enters the picture, the same write can invalidate a value saved for backward; Part II develops that consequence.
+Aliasing becomes visible under mutation. Methods ending in `_`, indexed assignment, and operations with an `out=` argument write into existing storage. Every view of that storage can observe the change. During training, an in-place write may also change a value that autograd saved for backward; Part II explains how PyTorch detects that case.
 
 ## Indexing
 
-Basic indexing follows Python rules. An integer removes an axis, a slice preserves it, `None` inserts a singleton axis, `...` fills unspecified axes, and negative indices count from the end. Basic slices generally return views, so mutating the result can mutate the base tensor.
+Basic indexing follows NumPy-style rules. An integer removes an axis, a slice preserves it, `None` inserts an axis of length one, `...` fills unspecified axes, and a negative index counts from the end. Basic slicing usually returns a view, so assigning through the result may change the original tensor.
 
-Advanced indexing uses integer tensors, lists of indices, or boolean masks and returns selected values in new storage. Assignment with advanced indexing still writes to the destination, so the read and write forms have different ownership behavior. `gather`, `index_select`, `take_along_dim`, `masked_select`, `scatter`, and `index_put_` make the indexed axis or write explicit when ordinary syntax hides too much.
+Advanced indexing uses integer tensors, lists of indices, or boolean masks. Reading with advanced indexing returns selected values in new storage. Assignment with the same syntax writes into the indexed positions of the destination. `gather`, `index_select`, `take_along_dim`, `masked_select`, `scatter`, and `index_put_` are useful when the indexed axis or write rule should be explicit.
 
-The reliable habit is to predict the output rank before its values. For `x` shaped `(batch, tokens, channels)`, `x[0]` removes the batch axis, `x[:1]` keeps it, and `x[..., -1]` removes the channel axis. Many model failures that look numerical are one missing or extra singleton dimension.
+Check the output rank before checking the values. If `x` has shape `(batch, tokens, channels)`, then `x[0]` has shape `(tokens, channels)`, `x[:1]` has shape `(1, tokens, channels)`, and `x[..., -1]` has shape `(batch, tokens)`. An unintended integer index often removes an axis that later code expected to preserve.
 
 ## Broadcasting
 
-PyTorch aligns operand shapes from the right. Two aligned dimensions are compatible when they are equal or either is `1`; missing leading dimensions behave as `1`. Adding a bias shaped `(channels,)` to activations shaped `(batch, tokens, channels)` therefore treats the bias as `(1, 1, channels)`.
+Broadcasting compares shapes from the last axis to the first. Two aligned dimensions are compatible if they are equal or if either one is `1`; a missing leading dimension behaves as `1`. Adding a bias with shape `(channels,)` to activations with shape `(batch, tokens, channels)` treats the bias as if it had shape `(1, 1, channels)`.
 
-Broadcasting avoids copying the smaller operand, but it does not make the downstream computation free. `expand` can represent repeated logical values with zero strides, while an operation using the expanded view may still process every logical element. This distinction—cheap representation versus expensive consumer—returns in Part III when we reason about memory and kernels.
+The smaller input is not copied to its expanded logical shape. `expand` can represent repeated values with zero strides. The operation that consumes the expanded tensor may still process every element of the broadcasted result, so broadcasting saves storage for the input but does not remove the arithmetic on the output.
 
-`cat` and `stack` answer a different shape question. `cat` extends an existing axis and preserves rank; every other axis must agree. `stack` requires equal shapes and inserts a new axis. If the operation creates a new semantic category such as ensemble, time, or sample, `stack` is usually the clearer starting point.
+`cat` and `stack` change shapes in different ways. `cat` joins tensors along an existing axis and keeps the rank unchanged; all other dimensions must match. `stack` requires equal input shapes and creates a new axis. Use `stack` when the new axis represents a new variable such as sample, time, or ensemble member.
 
 ## Dtype and layout
 
-Once shapes align, dtype promotion decides the result representation. Out-of-place operations may promote mixed inputs, while an in-place operation cannot store a result that is incompatible with its receiver's dtype. Use `torch.result_type` or `torch.promote_types` when Python scalars, zero-dimensional tensors, or mixed precision make the result unclear.
+After shapes are compatible, dtype promotion determines the result dtype. Out-of-place operations may promote their inputs. In-place operations must write the result back into the dtype of the destination, so some mixed-dtype expressions that work out of place fail in place. `torch.result_type` and `torch.promote_types` expose the promotion rule when Python scalars, zero-dimensional tensors, or mixed precision make it unclear.
 
-Numerical form matters as much as dtype. Prefer `logsumexp(x)` to `log(exp(x).sum())`, `log_softmax(x)` to `softmax(x).log()`, and `cross_entropy(logits, target)` to manually constructing probabilities and logarithms. These formulations preserve the mathematical objective while avoiding unstable intermediate values.
+Numerical stability also depends on the form of the computation. `logsumexp(x)` avoids the large intermediate values created by `log(exp(x).sum())`. `log_softmax(x)` is more stable than `softmax(x).log()`. `cross_entropy(logits, target)` combines log-softmax and negative log-likelihood without materializing probabilities. These functions compute the intended objective while avoiding unstable intermediate steps.
 
-Layout completes the tensor contract. Dense strided tensors dominate general model code; channels-last formats can benefit supported convolution workloads; sparse COO, CSR, CSC, BSR, and BSC layouts store indices with values; quantized tensors add scale and zero point; nested or jagged tensors represent ragged structure. Operator, autograd, dtype, and device coverage vary, so a specialized layout must be chosen for an entire supported operator path rather than for an isolated storage saving.
+Layout describes how tensor values are organized beyond shape and dtype. Dense strided tensors cover most model code. Channels-last memory formats can improve supported convolution workloads. Sparse COO, CSR, CSC, BSR, and BSC tensors store indices along with values. Quantized tensors add scale and zero-point metadata, while nested or jagged tensors represent ragged structure. Support varies by operator, dtype, device, and autograd path, so a specialized layout is useful only when the complete operation sequence supports it.
 
 ## Tensor exercise
 
-Before running the code, predict whether `tokens` shares storage with `base`, how the two-element bias aligns, and whether the final `clone` can observe a later mutation of `base`. Then change the slice or bias and rerun it.
+Before running the code, determine whether `tokens` shares storage with `base`, how the bias aligns with `tokens`, and whether the cloned `features` tensor can observe a later write through `tokens`. Change the slice or bias shape and run it again.
 
 <RevisionCodePair {...pytorchRevisionExamples.tensorIntuition} />
 
-The trace compresses the whole part into one sequence: allocate storage, expose a view, broadcast a smaller logical tensor, reshape the result, then make ownership explicit. In model code, writing these transitions down is usually more useful than printing a wall of values.
+The example performs the main representation changes in order: it creates storage, takes a strided view, broadcasts a bias, reshapes the result, and then copies it. The printed shapes and strides identify which steps changed metadata and which step created independent storage.
 
 ## Debugging tensors
 
-At a subsystem boundary, inspect `shape → dtype → device → layout → strides → ownership`. `numel() * element_size()` estimates the dense logical payload, but not allocator reservation, sparse indices, alignment, or a larger allocation retained by a view. `item()` converts exactly one element to a Python scalar; it does not reveal storage, and on an accelerator it may synchronize the host.
+At an interface between two parts of a model, inspect `shape`, `dtype`, `device`, `layout`, strides, and storage sharing. `numel() * element_size()` gives the dense logical payload, but it does not include allocator reservation, sparse indices, alignment, or unused elements in a larger allocation retained by a view. `item()` returns one Python scalar and may synchronize an accelerator with the host.
 
-The final question is whether the next operation should remember how the tensor was produced. If the answer is yes, the tensor now participates in a differentiable program. That is the starting point for [Part II: Autograd and Training](/revision%20notes/2026/08/10/pytorch-autograd-and-training.html).
+When `requires_grad` is enabled and grad mode is active, PyTorch also records the operations that produced a tensor. [Part II: Autograd and Training](/revision%20notes/2026/08/10/pytorch-autograd-and-training.html) explains that graph and how backward uses it.
 
 ## Sources
 


### PR DESCRIPTION
## What changed
- rewrote all three PyTorch Revision Notes paragraph by paragraph
- replaced canned teaching contrasts and abstract framing with direct technical claims
- preserved the equations, exercises, source links, routes, and three-part dependency order
- updated shelf summaries to state the technical scope directly

## Why
The previous prose sounded over-produced and sometimes lowered the technical register. The new version uses plain English while keeping the detailed treatment of tensor representation, autograd, training, and systems behavior.

## Testing
- git diff --check
- npm run ci
- verified all three generated routes and interactive runner markup