### PR TITLE
Add DeepSeek and Muse Glimmer local-serving guides

### DIFF
--- a/scripts/bench_llama_server_local.py
+++ b/scripts/bench_llama_server_local.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+
+"""Benchmark one local GGUF through llama-server on short and long prompts.
+
+The harness reports both time to the first generated token and time to the
+first answer token. Those differ for models that stream hidden reasoning before
+visible content. It intentionally measures runtime behavior, not answer quality.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+HOST = "127.0.0.1"
+PORT = 18081
+BASE_URL = f"http://{HOST}:{PORT}"
+REQUEST_TIMEOUT_S = 60 * 60
+
+CORPUS = """
+Running a language model locally is a question about capacity and latency. The
+weights must fit in memory, but that only establishes that inference can start.
+Prompt processing determines how long a document-scale request waits before the
+first generated token, and decode throughput determines whether the continuation
+feels interactive. A useful benchmark therefore holds the output task fixed and
+changes prompt length rather than mixing model quality with runtime behavior.
+
+Apple Silicon exposes one unified memory pool to the CPU and GPU. That removes a
+separate host-to-device copy, but the operating system, model weights, runtime
+workspace, and key-value cache still compete for the same finite capacity. A
+quantized checkpoint that occupies twenty gigabytes has very different headroom
+from a sixty-gigabyte checkpoint on a machine with sixty-four gigabytes total.
+
+Serving adds another distinction. A command-line generation can prove that a
+model loads, while an OpenAI-compatible server tests the interface used by chat
+applications and agent frameworks. For daily use, time to first visible answer
+can matter more than time to the first hidden reasoning token.
+""".strip()
+
+SUITES = {
+    "short": {"input_tokens": 512, "max_new_tokens": 192},
+    "long": {"input_tokens": 8192, "max_new_tokens": 96},
+}
+
+
+@dataclass(frozen=True)
+class Measurement:
+    target_input_tokens: int
+    actual_input_tokens: int
+    max_new_tokens: int
+    completion_tokens: int | None
+    reasoning_characters: int
+    answer_characters: int
+    reasoning_preview: str
+    answer_preview: str
+    first_generated_token_ms: float | None
+    first_answer_token_ms: float | None
+    elapsed_ms: float
+    decode_tokens_per_s: float | None
+    average_tokens_per_s: float | None
+
+
+def log(message: str) -> None:
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}", file=sys.stderr, flush=True)
+
+
+def request_json(
+    path: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout_s: float = 30,
+) -> dict[str, Any]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="GET" if data is None else "POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout_s) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_server(process: subprocess.Popen[str], attempts: int = 900) -> None:
+    for _ in range(attempts):
+        if process.poll() is not None:
+            raise RuntimeError(f"llama-server exited with status {process.returncode}")
+        try:
+            request_json("/health")
+            return
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+            time.sleep(1)
+    raise RuntimeError("Timed out waiting for llama-server")
+
+
+def stop_process(process: subprocess.Popen[str] | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    process.send_signal(signal.SIGTERM)
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=30)
+
+
+def ensure_port_is_free(host: str, port: int) -> None:
+    """Fail before launch instead of benchmarking an unrelated stale server."""
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.25)
+        if probe.connect_ex((host, port)) == 0:
+            raise RuntimeError(f"Refusing to use occupied benchmark port {host}:{port}")
+
+
+def token_count(text: str) -> int:
+    response = request_json("/tokenize", {"content": text, "add_special": False})
+    tokens = response.get("tokens")
+    if not isinstance(tokens, list):
+        raise RuntimeError(f"Unexpected /tokenize response: {response}")
+    return len(tokens)
+
+
+def build_prompt(target_tokens: int, lines: int) -> tuple[str, int]:
+    instruction = (
+        f"Read the background notes. Then print the integers 1 through {lines}, "
+        "one per line, zero-padded to three digits, and nothing else.\n\n"
+        "Background notes:\n"
+    )
+    corpus_words = CORPUS.split()
+    low = 1
+    high = max(target_tokens * 2, len(corpus_words))
+    best_prompt = instruction
+    best_count = token_count(best_prompt)
+
+    while low <= high:
+        word_count = (low + high) // 2
+        repeated = [corpus_words[index % len(corpus_words)] for index in range(word_count)]
+        candidate = f"{instruction}{' '.join(repeated)}"
+        candidate_count = token_count(candidate)
+        if abs(candidate_count - target_tokens) < abs(best_count - target_tokens):
+            best_prompt = candidate
+            best_count = candidate_count
+        if candidate_count < target_tokens:
+            low = word_count + 1
+        elif candidate_count > target_tokens:
+            high = word_count - 1
+        else:
+            break
+
+    return best_prompt, best_count
+
+
+def stream_chat(
+    model_alias: str,
+    prompt: str,
+    max_tokens: int,
+    *,
+    temperature: float,
+    top_p: float,
+    top_k: int,
+) -> Measurement:
+    payload = {
+        "model": model_alias,
+        "messages": [
+            {
+                "role": "system",
+                "content": "Be concise. Follow the requested output format exactly.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": temperature,
+        "top_p": top_p,
+        "top_k": top_k,
+        "seed": 123,
+        "max_tokens": max_tokens,
+    }
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{BASE_URL}/v1/chat/completions",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    started_at = time.perf_counter()
+    first_generated_at: float | None = None
+    first_answer_at: float | None = None
+    reasoning_parts: list[str] = []
+    answer_parts: list[str] = []
+    completion_tokens: int | None = None
+
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S) as response:
+        for raw_line in response:
+            line = raw_line.decode("utf-8").strip()
+            if not line.startswith("data: "):
+                continue
+            chunk = line[6:]
+            if chunk == "[DONE]":
+                break
+            event = json.loads(chunk)
+            usage = event.get("usage") or {}
+            if isinstance(usage.get("completion_tokens"), int):
+                completion_tokens = usage["completion_tokens"]
+            choices = event.get("choices") or []
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            reasoning = delta.get("reasoning_content") or ""
+            content = delta.get("content") or ""
+            if reasoning or content:
+                first_generated_at = first_generated_at or time.perf_counter()
+            if reasoning:
+                reasoning_parts.append(reasoning)
+            if content:
+                first_answer_at = first_answer_at or time.perf_counter()
+                answer_parts.append(content)
+
+    finished_at = time.perf_counter()
+    elapsed_s = finished_at - started_at
+    decode_s = None if first_generated_at is None else finished_at - first_generated_at
+    decode_tps = None
+    average_tps = None
+    if completion_tokens is not None and completion_tokens > 0:
+        average_tps = completion_tokens / elapsed_s
+        if decode_s is not None and decode_s > 0:
+            decode_tps = completion_tokens / decode_s
+
+    return Measurement(
+        target_input_tokens=0,
+        actual_input_tokens=0,
+        max_new_tokens=max_tokens,
+        completion_tokens=completion_tokens,
+        reasoning_characters=len("".join(reasoning_parts)),
+        answer_characters=len("".join(answer_parts)),
+        reasoning_preview="".join(reasoning_parts)[:240],
+        answer_preview="".join(answer_parts)[:240],
+        first_generated_token_ms=(
+            None if first_generated_at is None else round((first_generated_at - started_at) * 1000, 2)
+        ),
+        first_answer_token_ms=(
+            None if first_answer_at is None else round((first_answer_at - started_at) * 1000, 2)
+        ),
+        elapsed_ms=round(elapsed_s * 1000, 2),
+        decode_tokens_per_s=None if decode_tps is None else round(decode_tps, 2),
+        average_tokens_per_s=None if average_tps is None else round(average_tps, 2),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument(
+        "--draft-path",
+        type=Path,
+        help="Optional speculative-decoding draft model, such as Glimmer DFlash.",
+    )
+    parser.add_argument(
+        "--spec-type",
+        default="draft-dflash",
+        help="llama.cpp speculative decoder type used when --draft-path is set.",
+    )
+    parser.add_argument("--model-label", required=True)
+    parser.add_argument("--model-alias", default="local-model")
+    parser.add_argument("--ctx-size", type=int, default=16384)
+    parser.add_argument("--port", type=int, default=18082)
+    parser.add_argument("--reasoning-budget", type=int, default=32)
+    parser.add_argument("--reasoning-strength", default="low")
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=1)
+    parser.add_argument("--suites", default="short,long")
+    return parser.parse_args()
+
+
+def main() -> int:
+    global BASE_URL
+
+    args = parse_args()
+    if not args.model_path.is_file():
+        raise SystemExit(f"Model file does not exist: {args.model_path}")
+    if args.draft_path is not None and not args.draft_path.is_file():
+        raise SystemExit(f"Draft model file does not exist: {args.draft_path}")
+    suite_names = [name.strip() for name in args.suites.split(",") if name.strip()]
+    unknown_suites = [name for name in suite_names if name not in SUITES]
+    if unknown_suites:
+        raise SystemExit(f"Unknown suites: {', '.join(unknown_suites)}")
+    if not 1 <= args.port <= 65535:
+        raise SystemExit(f"Port must be between 1 and 65535: {args.port}")
+    ensure_port_is_free(HOST, args.port)
+    BASE_URL = f"http://{HOST}:{args.port}"
+
+    log_path = Path("/private/tmp") / f"llama-server-{args.model_alias}.log"
+    command = [
+        "llama-server",
+        "--model",
+        str(args.model_path),
+        "--alias",
+        args.model_alias,
+        "--host",
+        HOST,
+        "--port",
+        str(args.port),
+        "--ctx-size",
+        str(args.ctx_size),
+        "--parallel",
+        "1",
+        "--flash-attn",
+        "on",
+        "--gpu-layers",
+        "all",
+        "--jinja",
+        "--metrics",
+        "--reasoning-budget",
+        str(args.reasoning_budget),
+        "--chat-template-kwargs",
+        json.dumps({"reasoning_strength": args.reasoning_strength}),
+    ]
+    if args.draft_path is not None:
+        command.extend(
+            [
+                "--model-draft",
+                str(args.draft_path),
+                "--gpu-layers-draft",
+                "all",
+                "--spec-type",
+                args.spec_type,
+            ]
+        )
+
+    process: subprocess.Popen[str] | None = None
+    try:
+        log(f"Starting llama-server for {args.model_label}")
+        with log_path.open("w", encoding="utf-8") as log_file:
+            process = subprocess.Popen(
+                command,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        wait_for_server(process)
+
+        log("Warming up")
+        stream_chat(
+            args.model_alias,
+            "Reply with OK and nothing else.",
+            max_tokens=40,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            top_k=args.top_k,
+        )
+
+        measurements: dict[str, dict[str, Any]] = {}
+        for suite_name in suite_names:
+            suite = SUITES[suite_name]
+            prompt, input_tokens = build_prompt(suite["input_tokens"], suite["max_new_tokens"])
+            log(f"Measuring {suite_name} suite with {input_tokens} input tokens")
+            measurement = stream_chat(
+                args.model_alias,
+                prompt,
+                suite["max_new_tokens"],
+                temperature=args.temperature,
+                top_p=args.top_p,
+                top_k=args.top_k,
+            )
+            result = asdict(measurement)
+            result["target_input_tokens"] = suite["input_tokens"]
+            result["actual_input_tokens"] = input_tokens
+            measurements[suite_name] = result
+
+        payload = {
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            "machine": {
+                "platform": sys.platform,
+                "cpu": subprocess.run(
+                    ["sysctl", "-n", "machdep.cpu.brand_string"],
+                    check=True,
+                    text=True,
+                    capture_output=True,
+                ).stdout.strip(),
+                "memory_gib": round(
+                    int(
+                        subprocess.run(
+                            ["sysctl", "-n", "hw.memsize"],
+                            check=True,
+                            text=True,
+                            capture_output=True,
+                        ).stdout.strip()
+                    )
+                    / (1024**3),
+                    1,
+                ),
+            },
+            "runtime": subprocess.run(
+                ["llama-server", "--version"],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            ).stdout.strip(),
+            "model": {
+                "label": args.model_label,
+                "alias": args.model_alias,
+                "path": str(args.model_path),
+                "size_bytes": args.model_path.stat().st_size,
+                "draft_path": None if args.draft_path is None else str(args.draft_path),
+                "draft_size_bytes": (
+                    None if args.draft_path is None else args.draft_path.stat().st_size
+                ),
+            },
+            "controls": {
+                "ctx_size": args.ctx_size,
+                "parallel": 1,
+                "gpu_layers": "all",
+                "flash_attention": True,
+                "speculative_type": (
+                    None if args.draft_path is None else args.spec_type
+                ),
+                "reasoning_budget": args.reasoning_budget,
+                "reasoning_strength": args.reasoning_strength,
+                "temperature": args.temperature,
+                "top_p": args.top_p,
+                "top_k": args.top_k,
+            },
+            "server_log": str(log_path),
+            "suites": measurements,
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+    finally:
+        stop_process(process)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/content/posts/deepseek-v4-flash-0731-efficient-million-token-intelligence.md
+++ b/src/content/posts/deepseek-v4-flash-0731-efficient-million-token-intelligence.md
@@ -20,11 +20,12 @@ summary: '2026 – DeepSeek-V4-Flash-0731: Efficient Million-Token Intelligence 
 **arXiv:** [2606.19348](https://arxiv.org/abs/2606.19348)<br />
 **July 31 update:** [DeepSeek-V4-Flash Update](https://api-docs.deepseek.com/updates/)<br />
 **Original release:** [DeepSeek V4 Preview](https://api-docs.deepseek.com/news/news260424/)<br />
-**Preview weights:** [deepseek-ai/DeepSeek-V4-Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash)
+**0731 weights:** [deepseek-ai/DeepSeek-V4-Flash-0731](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731)<br />
+**Fit and serving guide:** [Can DeepSeek V4 Flash 0731 Run on a 64 GB MacBook Pro?](/blog/2026/08/13/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.html)
 
 ## Summary
 
-DeepSeek-V4-Flash-0731 is a post-training release, not a new base model. It keeps the April preview's architecture and size—284 billion total parameters, 13 billion active per token, and a one-million-token context window—while replacing the API checkpoint with a model tuned for stronger agent behavior and native Responses API use. DeepSeek says only the API changed; the web/app models and V4-Pro endpoint did not, and updated Flash weights were not announced with the July release.
+DeepSeek-V4-Flash-0731 is a post-training release, not a new base model. It keeps the April preview's architecture and size—284 billion total parameters, 13 billion active per token, and a one-million-token context window—while replacing the API checkpoint with a model tuned for stronger agent behavior and native Responses API use. DeepSeek initially said the July 31 update changed only the Flash API, leaving the web/app models and V4-Pro endpoint unchanged; the exact `0731` weights were published on Hugging Face on August 1.
 
 ## Core Insights
 
@@ -44,7 +45,7 @@ CSA first compresses each four-token KV group, then uses a learned indexer to se
 | 1M-token efficiency | 10% of V3.2 single-token FLOPs; 7% of its KV cache | Makes million-token decoding materially cheaper in the authors' estimate |
 | Pretraining | 32T tokens; 4K → 16K → 64K → 1M context | Trains the target context progressively rather than extrapolating only at inference |
 | Quantization | FP4 routed-expert weights; FP4 CSA indexer QK path during QAT | Reduces expert memory traffic and long-context index cost |
-| July 31 delta | Same architecture, API checkpoint re-post-trained | Capability change cannot be attributed to a new backbone or more pretraining |
+| July 31 delta | Same architecture, re-post-trained weights plus a DSpark draft module | Capability change cannot be attributed to a new backbone or more pretraining |
 
 The 32T-token corpus extends DeepSeek-V3 data with filtered web pages, mathematics, code, multilingual material, long documents, and agentic mid-training data. Flash trains with dense attention for the first trillion tokens, introduces sparse attention at 64K context, and eventually reaches 1M. The report supplies unusually concrete optimization controls: auxiliary load-balancing loss weight 0.0001, multi-token-prediction loss weight 0.3 for most of training and 0.1 during learning-rate decay, and a 75.5M-token maximum batch. It does not report category mixture proportions or contamination audits for the July agent benchmarks.
 
@@ -58,5 +59,5 @@ The official July evaluation reports 82.7 on Terminal-Bench 2.1, 54.2 on NL2Repo
 - The expensive commitment is to a custom serving stack for hybrid attention, sparse experts, mHC residual paths, FP4 computation, and persistent tool state. The paper reports striking modeled efficiency against V3.2, but does not isolate CSA, HCA, mHC, Muon, data, and scale under a single matched budget. The decisive experiment is a long-context retrieval-and-agent sweep that holds active parameters, training tokens, decoding budget, and hardware constant while varying compression rate and selector top-k. Reject the architecture choice if a simpler MLA/GQA baseline matches end-task accuracy and latency, or if retrieval degrades sharply outside synthetic long-context tests.
 - For the 0731 checkpoint, the missing control is even simpler: evaluate the preview and updated API models with the same public harness, effort budget, samples, and judge. Without that table, the size of the post-training gain is not reported. At ten times the context or trajectory length, selector recall, accumulated compressed-state error, sandbox persistence, and cache bandwidth are likely to dominate before nominal MoE capacity does.
 - DeepSeek-V4-Flash is the smaller V4 branch: it shares the V4 hybrid-attention and post-training stack, but activates 13B parameters rather than V4-Pro's 49B.
-- The July checkpoint is API-only, its post-training recipe and updated weights are not reported, its code-agent harness is not yet released, two headline benchmarks are internal, and the release provides no matched preview-versus-0731 table.
+- The July checkpoint's weights are public, but its post-training recipe is not reported, its code-agent harness is not yet released, two headline benchmarks are internal, and the release provides no controlled ablation of the post-training changes.
 - DeepSeek-V4-Flash-0731 is evidence that post-training can move agent performance without changing a 32T-token base; until the harness and matched before/after results are released, use it as a deployment update rather than proof of a new training method.

--- a/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
@@ -1,0 +1,80 @@
+---
+title: Which Current Open-Weight Models Fit on a 64 GB MacBook Pro?
+date: '2026-08-13T04:00:00.000Z'
+section: blog
+postSlug: open-weight-models-that-fit-on-a-64-gb-macbook-pro
+legacyPath: /blog/2026/08/13/open-weight-models-that-fit-on-a-64-gb-macbook-pro.html
+tags:
+  - LLMs
+  - Apple Silicon
+  - Inference
+summary: >-
+  A current fit guide for Muse Glimmer, Ministral, Granite, Nemotron, Mistral
+  Small 4, and DeepSeek V4 Flash on a 64 GB Apple Silicon machine.
+---
+# Which Current Open-Weight Models Fit on a 64 GB MacBook Pro?
+
+The useful local-model question is no longer “which old Qwen quant should I download?” It is which current open-weight models leave enough of a `64 GB` unified-memory budget for the runtime, context, and the rest of macOS.
+
+My shortlist on an M5 Max is `Muse Glimmer 30B` when I want a current multimodal generalist, `Ministral 3 14B` when I want the easiest fast deployment, and `Granite 4.1 30B` when the workload is closer to retrieval, tools, or enterprise text. `Nemotron 3 Nano 30B-A3B` is also plausible through a community 4-bit conversion, but its official full-precision checkpoint is too close to the machine's entire memory capacity. `Mistral Small 4` and `DeepSeek V4 Flash 0731` do not belong on this laptop.
+
+This is a fit guide dated August 13, 2026. File sizes are from the linked model repositories. Only the Glimmer row is backed by my own local benchmark; the other rows are capacity recommendations, not invented performance measurements.
+
+## The shortlist
+
+| Model | Practical local artifact | Weight size | `64 GB` verdict | Why I would choose it |
+| --- | --- | ---: | --- | --- |
+| `Muse Glimmer 30B` | Official `Q4_K_M` GGUF | `16.76 GB` | Comfortable | Current dense vision-language model with an official Mac-oriented quant |
+| `Ministral 3 14B Instruct` | Official `Q4_K_M` GGUF | `8.24 GB` | Very comfortable | Simplest current general-purpose serving target in this set |
+| `Granite 4.1 30B` | Official `Q4_K_M` GGUF | `17.49 GB` | Comfortable | Apache-licensed text model aimed at instruction following, tools, and RAG |
+| `Nemotron 3 Nano 30B-A3B` | Community MLX 4-bit conversion | About `17.8 GB` | Comfortable with a caveat | Only about `3B` parameters active per token, but the convenient Mac artifact is not NVIDIA's official release |
+| `Mistral Small 4 119B-A6B` | Official `NVFP4` checkpoint | About `70.8 GB` | No | Active compute is small; resident weights still exceed the laptop budget |
+| `DeepSeek V4 Flash 0731` | Official fused checkpoint | About `167 GB` | No | Supported serving starts around `200 GB` of accelerator memory |
+
+“Comfortable” does not mean “load a 128K context for free.” It means the weights leave a credible working budget. The KV cache, Metal buffers, multimodal projector, speculative draft model, application processes, and macOS all draw from the same physical memory. A model whose files consume `60+ GB` is not a `64 GB` laptop model merely because the operating system can swap.
+
+I am using *open-weight* deliberately. These releases do not all use the same license, publish the same training information, or provide equally official Mac artifacts. A downloadable checkpoint is a deployment property, not a blanket claim that every part of the model is open source.
+
+## Muse Glimmer 30B is the interesting new default
+
+Meta's [`Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B) is a `29.6B` dense vision-language model with a `131K` context window. The official [GGUF repository](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF) makes the laptop decision unusually clean: the recommended `Q4_K_M` file is `16,756,683,904` bytes, while the higher-quality dynamic `Q4_K_XL` file is `19,653,960,832` bytes. Both leave far more headroom than this machine needs for text serving.
+
+Vision adds an approximately `1.4 GB` multimodal projector. Meta also publishes an approximately `1.6 GB` DFlash draft model for speculative decoding. Even with both components, the smaller official quant remains comfortably below half of unified memory.
+
+That does not make Glimmer automatically better than every smaller specialist. It makes it the model in this list whose capability envelope is widest without making the fit decision uncomfortable. With full Metal offload, I measured the official `17 GB` quant at `27.9 tok/s`, rising to `48.3 tok/s` with the official DFlash drafter in [my Glimmer benchmark](/blog/2026/08/13/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.html).
+
+## Ministral 3 14B is the low-friction choice
+
+The official [`Ministral-3-14B-Instruct-2512-GGUF`](https://huggingface.co/mistralai/Ministral-3-14B-Instruct-2512-GGUF) repository provides a `Q4_K_M` file of `8,239,593,024` bytes. That is the healthiest memory ratio in the shortlist: the runtime can keep a useful context and still leave most of the machine available for an IDE, browser, retrieval index, and local tools.
+
+I would start here when multimodality and maximum model size are not requirements. A `14B` model that remains responsive inside a real application is more useful than a nominally stronger checkpoint that forces the laptop into memory pressure. This is a sizing recommendation; I have not put Ministral through the identical M5 Max harness yet.
+
+## Granite 4.1 30B is the text-and-tools alternative
+
+IBM's official [`granite-4.1-30b-GGUF`](https://huggingface.co/ibm-granite/granite-4.1-30b-GGUF) release includes a `17,490,240,736`-byte `Q4_K_M` artifact. Its weight budget is almost the same as Glimmer's smaller quant, but the product decision is different: Granite is the text-centric candidate I would inspect for retrieval, tool use, and controlled enterprise workflows rather than for native image understanding.
+
+The fit is easy; model selection still depends on the task. I would evaluate Granite on the actual retrieval documents, function schemas, and refusal behavior before replacing a known-good deployment. Capacity tells me it can participate in that evaluation, not that it wins it.
+
+## Nemotron fits only after a packaging decision
+
+NVIDIA's [`Nemotron-3-Nano-30B-A3B`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16) is a sparse model: roughly `30B` total parameters with about `3B` active per token. The official BF16 repository is approximately `63.2 GB`, which is not a credible `64 GB` deployment after runtime overhead. A community [4-bit MLX conversion](https://huggingface.co/mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit) is about `17.8 GB` and does fit.
+
+That distinction matters. I would use the conversion for experimentation, but I would record the converter, quantization settings, revision, and hashes in any reproducible deployment. “The model fits” and “the vendor ships an official Mac-ready artifact” are separate claims.
+
+## The two tempting models I would not force onto the Mac
+
+Sparse activation does not rescue resident-weight capacity. The official [`Mistral-Small-4-119B-2603-NVFP4`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4) repository is about `70.8 GB`. Its `6B` active parameter count helps per-token compute, but the quantized expert bank still exceeds total unified memory before the runtime and cache exist.
+
+DeepSeek V4 Flash is even clearer. Its official `0731` checkpoint is about `167 GB`, and the maintained vLLM recipe gives it a `200 GB` minimum accelerator-memory target. I broke down that decision in [the DeepSeek fit and serving guide](/blog/2026/08/13/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.html). On this laptop, the exact model belongs behind DeepSeek's API or on a large accelerator server.
+
+## What I would run
+
+For this `64 GB` M5 Max, my order is:
+
+1. Start with `Muse Glimmer 30B Q4_K_M` for a current local multimodal generalist.
+2. Start with `Ministral 3 14B Q4_K_M` when speed, context headroom, and application co-residency matter more than model scale.
+3. Evaluate `Granite 4.1 30B Q4_K_M` for text-heavy retrieval and tool workflows.
+4. Treat `Nemotron 3 Nano` as a community-quant experiment unless an official compressed artifact appears.
+5. Serve `Mistral Small 4` and `DeepSeek V4 Flash` elsewhere instead of turning SSD swap into an inference strategy.
+
+My earlier [Gemma 4 benchmark](/blog/2026/04/04/running-gemma-4-locally-on-a-64-gb-macbook-pro.html) remains relevant if Gemma is already working well. The point of this list is not to replace a stable model every release cycle. It is to make the current capacity boundary explicit: on a `64 GB` Mac, the practical sweet spot is still an official `8–20 GB` quant with enough remaining memory for the context and the application around it.

--- a/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
@@ -1,0 +1,117 @@
+---
+title: Can DeepSeek V4 Flash 0731 Run on a 64 GB MacBook Pro?
+date: '2026-08-13T04:00:00.000Z'
+section: blog
+postSlug: running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro
+legacyPath: /blog/2026/08/13/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.html
+tags:
+  - LLMs
+  - Apple Silicon
+  - Inference
+summary: >-
+  Why DeepSeek V4 Flash 0731 does not fit in 64 GB unified memory, what its
+  13B active parameter count actually means, and the practical serving path.
+---
+# Can DeepSeek V4 Flash 0731 Run on a 64 GB MacBook Pro?
+
+I wanted the same practical answer I measured for Qwen and Gemma: can I fit the exact `DeepSeek-V4-Flash-0731` checkpoint on my `64 GB` M5 Max MacBook Pro, and can I serve it at an interactive speed?
+
+No. The official checkpoint is about `167 GB` on disk, and the maintained vLLM recipe assigns it a `200 GB` minimum accelerator-memory target. That is before leaving room for the inference runtime, activations, and KV cache. A `64 GB` Mac can call the hosted model and can serve a local application backed by that API, but it cannot load the official weights into unified memory.
+
+This is a sizing analysis dated August 13, 2026, not a benchmark. I did not manufacture latency numbers for a model that cannot load on the machine.
+
+## The fit decision
+
+DeepSeek V4 Flash is a mixture-of-experts model with `284B` total parameters and `13B` active parameters per generated token. The second number makes inference compute much smaller than a dense `284B` model, but it does not turn the checkpoint into a `13B` model. The router may choose only a small subset of experts for one token while choosing a different subset for the next, so the serving process still needs access to the full expert bank.
+
+The official [`DeepSeek-V4-Flash-0731` repository](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) contains roughly `166.9 GB` of files. The [vLLM deployment recipe](https://github.com/vllm-project/recipes/blob/main/models/deepseek-ai/DeepSeek-V4-Flash.yaml) rounds the fused checkpoint to about `167 GB` on disk and lists `200 GB` as its minimum VRAM target. The extra margin is not waste: the engine needs working memory, and context consumes additional KV-cache capacity even though V4 compresses that cache aggressively.
+
+| Question | `64 GB` M5 Max | Result |
+| --- | ---: | --- |
+| Can I store the checkpoint? | Requires about `167 GB` of free disk | Possibly |
+| Can I load the official weights? | Checkpoint alone is about `2.6×` total unified memory | No |
+| Can I self-host with the supported vLLM path? | Recipe minimum is `200 GB` accelerator memory | No |
+| Can I use the exact `0731` model from this Mac? | DeepSeek exposes it as `deepseek-v4-flash` | Yes, through the API |
+
+This table separates storage from inference. Downloading `167 GB` to the SSD proves only that the files fit on disk. It does not make them resident in memory, and macOS swap does not convert a `64 GB` laptop into a `200 GB` inference server. An experimental engine could offload experts and stream weights, but a deficit above `100 GB` moves the problem from GPU or unified-memory bandwidth to transfers from much slower storage. That is a systems experiment, not a sensible daily serving plan.
+
+## Why 13B active does not mean 13B resident
+
+The `13B` active count is still useful: it explains why DeepSeek can reduce the arithmetic performed for each token. It answers a compute question, not the fit question.
+
+For a dense model, almost every layer uses almost every weight for every token. For this MoE model, the router activates six of 256 routed experts per token, alongside shared components. That sparsity cuts expert computation, but the next token can select other experts. Unless the runtime accepts the large latency cost of repeatedly fetching missing experts, all routed experts remain part of the resident model state.
+
+The `0731` checkpoint also includes an attached DSpark speculative-decoding module. DeepSeek says the release keeps the preview architecture and changes post-training, while the public model card describes the official checkpoint as new weights plus the draft module. That is why `0731` is about `7 GB` larger than the roughly `160 GB` preview repository even though both use the same `284B`-total, `13B`-active backbone.
+
+The practical memory model is therefore:
+
+$$
+\text{serving memory} \approx \text{all resident weights} + \text{runtime workspace} + \text{KV cache} + \text{request headroom}.
+$$
+
+Active parameters mainly affect the work to generate the next token. Total stored parameters dominate whether the checkpoint can load at all.
+
+## What self-hosting actually requires
+
+DeepSeek's model card demonstrates the exact `0731` checkpoint with vLLM on one `4 × GB300` node. The maintained vLLM recipe also documents hardware-specific deployments and requires vLLM `0.25.0` for the fused DSpark checkpoint. These are accelerator-server configurations, not Apple Silicon paths.
+
+The documented launch shape is:
+
+```bash
+vllm serve deepseek-ai/DeepSeek-V4-Flash-0731 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8 \
+  --block-size 256 \
+  --data-parallel-size 4 \
+  --enable-expert-parallel \
+  --moe-backend deep_gemm_mega_moe \
+  --attention-config '{"use_fp4_indexer_cache": true}' \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"greedy"}'
+```
+
+That command is evidence of the intended serving stack, not a command to paste into the Mac. It assumes supported CUDA hardware, specialized MoE and sparse-attention kernels, and enough aggregate memory for the weights plus serving state. MLX and `llama.cpp` were meaningful choices in my Qwen and Gemma benchmarks because those checkpoints fit. Runtime preference is secondary when the DeepSeek checkpoint misses the machine's memory budget by more than `100 GB`.
+
+## The serving path I would use
+
+On this laptop, I would treat DeepSeek as a remote inference backend. DeepSeek's API currently maps the model name `deepseek-v4-flash` to `DeepSeek-V4-Flash-0731`, exposes an OpenAI-compatible base URL, and supports the one-million-token context window. The model uses thinking mode by default, so I would set that behavior explicitly instead of allowing hidden reasoning work to distort latency and token cost.
+
+```python
+import os
+
+from openai import OpenAI
+
+
+client = OpenAI(
+    api_key=os.environ["DEEPSEEK_API_KEY"],
+    base_url="https://api.deepseek.com",
+)
+
+response = client.chat.completions.create(
+    model="deepseek-v4-flash",
+    messages=[
+        {
+            "role": "user",
+            "content": "Explain why active MoE parameters do not equal resident weights.",
+        }
+    ],
+    reasoning_effort="low",
+    extra_body={"thinking": {"type": "enabled"}},
+)
+
+print(response.choices[0].message.content)
+```
+
+This still lets a local browser app expose a service on the Mac: the UI, retrieval, tools, logging, and request policy run locally, while model inference runs behind DeepSeek's endpoint. It is not private local inference, but it is the only practical way to use the exact `0731` checkpoint on this hardware without renting a large accelerator server.
+
+DeepSeek's pricing changes on August 16, 2026, so I would read the [live pricing page](https://api-docs.deepseek.com/quick_start/pricing/) rather than freeze a cost comparison that will be stale three days after publication. The durable comparison is architectural: API use converts a large fixed hardware commitment into metered requests, while self-hosting becomes rational only when privacy, sustained utilization, or deployment control repays a server with at least roughly `200 GB` of accelerator memory.
+
+## Recommendation
+
+For this `64 GB` M5 Max, my recommendation is:
+
+1. Do not download the official `0731` weights expecting MLX, `llama.cpp`, or Ollama to make them fit.
+2. Use `deepseek-v4-flash` through DeepSeek's API when the exact checkpoint matters.
+3. Keep Qwen or Gemma as the local model when offline use, privacy, or predictable laptop latency matters more than matching DeepSeek's model behavior.
+4. Consider self-hosting DeepSeek V4 Flash only on a supported accelerator configuration with at least the vLLM recipe's `200 GB` memory floor and enough additional capacity for the context and concurrency you actually need.
+
+The important number is not `13B active`. For a fit decision, it is `167 GB` of weights against `64 GB` of unified memory. That comparison ends the local benchmark before the first token.

--- a/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
@@ -1,0 +1,113 @@
+---
+title: Benchmarking Muse Glimmer 30B on a 64 GB MacBook Pro
+date: '2026-08-13T04:00:00.000Z'
+section: blog
+postSlug: running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro
+legacyPath: /blog/2026/08/13/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.html
+tags:
+  - LLMs
+  - Apple Silicon
+  - Inference
+summary: >-
+  A measured llama.cpp benchmark of Meta's official 17 GB Muse Glimmer 30B
+  quant on a 64 GB M5 Max, including reasoning latency and an 8K prompt test.
+---
+# Benchmarking Muse Glimmer 30B on a 64 GB MacBook Pro
+
+`Muse Glimmer 30B` fits comfortably on a `64 GB` M5 Max MacBook Pro and serves through `llama.cpp`. The official `Q4_K_M` GGUF occupies `16.76 GB`. With all layers explicitly placed on Metal, it generated at `27.9 tokens/s`; adding Meta's official `1.63 GB` DFlash drafter raised short-prompt decode to `48.3 tokens/s`.
+
+The first run was much slower—about `10 tokens/s`—because I had left GPU-layer placement on the runtime's automatic setting. The controlled reruns make the practical lesson clearer than the initial number: use full Metal offload, then enable DFlash. That gets close to Meta's reported M5 Max speed on short generation. Long prompts remain the constraint: the `8K` DFlash run needed `16.4 s` to begin reasoning and `17.9 s` to show the answer.
+
+This is a hardware-and-software snapshot from August 13, 2026. Muse Glimmer and its `llama.cpp` support are new enough that runtime releases may change the result materially.
+
+## Why the model fits
+
+Meta's [`Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B) is a `29.6B` dense vision-language model, including an approximately `1.8B` perception encoder, with a `131K` context window. Unlike a mixture-of-experts model, it does not reduce decode compute by activating only a small expert subset. Quantization is what makes the laptop deployment practical.
+
+The official [GGUF release](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF) offers two clear Mac targets:
+
+| Official artifact | File size | Published target | `64 GB` verdict |
+| --- | ---: | ---: | --- |
+| `K-Quant-17GB-Q4_K_M` | `16.76 GB` | `24 GB` VRAM | Comfortable |
+| `Dynamic-20GB-Q4_K_XL` | `19.65 GB` | `32 GB` VRAM | Comfortable |
+
+The vision projector adds about `1.4 GB`; Meta's DFlash speculative draft model adds about `1.6 GB`. Even the `20 GB` quant plus both auxiliaries leaves a credible memory budget on this machine. Context still consumes KV-cache capacity, so “supports 131K” should not be read as “131K will feel interactive.”
+
+I tested the smaller official quant because it is the obvious starting point. It is an official Meta artifact rather than an untracked community conversion, and its exact size is `16,756,683,904` bytes.
+
+## Benchmark setup
+
+I ran the model on:
+
+- `Apple M5 Max`
+- `64 GB` unified memory
+- `macOS 26.5.2`
+- `llama.cpp` build `10360` (`48d22e295`)
+- Official `Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf`
+- Official `dflash-Muse-Glimmer-30B-Q4_K_M.gguf` for the speculative run
+
+Glimmer support requires `llama.cpp` build `10353` or newer, so I upgraded the local Homebrew build from `8660` to `10360` before testing. I used `llama-server` with one slot, Metal acceleration, flash attention, a `16K` allocated context, and the model's Jinja chat template.
+
+The benchmark was text-only, so I did not load the vision projector. I ran three serving configurations: automatic layer placement without a drafter, explicit full Metal offload, and full Metal offload plus DFlash. I used two deterministic suites:
+
+- Short: `512` input tokens, at most `192` completion tokens
+- Long: `8193` input tokens, at most `96` completion tokens
+
+The task asked the model to print zero-padded integers, which it followed until each completion cap. Temperature was `0`, top-p was `1`, top-k was `1`, and the seed was fixed. Glimmer reasons by default, so I set low reasoning strength and a `32`-token reasoning budget rather than pretending hidden generation did not exist.
+
+I report two first-token measurements. *First generated token* includes hidden reasoning. *First answer token* is when visible content begins. Decode throughput comes from all completion tokens and the time after the first streamed token, while average throughput includes prompt processing and generation.
+
+## Results
+
+| Configuration | Input | First generated | First answer | Decode tok/s | End-to-end average |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Auto placement | `512` | `2.40 s` | `9.77 s` | `9.92` | `8.83 tok/s` |
+| Full Metal | `512` | `0.95 s` | `3.50 s` | `27.90` | `24.52 tok/s` |
+| Full Metal + DFlash | `512` | `1.01 s` | `2.67 s` | `48.31` | `38.54 tok/s` |
+| Auto placement | `8193` | `32.26 s` | `37.41 s` | `10.07` | `2.30 tok/s` |
+| Full Metal | `8193` | `17.10 s` | `19.01 s` | `26.62` | `4.64 tok/s` |
+| Full Metal + DFlash | `8193` | `16.41 s` | `17.94 s` | `35.47` | `5.02 tok/s` |
+
+The largest correction was explicit placement. `--gpu-layers all` lifted the short decode rate from `9.92` to `27.90 tok/s`, a `2.8×` change before speculation entered the comparison. It also cut the long prompt's first generated token from `32.26 s` to `17.10 s`. A model that fits in unified memory can still run slowly if the engine chooses a conservative CPU/GPU split.
+
+DFlash then changed decode rather than fit. With `--spec-type draft-dflash` active, the server accepted `87.9%` of proposed short-suite draft tokens and `79.8%` on the long suite. Short decode rose from `27.90` to `48.31 tok/s`; long decode rose from `26.62` to `35.47 tok/s`. The speedup is smaller at `8K` because prompt processing is unchanged by speculative generation and dominates more of the request.
+
+Reasoning creates a second latency boundary. In the short DFlash suite, the server began hidden generation at `1.01 s`, while the first visible integer arrived at `2.67 s`. A client that reports only transport-level time to first token still makes the chat experience look faster than it feels, although the gap is no longer severe.
+
+Meta reports `26.6 tok/s` without DFlash and `50.2 tok/s` with DFlash on an M5 Max, using ExecuTorch, batch size one, and greedy decoding. My short `llama.cpp` results of `27.90` and `48.31 tok/s` are remarkably close, but they remain separate measurements from a different runtime and harness. The agreement is useful evidence that the optimized local path is working; it is not a cross-runtime benchmark victory.
+
+## Serving Glimmer locally
+
+The text-only OpenAI-compatible server I validated is:
+
+```bash
+llama-server \
+  --model Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf \
+  --alias muse-glimmer-30b \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --ctx-size 16384 \
+  --parallel 1 \
+  --gpu-layers all \
+  --flash-attn on \
+  --model-draft dflash-Muse-Glimmer-30B-Q4_K_M.gguf \
+  --gpu-layers-draft all \
+  --spec-type draft-dflash \
+  --jinja \
+  --reasoning-budget 32 \
+  --chat-template-kwargs '{"reasoning_strength":"low"}'
+```
+
+Keeping the host on `127.0.0.1` matters because `llama-server` otherwise needs deliberate authentication and network policy. Once it is listening, an OpenAI-compatible client can use `http://127.0.0.1:8080/v1` as its base URL.
+
+For vision, download the matching projector from the official GGUF repository and add `--mmproj mmproj-Muse-Glimmer-30B-Q4_K_M.gguf`. That adds image input but was not part of this text benchmark. On `llama.cpp` build `10360`, merely loading the DFlash file did not activate speculation: the server log showed draft loading but no accepted proposals. Adding `--spec-type draft-dflash` produced explicit acceptance statistics and the measured speedup, so I would keep that flag rather than assume autodetection.
+
+The reusable harness for this run is in [`scripts/bench_llama_server_local.py`](https://github.com/arunabh1904/arunabh1904.github.io/blob/main/scripts/bench_llama_server_local.py). It refuses to run on an occupied port so that a stale local server cannot silently contaminate the measurements.
+
+## Recommendation
+
+I would run Glimmer locally when I want one current model that can cover text and images without putting pressure on a `64 GB` memory budget. I would start with the official `17 GB Q4_K_M`, add the projector only when the application needs vision, and keep the context well below the advertised maximum until the workload proves otherwise.
+
+I would use the full-Metal DFlash configuration for rapid local chat. Nearly `48 tok/s` on the short suite is fluid, and the model still leaves ample memory headroom. I would remain careful with agent loops that repeatedly inject `8K` of state: speculative decoding accelerates generation, not the entire prefill, so the long suite still took almost `18 s` to expose an answer. The next optimization target is prompt reuse or a smaller active context, not a larger quant.
+
+For the broader laptop decision, see [which current open-weight models fit on a 64 GB Mac](/blog/2026/08/13/open-weight-models-that-fit-on-a-64-gb-macbook-pro.html). Glimmer is the most interesting new model in that list because it fits with room to spare. DeepSeek V4 Flash is the opposite case: its official checkpoint is about `167 GB`, so [serving it from this Mac means using an API](/blog/2026/08/13/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.html), not finding a cleverer local runtime.


### PR DESCRIPTION
## Summary
- add a fit and serving analysis for DeepSeek V4 Flash 0731 on a 64 GB M5 Max
- benchmark Muse Glimmer 30B with automatic placement, full Metal offload, and active DFlash speculation
- add a current open-weight model shortlist excluding the old Qwen line
- publish a reusable llama-server benchmark harness and correct the existing DeepSeek 0731 note now that exact weights are public

## Validation
- `python3 -m py_compile scripts/bench_llama_server_local.py`
- `git diff --check`
- `npm run ci` (0 Astro diagnostics; 7 test files / 28 tests; 256 pages built)
- local browser QA for all new routes, tables, code, cross-links, broken images, and horizontal overflow
- measured official Glimmer 17 GB GGUF on Apple M5 Max with llama.cpp build 10360