### PR TITLE
Add PyTorch revision insight callouts

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -5059,6 +5059,71 @@ html {
   margin: 0;
 }
 
+.revision-insight {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.9rem;
+  align-items: start;
+  margin: 1.5rem 0 1.75rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid color-mix(in srgb, var(--accent-color) 40%, transparent);
+  border-left: 4px solid var(--accent-color);
+  border-radius: 14px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-color) 12%, transparent), transparent 70%),
+    var(--panel-bg);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--accent-color) 8%, transparent);
+}
+
+.revision-insight__badge {
+  display: grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  place-items: center;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.revision-insight__title {
+  margin: 0 0 0.35rem;
+  color: var(--text-color);
+  font-family: var(--font-heading);
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.revision-insight__content > :first-child {
+  margin-top: 0;
+}
+
+.revision-insight__content > :last-child {
+  margin-bottom: 0;
+}
+
+.revision-insight__content p,
+.revision-insight__content li {
+  font-size: 0.95rem;
+}
+
+.revision-insight__content pre {
+  margin: 0.8rem 0;
+}
+
+@media (max-width: 560px) {
+  .revision-insight {
+    grid-template-columns: 1fr;
+  }
+
+  .revision-insight__badge {
+    width: 2rem;
+    height: 2rem;
+  }
+}
+
 /* Revision notes use the same compact, code-first workspace as Code practice. */
 .python-playground--compact {
   display: grid;

--- a/src/components/RevisionInsight.astro
+++ b/src/components/RevisionInsight.astro
@@ -1,0 +1,16 @@
+---
+interface Props {
+  title?: string;
+  icon?: string;
+}
+
+const { title = 'More you know', icon = '🧠' } = Astro.props;
+---
+
+<aside class="revision-insight" aria-label={title}>
+  <div class="revision-insight__badge" aria-hidden="true">{icon}</div>
+  <div class="revision-insight__body">
+    <p class="revision-insight__title">{title}</p>
+    <div class="revision-insight__content"><slot /></div>
+  </div>
+</aside>

--- a/src/content/posts/pytorch-autograd-and-training.mdx
+++ b/src/content/posts/pytorch-autograd-and-training.mdx
@@ -9,6 +9,7 @@ tags:
 summary: Derive how PyTorch records operations, computes gradients, registers model state, updates parameters, loads data, and saves training state.
 ---
 import RevisionCodePair from '../../components/RevisionCodePair.astro';
+import RevisionInsight from '../../components/RevisionInsight.astro';
 import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
 
 # PyTorch II: Autograd and Training
@@ -84,6 +85,16 @@ Autograd state and module mode are separate controls:
 
 Use `no_grad` for parameter updates and for computations whose results may later be used with autograd. Use `inference_mode` for an isolated inference path after checking compatibility. Call `model.train()` or `model.eval()` whenever the model contains modules whose forward behavior changes by mode. Evaluation usually requires both `model.eval()` and a disabled gradient context.
 
+<RevisionInsight title="More you know · five switches, five meanings" icon="🧠">
+
+`model.train()` and `model.eval()` change module behavior—most visibly Dropout and BatchNorm—but they do not turn autograd on or off. `torch.no_grad()` changes the gradient-recording context, so the usual validation boundary is `model.eval()` plus `torch.no_grad()`.
+
+`requires_grad` is tensor metadata: it asks autograd to track future operations involving that tensor when grad mode is enabled. It is not the same as `detach()`, which removes an existing graph edge. A leaf tensor is typically user-created and has no `grad_fn`; when it requires gradients, backward writes into its `.grad`. Intermediate tensors do not retain `.grad` unless you call `retain_grad()`.
+
+The debugging question is therefore: “Is the module in the right mode, is grad recording enabled, and is this tensor a leaf connected to the loss?” Those are three separate checks, not three spellings for the same operation.
+
+</RevisionInsight>
+
 ## Modules and model state
 
 `nn.Module` registers state through attribute assignment. Assigning an `nn.Parameter` registers a trainable tensor. Assigning another `Module` registers a child subtree. `register_buffer` registers tensor state that should move with the module but should not be optimized. Methods such as `parameters()`, `state_dict()`, `to()`, and `train()` traverse this registered tree.
@@ -98,6 +109,30 @@ Call `model(inputs)` rather than `model.forward(inputs)` so that `Module.__call_
 | Plain tensor attribute | No | No | No |
 
 `forward` defines the computation. Registration defines which tensors belong to the model across optimization, device placement, serialization, and distributed wrapping. A tensor used by `forward` but absent from the registered tree may compute correctly on one machine and still disappear from the rest of the training system.
+
+<RevisionInsight title="More you know · the model is the registered tree" icon="🧩">
+
+The screenshot's bug is a registration bug, not a Python-loop bug:
+
+```python
+class BadModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = [nn.Linear(256, 256) for _ in range(5)]  # invisible
+
+class GoodModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(nn.Linear(256, 256) for _ in range(5))
+        self.heads = nn.ModuleDict({"main": nn.Linear(256, 10)})
+        self.register_buffer("temperature", torch.ones(()))
+```
+
+An assigned `nn.Parameter` is trainable model state; an ordinary `Tensor`, even one with `requires_grad=True`, is not automatically a parameter. `ModuleList` and `ModuleDict` register child modules, while a plain Python `list` or `dict` hides them from `parameters()`, `state_dict()`, `to()`, `cuda()`, and `train()`/`eval()`. `register_buffer()` is for tensor state that should move and serialize with the module but should not be optimized.
+
+This is why `model.cuda()` or `model.to(device)` cannot repair an unregistered layer: device movement only traverses the registered module tree. When a model behaves differently across CPU and GPU, inspect `named_parameters()`, `named_buffers()`, and every child container before inspecting the kernel.
+
+</RevisionInsight>
 
 ## Loss functions
 

--- a/src/content/posts/pytorch-systems-and-scale.mdx
+++ b/src/content/posts/pytorch-systems-and-scale.mdx
@@ -9,6 +9,7 @@ tags:
 summary: Analyze PyTorch execution through device transfers, streams, memory lifetime, compilation, distributed training, export, and profiling.
 ---
 import RevisionCodePair from '../../components/RevisionCodePair.astro';
+import RevisionInsight from '../../components/RevisionInsight.astro';
 import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
 
 # PyTorch III: Performance and Scale
@@ -26,6 +27,14 @@ PyTorch supports several backends, including CPU, CUDA, MPS, and XPU, with diffe
 `tensor.to(device=..., dtype=..., non_blocking=..., copy=...)` handles tensor conversion. It may return the original tensor when neither dtype nor device changes. `module.to(...)` instead updates the registered parameters and buffers in the module tree and returns the module. The difference matters when tracking allocation: tensor conversion usually produces a value, while module conversion updates model state.
 
 Pinned CPU memory allows CUDA to perform direct memory access for host-to-device copies. With `non_blocking=True`, the Python thread does not wait for the copy to finish. This does not guarantee overlap with useful work: overlap requires independent host work or device work on a stream that can run while the transfer is in progress. Pinning also consumes a limited host resource, so it should be tested with the actual input pipeline.
+
+<RevisionInsight title="More you know · device bugs often start in containers" icon="🚦">
+
+`model.to(device)` and `model.cuda()` recurse through registered parameters, buffers, and child modules only. A layer kept in a plain Python `list` remains unregistered and may stay on the CPU even though the top-level model reports a CUDA device. Use `ModuleList`/`ModuleDict` for dynamic module collections and `register_buffer()` for non-trainable tensor state that must follow the model.
+
+Before chasing an accelerator error, check that the inputs, `named_parameters()`, and `named_buffers()` agree on device and dtype. Registration is the boundary between “Python can reach this object” and “PyTorch knows this object is part of the model.”
+
+</RevisionInsight>
 
 ## Asynchronous execution
 

--- a/src/content/posts/pytorch-tensor-revision-notes.mdx
+++ b/src/content/posts/pytorch-tensor-revision-notes.mdx
@@ -9,6 +9,7 @@ tags:
 summary: Understand how PyTorch represents tensors through storage, shape, strides, dtype, device, layout, and autograd metadata.
 ---
 import RevisionCodePair from '../../components/RevisionCodePair.astro';
+import RevisionInsight from '../../components/RevisionInsight.astro';
 import { pytorchRevisionExamples } from '../../lib/pytorch-revision-examples';
 
 # PyTorch I: Tensors
@@ -62,6 +63,16 @@ NumPy and PyTorch have different defaults at this boundary. A NumPy array create
 `contiguous()`, `clone()`, and `detach()` solve different problems. `contiguous()` copies only when the tensor does not already have the requested memory format. `clone()` always copies the values and preserves the autograd connection to the source. `detach()` removes the incoming autograd edge but usually keeps the same storage. A tensor can therefore be independent in storage but connected in the computation graph, or detached from the graph but aliased in storage.
 
 Aliasing becomes visible under mutation. Methods ending in `_`, indexed assignment, and operations with an `out=` argument write into existing storage. Every view of that storage can observe the change. During training, an in-place write may also change a value that autograd saved for backward; Part II explains how PyTorch detects that case.
+
+<RevisionInsight title="More you know · storage and graph are different" icon="👀">
+
+`view()` is a stride-only reinterpretation and fails when the layout cannot support it; `reshape()` chooses a view when possible and silently copies otherwise. `contiguous()` makes a contiguous copy only when needed. Do not use `reshape()` when you need to prove that no allocation occurred.
+
+`clone()` gives the values new storage but keeps the autograd connection. `detach()` cuts the graph edge but usually shares storage with the source. For an independent snapshot with no gradient history, use `x.detach().clone()`.
+
+An `in-place` operation such as `add_()`, `relu_()`, or indexed assignment mutates every alias. That can change a value saved for backward and trigger a version-counter error—or, outside autograd's checks, make the computation harder to reason about. Prefer the out-of-place form unless the memory trade-off is deliberate and tested.
+
+</RevisionInsight>
 
 [![Animation comparing how a slice view, detached tensor, and clone respond to an in-place mutation](/assets/images/pytorch-tensor-aliasing.gif)](/assets/images/pytorch-tensor-aliasing.gif)
 


### PR DESCRIPTION
## What changed
- Add reusable More you know callouts to the three PyTorch revision notes.
- Cover autograd modes, tensor aliasing, reshape/view behavior, in-place operations, module registration, containers, buffers, and device placement.
- Add a screenshot-inspired ModuleList versus plain-list debugging example.

## Testing
- git diff --check
- npm run ci
- 0 Astro diagnostics, 28 tests passed, production build and verify-build passed.