### PR TITLE
Keep Code walkthrough annotations beside editor

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -6193,102 +6193,6 @@ html {
   justify-content: flex-end;
 }
 
-.code-practice-lab__view-toggle {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  padding: 0.25rem;
-  border: 1px solid rgba(127, 197, 255, 0.28);
-  border-radius: 14px;
-  background: rgba(5, 16, 34, 0.72);
-}
-
-.code-practice-lab__button--view {
-  min-height: 2.35rem;
-  padding-inline: 0.75rem;
-  border-color: transparent;
-  background: transparent;
-  box-shadow: none;
-}
-
-.code-practice-lab__button--view:hover:not(:disabled),
-.code-practice-lab__button--view.code-practice-lab__button--active {
-  border-color: rgba(127, 197, 255, 0.46);
-  background: rgba(41, 91, 151, 0.54);
-  box-shadow: none;
-}
-
-.code-practice-lab__walkthrough {
-  min-height: 36rem;
-  padding: clamp(1.25rem, 3vw, 2.4rem);
-  border: 1px solid rgba(127, 197, 255, 0.2);
-  border-radius: 18px;
-  background: rgba(7, 20, 43, 0.72);
-}
-
-.code-practice-lab__walkthrough-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.code-practice-lab__walkthrough-heading h2 {
-  margin: 0.25rem 0 0;
-  color: #f5fbff;
-  font-size: clamp(1.2rem, 2vw, 1.65rem);
-}
-
-.code-practice-lab__walkthrough-copy {
-  max-width: 62ch;
-  margin-top: 1.5rem;
-}
-
-.code-practice-lab__walkthrough-copy p {
-  margin: 0 0 1rem;
-  color: rgba(223, 240, 255, 0.9);
-  line-height: 1.7;
-}
-
-.code-practice-lab__walkthrough-tip {
-  max-width: 62ch;
-  margin: 2rem 0 0;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(127, 197, 255, 0.16);
-  color: rgba(223, 240, 255, 0.68);
-  font-size: 0.9rem;
-  line-height: 1.6;
-}
-
-:root[data-theme="dark"] .code-practice-lab__view-toggle {
-  border-color: rgba(255, 228, 92, 0.28);
-  background: rgba(35, 28, 2, 0.72);
-}
-
-:root[data-theme="dark"] .code-practice-lab__button--view:hover:not(:disabled),
-:root[data-theme="dark"] .code-practice-lab__button--view.code-practice-lab__button--active {
-  border-color: rgba(255, 228, 92, 0.5);
-  background: rgba(104, 78, 8, 0.56);
-}
-
-:root[data-theme="dark"] .code-practice-lab__walkthrough {
-  border-color: rgba(255, 228, 92, 0.2);
-  background: rgba(24, 20, 3, 0.72);
-}
-
-:root[data-theme="dark"] .code-practice-lab__walkthrough-heading h2 {
-  color: #fff7cf;
-}
-
-:root[data-theme="dark"] .code-practice-lab__walkthrough-copy p {
-  color: rgba(255, 247, 207, 0.9);
-}
-
-:root[data-theme="dark"] .code-practice-lab__walkthrough-tip {
-  border-color: rgba(255, 228, 92, 0.16);
-  color: rgba(255, 247, 207, 0.68);
-}
-
 .code-practice-lab__button {
   appearance: none;
   display: inline-flex;
@@ -6819,8 +6723,7 @@ html {
 }
 
 :root[data-theme="light"] .code-practice-lab__problem-header h1,
-:root[data-theme="light"] .code-practice-lab__workspace-header h2,
-:root[data-theme="light"] .code-practice-lab__walkthrough-heading h2 {
+:root[data-theme="light"] .code-practice-lab__workspace-header h2 {
   color: var(--text-color);
 }
 
@@ -6828,14 +6731,12 @@ html {
 :root[data-theme="light"] .code-practice-lab__status,
 :root[data-theme="light"] .code-practice-lab__shortcut,
 :root[data-theme="light"] .code-practice-lab__editor-label,
-:root[data-theme="light"] .code-practice-lab__walkthrough-copy p,
-:root[data-theme="light"] .code-practice-lab__walkthrough-tip {
+:root[data-theme="light"] .code-practice-lab__annotation p {
   color: var(--text-secondary-color);
 }
 
 :root[data-theme="light"] .code-practice-lab__spec-card,
 :root[data-theme="light"] .code-practice-lab__example,
-:root[data-theme="light"] .code-practice-lab__walkthrough,
 :root[data-theme="light"] .code-practice-lab__output > div {
   border-color: var(--code-border-color);
   background: var(--panel-bg);
@@ -6875,18 +6776,6 @@ html {
   color: #654409;
 }
 
-:root[data-theme="light"] .code-practice-lab__view-toggle {
-  border-color: var(--button-border);
-  background: var(--background-secondary);
-}
-
-:root[data-theme="light"] .code-practice-lab__button--view:hover:not(:disabled),
-:root[data-theme="light"] .code-practice-lab__button--view.code-practice-lab__button--active {
-  border-color: rgba(53, 109, 255, 0.36);
-  background: rgba(53, 109, 255, 0.14);
-  box-shadow: none;
-}
-
 :root[data-theme="light"] .code-practice-lab__editor-shell,
 :root[data-theme="light"] .code-practice-lab__editor .cm-editor {
   border-color: var(--code-border-color);
@@ -6906,4 +6795,130 @@ html {
 :root[data-theme="light"] .code-practice-lab__editor .cm-activeLine,
 :root[data-theme="light"] .code-practice-lab__editor .cm-activeLineGutter {
   background: rgba(53, 109, 255, 0.07);
+}
+
+/* Keep the explanation beside the code so it is available while editing. */
+.code-practice-lab__editor-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(15rem, 0.38fr);
+  gap: 1rem;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.code-practice-lab__editor-column {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.code-practice-lab__annotations {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  padding: 0.55rem 0.25rem 0.75rem 1rem;
+  border-left: 1px solid rgba(118, 169, 255, 0.18);
+}
+
+.code-practice-lab__annotations-heading h2 {
+  margin: 0.25rem 0 0;
+  color: #f5fbff;
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+:root[data-theme="dark"] .code-practice-lab__annotations {
+  border-color: rgba(255, 228, 92, 0.18);
+}
+
+:root[data-theme="dark"] .code-practice-lab__annotations-heading h2 {
+  color: #fff7cf;
+}
+
+.code-practice-lab__annotation-list {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1.1rem;
+}
+
+.code-practice-lab__annotation {
+  display: grid;
+  grid-template-columns: 1.8rem minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: start;
+  padding: 0.75rem 0.8rem 0.8rem 0;
+  border-top: 1px solid rgba(118, 169, 255, 0.14);
+}
+
+.code-practice-lab__annotation-marker {
+  display: inline-grid;
+  place-items: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  border: 1px solid rgba(127, 197, 255, 0.3);
+  border-radius: 50%;
+  color: #8fd2ff;
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.code-practice-lab__annotation p {
+  margin: 0;
+  color: rgba(223, 240, 255, 0.78);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+:root[data-theme="dark"] .code-practice-lab__annotation {
+  border-color: rgba(255, 228, 92, 0.14);
+}
+
+:root[data-theme="dark"] .code-practice-lab__annotation-marker {
+  border-color: rgba(255, 228, 92, 0.34);
+  color: #ffe45c;
+}
+
+:root[data-theme="dark"] .code-practice-lab__annotation p {
+  color: rgba(255, 247, 207, 0.78);
+}
+
+:root[data-theme="light"] .code-practice-lab__annotations {
+  border-color: var(--code-border-color);
+}
+
+:root[data-theme="light"] .code-practice-lab__annotations-heading h2 {
+  color: var(--text-color);
+}
+
+:root[data-theme="light"] .code-practice-lab__annotation {
+  border-color: var(--code-border-color);
+}
+
+:root[data-theme="light"] .code-practice-lab__annotation-marker {
+  border-color: rgba(53, 109, 255, 0.3);
+  color: var(--accent-color);
+}
+
+:root[data-theme="light"] .code-practice-lab__annotation p {
+  color: var(--text-secondary-color);
+}
+
+@media (max-width: 980px) {
+  .code-practice-lab__editor-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(24rem, 1fr) auto;
+    overflow: auto;
+  }
+
+  .code-practice-lab__annotations {
+    overflow: visible;
+    padding: 1rem 0 0;
+    border-top: 1px solid rgba(118, 169, 255, 0.18);
+    border-left: 0;
+  }
+
+  :root[data-theme="dark"] .code-practice-lab__annotations {
+    border-color: rgba(255, 228, 92, 0.18);
+  }
 }

--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -27,20 +27,48 @@ function createHintCommentBlock(hints: readonly string[]) {
   return ['# Hints', ...hints.map((hint, index) => `# ${index + 1}. ${hint}`)].join('\n');
 }
 
+/**
+ * The exercise scaffold used to repeat the guidance in a large TODO comment
+ * block above the placeholder. That guidance now lives beside the editor, so
+ * keep only the executable placeholder in the code surface.
+ */
+function removeTodoCommentBlocks(source: string) {
+  const lines = source.split('\n');
+  const cleaned: string[] = [];
+  let removingTodoComments = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (/^# TODO\b/.test(trimmed)) {
+      removingTodoComments = true;
+      continue;
+    }
+
+    if (removingTodoComments && (trimmed === '' || trimmed.startsWith('#'))) {
+      continue;
+    }
+
+    removingTodoComments = false;
+    cleaned.push(line);
+  }
+
+  return cleaned.join('\n');
+}
+
 export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const containerRef = useRef<HTMLElement | null>(null);
   const runtimeRef = useRef<PyodideRuntime | null>(null);
   const loadingRef = useRef(false);
   const isRunningRef = useRef(false);
   const runHandlerRef = useRef<() => void>(() => {});
-  const [code, setCode] = useState(problem.starterCode);
+  const [code, setCode] = useState(() => removeTodoCommentBlocks(problem.starterCode));
   const [output, setOutput] = useState('');
   const [errorOutput, setErrorOutput] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [statusMessage, setStatusMessage] = useState('Loading Python...');
   const [isRunning, setIsRunning] = useState(false);
   const [hasRun, setHasRun] = useState(false);
-  const [viewMode, setViewMode] = useState<'code' | 'walkthrough'>('code');
   const [editorTheme, setEditorTheme] = useState(() =>
     getCodeEditorThemeName(
       typeof document === 'undefined' ? 'light' : document.documentElement.getAttribute('data-theme'),
@@ -74,11 +102,10 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   );
 
   useEffect(() => {
-    setCode(problem.starterCode);
+    setCode(removeTodoCommentBlocks(problem.starterCode));
     setOutput('');
     setErrorOutput('');
     setHasRun(false);
-    setViewMode('code');
   }, [problem]);
 
   useEffect(() => {
@@ -205,7 +232,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   }
 
   function handleReset() {
-    setCode(problem.starterCode);
+    setCode(removeTodoCommentBlocks(problem.starterCode));
     setOutput('');
     setErrorOutput('');
     setHasRun(false);
@@ -302,65 +329,43 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
             </p>
           </div>
           <div className="code-practice-lab__workspace-controls">
-            <div className="code-practice-lab__view-toggle" role="group" aria-label="Practice view">
-              <button
-                className={`code-practice-lab__button code-practice-lab__button--view${viewMode === 'code' ? ' code-practice-lab__button--active' : ''}`}
-                type="button"
-                aria-pressed={viewMode === 'code'}
-                onClick={() => setViewMode('code')}
-              >
-                Code
-              </button>
-              <button
-                className={`code-practice-lab__button code-practice-lab__button--view${viewMode === 'walkthrough' ? ' code-practice-lab__button--active' : ''}`}
-                type="button"
-                aria-pressed={viewMode === 'walkthrough'}
-                onClick={() => setViewMode('walkthrough')}
-              >
-                Walkthrough
-              </button>
-            </div>
-            {viewMode === 'code' && (
-              <>
-                <button
-                  className="code-practice-lab__button code-practice-lab__button--secondary"
-                  type="button"
-                  onClick={handleAddHints}
-                >
-                  Add hints
-                </button>
-                <button
-                  className="code-practice-lab__button code-practice-lab__button--solution"
-                  type="button"
-                  onClick={handleLoadSolution}
-                >
-                  Load solution
-                </button>
-                <button
-                  className="code-practice-lab__button code-practice-lab__button--primary"
-                  type="button"
-                  aria-label="Run code"
-                  aria-keyshortcuts="Control+Enter Meta+Enter"
-                  onClick={() => void handleRun()}
-                  disabled={status !== 'ready' || isRunning}
-                >
-                  <span>{isRunning ? 'Running...' : 'Run'}</span>
-                  {!isRunning && <kbd>Ctrl / Cmd + Enter</kbd>}
-                </button>
-                <button
-                  className="code-practice-lab__button code-practice-lab__button--secondary"
-                  type="button"
-                  onClick={handleReset}
-                >
-                  Reset
-                </button>
-              </>
-            )}
+            <button
+              className="code-practice-lab__button code-practice-lab__button--secondary"
+              type="button"
+              onClick={handleAddHints}
+            >
+              Add hints
+            </button>
+            <button
+              className="code-practice-lab__button code-practice-lab__button--solution"
+              type="button"
+              onClick={handleLoadSolution}
+            >
+              Load solution
+            </button>
+            <button
+              className="code-practice-lab__button code-practice-lab__button--primary"
+              type="button"
+              aria-label="Run code"
+              aria-keyshortcuts="Control+Enter Meta+Enter"
+              onClick={() => void handleRun()}
+              disabled={status !== 'ready' || isRunning}
+            >
+              <span>{isRunning ? 'Running...' : 'Run'}</span>
+              {!isRunning && <kbd>Ctrl / Cmd + Enter</kbd>}
+            </button>
+            <button
+              className="code-practice-lab__button code-practice-lab__button--secondary"
+              type="button"
+              onClick={handleReset}
+            >
+              Reset
+            </button>
           </div>
         </header>
 
-        {viewMode === 'code' ? (
-          <>
+        <div className="code-practice-lab__editor-layout">
+          <div className="code-practice-lab__editor-column">
             <label className="code-practice-lab__editor-label" htmlFor={editorId}>
               solution.py editor
             </label>
@@ -379,40 +384,36 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
                 onChange={(value) => setCode(value)}
               />
             </div>
+          </div>
 
-            {hasExecutionResult && (
-              <div className="code-practice-lab__output" aria-live="polite">
-                <div>
-                  <p>{errorOutput ? 'Errors' : 'Output'}</p>
-                  <pre>{errorOutput || output || 'Program finished with no output.'}</pre>
-                </div>
-              </div>
-            )}
-          </>
-        ) : (
-          <section className="code-practice-lab__walkthrough" aria-labelledby={`${problem.id}-walkthrough-title`}>
-            <div className="code-practice-lab__walkthrough-heading">
-              <div>
-                <p className="code-practice-lab__section-label">Reference</p>
-                <h2 id={`${problem.id}-walkthrough-title`}>How to reason through it</h2>
-              </div>
-              <button
-                className="code-practice-lab__button code-practice-lab__button--solution"
-                type="button"
-                onClick={() => setViewMode('code')}
-              >
-                Back to code
-              </button>
+          <aside
+            className="code-practice-lab__annotations"
+            aria-labelledby={`${problem.id}-annotations-title`}
+          >
+            <div className="code-practice-lab__annotations-heading">
+              <p className="code-practice-lab__section-label">Walkthrough</p>
+              <h2 id={`${problem.id}-annotations-title`}>What the important lines do</h2>
             </div>
-            <div className="code-practice-lab__walkthrough-copy">
-              {problem.solutionNotes.map((note) => (
-                <p key={note}>{note}</p>
+            <div className="code-practice-lab__annotation-list">
+              {problem.solutionNotes.map((note, index) => (
+                <article className="code-practice-lab__annotation" key={`${index}-${note}`}>
+                  <span className="code-practice-lab__annotation-marker" aria-hidden="true">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <p>{note}</p>
+                </article>
               ))}
             </div>
-            <p className="code-practice-lab__walkthrough-tip">
-              When you are ready, switch to Code and use Load solution to inspect the complete implementation.
-            </p>
-          </section>
+          </aside>
+        </div>
+
+        {hasExecutionResult && (
+          <div className="code-practice-lab__output" aria-live="polite">
+            <div>
+              <p>{errorOutput ? 'Errors' : 'Output'}</p>
+              <pre>{errorOutput || output || 'Program finished with no output.'}</pre>
+            </div>
+          </div>
         )}
       </article>
     </section>

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -122,8 +122,9 @@ describe('CodePracticeLab', () => {
 
     expect(container.textContent).toContain('Problem 01');
     expect(container.textContent).toContain('Stable softmax cross-entropy');
-    expect(container.textContent).not.toContain('Subtract the row max first.');
+    expect(container.textContent).toContain('Use a row-wise max shift before the exponentials.');
     expect(container.textContent).not.toContain('return "solution"');
+    expect(getEditor().textContent).not.toContain('TODO');
 
     const buttons = Array.from(container.querySelectorAll('button'));
     const hintButton = buttons.find((button) => button.textContent === 'Add hints');
@@ -226,35 +227,18 @@ describe('CodePracticeLab', () => {
     expect(container.textContent).toContain('Ctrl / Cmd + Enter');
   });
 
-  it('toggles between the editable code and the problem walkthrough', async () => {
+  it('keeps the editor and walkthrough annotations visible together', async () => {
     loadPyodideRuntime.mockResolvedValueOnce({
       runPythonAsync: vi.fn(),
     });
 
     await render();
 
-    const walkthroughButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Walkthrough',
-    );
-    expect(walkthroughButton).toBeDefined();
-    expect(container.querySelector('.code-practice-lab__walkthrough')).toBeNull();
-
-    await act(async () => {
-      walkthroughButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    expect(container.querySelector('.code-practice-lab__walkthrough')).not.toBeNull();
-    expect(container.textContent).toContain('How to reason through it');
-    expect(container.querySelector('.cm-editor')).toBeNull();
-
-    const codeButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Code',
-    );
-    await act(async () => {
-      codeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    expect(container.querySelector('.code-practice-lab__walkthrough')).toBeNull();
+    expect(container.querySelector('.code-practice-lab__view-toggle')).toBeNull();
+    expect(container.querySelector('.code-practice-lab__editor-layout')).not.toBeNull();
+    expect(container.querySelector('.code-practice-lab__annotations')).not.toBeNull();
+    expect(container.textContent).toContain('What the important lines do');
+    expect(container.textContent).toContain('Use a row-wise max shift before the exponentials.');
     expect(container.querySelector('.cm-editor')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## What changed
- keep the CodeMirror editor and walkthrough guidance visible together
- render each problem's solution notes as a persistent right-side annotation panel
- remove visible TODO instruction blocks from the starter editor while preserving placeholders
- stack the annotations below the editor on narrow screens

## Validation
- `npm run ci`
- 31 tests passed, Astro check clean, build verification passed
- visual smoke-tested desktop and 390px layouts