### PR TITLE
Tighten PyTorch revision insight cards

### DIFF
--- a/src/components/RevisionInsight.astro
+++ b/src/components/RevisionInsight.astro
@@ -4,7 +4,7 @@ interface Props {
   icon?: string;
 }
 
-const { title = 'More you know', icon = '🧠' } = Astro.props;
+const { title = '💡', icon = '💡' } = Astro.props;
 ---
 
 <aside class="revision-insight" aria-label={title}>

--- a/src/content/posts/pytorch-autograd-and-training.mdx
+++ b/src/content/posts/pytorch-autograd-and-training.mdx
@@ -85,13 +85,11 @@ Autograd state and module mode are separate controls:
 
 Use `no_grad` for parameter updates and for computations whose results may later be used with autograd. Use `inference_mode` for an isolated inference path after checking compatibility. Call `model.train()` or `model.eval()` whenever the model contains modules whose forward behavior changes by mode. Evaluation usually requires both `model.eval()` and a disabled gradient context.
 
-<RevisionInsight title="More you know · five switches, five meanings" icon="🧠">
+<RevisionInsight title="Five switches, five meanings" icon="💡">
 
-`model.train()` and `model.eval()` change module behavior—most visibly Dropout and BatchNorm—but they do not turn autograd on or off. `torch.no_grad()` changes the gradient-recording context, so the usual validation boundary is `model.eval()` plus `torch.no_grad()`.
+`model.train()` and `model.eval()` control module behavior such as Dropout and BatchNorm; they do not control autograd. `torch.no_grad()` and `torch.inference_mode()` control graph recording, so validation usually needs `model.eval()` plus `torch.no_grad()`.
 
-`requires_grad` is tensor metadata: it asks autograd to track future operations involving that tensor when grad mode is enabled. It is not the same as `detach()`, which removes an existing graph edge. A leaf tensor is typically user-created and has no `grad_fn`; when it requires gradients, backward writes into its `.grad`. Intermediate tensors do not retain `.grad` unless you call `retain_grad()`.
-
-The debugging question is therefore: “Is the module in the right mode, is grad recording enabled, and is this tensor a leaf connected to the loss?” Those are three separate checks, not three spellings for the same operation.
+`requires_grad` tracks future operations, while `detach()` cuts an existing graph edge. Leaf tensors receive `.grad`; intermediate tensors need `retain_grad()`. Debug these as separate checks: module mode, grad mode, and whether the tensor is a leaf connected to the loss.
 
 </RevisionInsight>
 
@@ -110,7 +108,7 @@ Call `model(inputs)` rather than `model.forward(inputs)` so that `Module.__call_
 
 `forward` defines the computation. Registration defines which tensors belong to the model across optimization, device placement, serialization, and distributed wrapping. A tensor used by `forward` but absent from the registered tree may compute correctly on one machine and still disappear from the rest of the training system.
 
-<RevisionInsight title="More you know · the model is the registered tree" icon="🧩">
+<RevisionInsight title="The model is the registered tree" icon="💡">
 
 The screenshot's bug is a registration bug, not a Python-loop bug:
 
@@ -128,9 +126,9 @@ class GoodModel(nn.Module):
         self.register_buffer("temperature", torch.ones(()))
 ```
 
-An assigned `nn.Parameter` is trainable model state; an ordinary `Tensor`, even one with `requires_grad=True`, is not automatically a parameter. `ModuleList` and `ModuleDict` register child modules, while a plain Python `list` or `dict` hides them from `parameters()`, `state_dict()`, `to()`, `cuda()`, and `train()`/`eval()`. `register_buffer()` is for tensor state that should move and serialize with the module but should not be optimized.
+`nn.Parameter` is trainable model state. `ModuleList` and `ModuleDict` register child modules; a plain Python `list` or `dict` hides them from `parameters()`, `state_dict()`, `to()`, `cuda()`, and `train()`/`eval()`. Use `register_buffer()` for non-trainable tensor state that should move and serialize.
 
-This is why `model.cuda()` or `model.to(device)` cannot repair an unregistered layer: device movement only traverses the registered module tree. When a model behaves differently across CPU and GPU, inspect `named_parameters()`, `named_buffers()`, and every child container before inspecting the kernel.
+`model.to(device)` cannot repair an unregistered layer because it only traverses the registered tree. If CPU/GPU behavior differs, inspect `named_parameters()`, `named_buffers()`, and child containers.
 
 </RevisionInsight>
 

--- a/src/content/posts/pytorch-systems-and-scale.mdx
+++ b/src/content/posts/pytorch-systems-and-scale.mdx
@@ -28,11 +28,11 @@ PyTorch supports several backends, including CPU, CUDA, MPS, and XPU, with diffe
 
 Pinned CPU memory allows CUDA to perform direct memory access for host-to-device copies. With `non_blocking=True`, the Python thread does not wait for the copy to finish. This does not guarantee overlap with useful work: overlap requires independent host work or device work on a stream that can run while the transfer is in progress. Pinning also consumes a limited host resource, so it should be tested with the actual input pipeline.
 
-<RevisionInsight title="More you know · device bugs often start in containers" icon="🚦">
+<RevisionInsight title="Device bugs often start in containers" icon="💡">
 
-`model.to(device)` and `model.cuda()` recurse through registered parameters, buffers, and child modules only. A layer kept in a plain Python `list` remains unregistered and may stay on the CPU even though the top-level model reports a CUDA device. Use `ModuleList`/`ModuleDict` for dynamic module collections and `register_buffer()` for non-trainable tensor state that must follow the model.
+`model.to(device)` follows registered parameters, buffers, and child modules only. A layer in a plain Python `list` can stay on the CPU; use `ModuleList`/`ModuleDict` and `register_buffer()` for state that must follow the model.
 
-Before chasing an accelerator error, check that the inputs, `named_parameters()`, and `named_buffers()` agree on device and dtype. Registration is the boundary between “Python can reach this object” and “PyTorch knows this object is part of the model.”
+Before chasing an accelerator error, compare the inputs, `named_parameters()`, and `named_buffers()` for device and dtype mismatches.
 
 </RevisionInsight>
 

--- a/src/content/posts/pytorch-tensor-revision-notes.mdx
+++ b/src/content/posts/pytorch-tensor-revision-notes.mdx
@@ -64,13 +64,11 @@ NumPy and PyTorch have different defaults at this boundary. A NumPy array create
 
 Aliasing becomes visible under mutation. Methods ending in `_`, indexed assignment, and operations with an `out=` argument write into existing storage. Every view of that storage can observe the change. During training, an in-place write may also change a value that autograd saved for backward; Part II explains how PyTorch detects that case.
 
-<RevisionInsight title="More you know · storage and graph are different" icon="👀">
+<RevisionInsight title="Storage and graph are different" icon="💡">
 
-`view()` is a stride-only reinterpretation and fails when the layout cannot support it; `reshape()` chooses a view when possible and silently copies otherwise. `contiguous()` makes a contiguous copy only when needed. Do not use `reshape()` when you need to prove that no allocation occurred.
+`view()` only changes shape when strides allow it; `reshape()` may silently copy. `contiguous()` copies only when needed, `clone()` copies storage but keeps the graph edge, and `detach()` cuts the edge but usually shares storage. For an independent snapshot, use `x.detach().clone()`.
 
-`clone()` gives the values new storage but keeps the autograd connection. `detach()` cuts the graph edge but usually shares storage with the source. For an independent snapshot with no gradient history, use `x.detach().clone()`.
-
-An `in-place` operation such as `add_()`, `relu_()`, or indexed assignment mutates every alias. That can change a value saved for backward and trigger a version-counter error—or, outside autograd's checks, make the computation harder to reason about. Prefer the out-of-place form unless the memory trade-off is deliberate and tested.
+In-place writes mutate every alias and can invalidate values saved for backward. Prefer out-of-place operations unless the memory trade-off is measured and tested.
 
 </RevisionInsight>
 


### PR DESCRIPTION
## What changed
- Replace the generic More you know heading with a lightbulb cue.
- Shorten the four PyTorch revision insight cards while preserving the technical distinctions.

## Why
Make the callouts faster to scan and less repetitive.

## Validation
- npm run ci
- Pre-push CI passed
- 0 Astro diagnostics, 31 tests passed, 272 pages built, build verification passed