### PR TITLE
Improve Code problem navigation and focus

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -6030,6 +6030,74 @@ html {
   color: var(--text-secondary-color);
 }
 
+.code-problem-page__navigation {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 1rem;
+  margin: 0 0 1.25rem;
+  padding: 0.35rem 0 0.85rem;
+  border-bottom: 1px solid var(--code-border-color);
+}
+
+.code-problem-page__navigation-link,
+.code-problem-page__navigation-index {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 0;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  text-decoration: none;
+}
+
+.code-problem-page__navigation-link--next {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.code-problem-page__navigation-link > span:last-child,
+.code-problem-page__navigation-link > span:first-child {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.code-problem-page__navigation-link > span[aria-hidden="true"] {
+  display: block;
+  color: var(--accent-color);
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.code-problem-page__navigation-link small {
+  color: var(--text-secondary-color);
+  font-size: 0.64rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.code-problem-page__navigation-link strong {
+  color: var(--text-color);
+  font-size: 0.78rem;
+}
+
+.code-problem-page__navigation-link:hover:not(.is-disabled) strong,
+.code-problem-page__navigation-index:hover {
+  color: var(--accent-color);
+}
+
+.code-problem-page__navigation-link.is-disabled {
+  cursor: default;
+  opacity: 0.42;
+}
+
+.code-problem-page__navigation-index {
+  justify-self: center;
+  color: var(--text-color);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
 @media (max-width: 820px) {
   .python-playground__header,
   .python-playground__walkthrough-header,
@@ -6797,15 +6865,6 @@ html {
   background: rgba(53, 109, 255, 0.07);
 }
 
-/* Keep the explanation beside the code so it is available while editing. */
-.code-practice-lab__editor-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(15rem, 0.38fr);
-  gap: 1rem;
-  min-height: 0;
-  overflow: hidden;
-}
-
 .code-practice-lab__editor-column {
   min-width: 0;
   min-height: 0;
@@ -6813,11 +6872,19 @@ html {
   flex-direction: column;
 }
 
+/* Keep the code and the selected explanation in view at the same time. */
+.code-practice-lab__editor-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.38fr);
+  gap: 1rem;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .code-practice-lab__annotations {
   min-width: 0;
   min-height: 0;
-  overflow: auto;
-  padding: 0.55rem 0.25rem 0.75rem 1rem;
+  padding: 0.55rem 0.2rem 0.75rem 1rem;
   border-left: 1px solid rgba(118, 169, 255, 0.18);
 }
 
@@ -6828,6 +6895,152 @@ html {
   line-height: 1.35;
 }
 
+.code-practice-lab__annotations-empty {
+  margin: 1.2rem 0 0;
+  color: rgba(223, 240, 255, 0.62);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.code-practice-lab__annotations-empty strong {
+  color: #ffe45c;
+}
+
+/* Reference explanations live on the relevant editor lines. The compact
+ * gutter keeps the line toggle discoverable without taking space from code. */
+.code-practice-lab__walkthrough-help {
+  margin: 0.65rem 0 0;
+  color: var(--text-secondary-color);
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
+.code-practice-lab__walkthrough-help strong {
+  color: var(--accent-color);
+}
+
+.code-practice-lab__walkthrough-panel {
+  margin-top: 0.8rem;
+  padding: 0.95rem 1rem 1rem;
+  border: 1px solid rgba(118, 169, 255, 0.25);
+  border-radius: 0.65rem;
+  background: rgba(13, 24, 39, 0.62);
+  box-shadow: 0 0.8rem 2rem rgba(0, 0, 0, 0.16);
+}
+
+.code-practice-lab__walkthrough-panel-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.65rem;
+}
+
+.code-practice-lab__walkthrough-panel-heading p {
+  margin: 0;
+}
+
+.code-practice-lab__walkthrough-panel-heading p:last-child {
+  color: #f8fbff;
+  font-size: 0.87rem;
+  font-weight: 700;
+}
+
+.code-practice-lab__walkthrough-code {
+  margin: 0;
+  padding: 0.65rem 0.75rem;
+  overflow-x: auto;
+  border: 1px solid rgba(118, 169, 255, 0.18);
+  border-radius: 0.4rem;
+  background: rgba(0, 0, 0, 0.22);
+  color: #b9ddff;
+  font-family: var(--code-font-family, monospace);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.code-practice-lab__walkthrough-explanation,
+.code-practice-lab__walkthrough-overview {
+  margin: 0.75rem 0 0;
+  color: rgba(223, 240, 255, 0.86);
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+.code-practice-lab__walkthrough-overview {
+  padding-top: 0.7rem;
+  border-top: 1px solid rgba(118, 169, 255, 0.16);
+  color: rgba(223, 240, 255, 0.68);
+}
+
+.code-practice-lab__walkthrough-explanation code,
+.code-practice-lab__walkthrough-overview code {
+  color: #ffe998;
+  font-family: var(--code-font-family, monospace);
+  font-size: 0.9em;
+}
+
+.code-practice-lab__walkthrough-formula {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+  padding: 0.7rem 0.75rem;
+  border-left: 2px solid #ffe45c;
+  background: rgba(255, 228, 92, 0.08);
+}
+
+.code-practice-lab__walkthrough-formula span {
+  color: rgba(255, 247, 207, 0.62);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.code-practice-lab__math {
+  min-width: 0;
+  overflow-x: auto;
+  padding: 0.15rem 0;
+  color: #fff7cf;
+  font-size: 1rem;
+  line-height: 1.8;
+  white-space: nowrap;
+}
+
+.cm-solution-walkthrough-gutter {
+  min-width: 1.8rem;
+  border-left: 1px solid rgba(118, 169, 255, 0.12);
+}
+
+.cm-solution-line-toggle {
+  display: inline-grid;
+  place-items: center;
+  width: 1.1rem;
+  height: 1.2rem;
+  margin: 0.05rem 0.12rem;
+  padding: 0;
+  border: 0;
+  border-radius: 0.2rem;
+  background: transparent;
+  color: rgba(143, 210, 255, 0.58);
+  cursor: pointer;
+  font: 700 1.05rem/1 var(--code-font-family, monospace);
+}
+
+.cm-solution-line-toggle:hover,
+.cm-solution-line-toggle:focus-visible,
+.cm-solution-line-toggle.is-open {
+  background: rgba(255, 228, 92, 0.1);
+  color: #ffe45c;
+  outline: none;
+}
+
+:root[data-theme="light"] .code-practice-lab__walkthrough-panel {
+  border-color: var(--code-border-color);
+  background: #f7f9fc;
+  box-shadow: var(--button-shadow);
+}
+
 :root[data-theme="dark"] .code-practice-lab__annotations {
   border-color: rgba(255, 228, 92, 0.18);
 }
@@ -6836,51 +7049,13 @@ html {
   color: #fff7cf;
 }
 
-.code-practice-lab__annotation-list {
-  display: grid;
-  gap: 0.9rem;
-  margin-top: 1.1rem;
+:root[data-theme="dark"] .code-practice-lab__annotations-empty {
+  color: rgba(255, 247, 207, 0.62);
 }
 
-.code-practice-lab__annotation {
-  display: grid;
-  grid-template-columns: 1.8rem minmax(0, 1fr);
-  gap: 0.65rem;
-  align-items: start;
-  padding: 0.75rem 0.8rem 0.8rem 0;
-  border-top: 1px solid rgba(118, 169, 255, 0.14);
-}
-
-.code-practice-lab__annotation-marker {
-  display: inline-grid;
-  place-items: center;
-  width: 1.55rem;
-  height: 1.55rem;
-  border: 1px solid rgba(127, 197, 255, 0.3);
-  border-radius: 50%;
-  color: #8fd2ff;
-  font-size: 0.66rem;
-  font-weight: 700;
-}
-
-.code-practice-lab__annotation p {
-  margin: 0;
-  color: rgba(223, 240, 255, 0.78);
-  font-size: 0.78rem;
-  line-height: 1.55;
-}
-
-:root[data-theme="dark"] .code-practice-lab__annotation {
-  border-color: rgba(255, 228, 92, 0.14);
-}
-
-:root[data-theme="dark"] .code-practice-lab__annotation-marker {
-  border-color: rgba(255, 228, 92, 0.34);
-  color: #ffe45c;
-}
-
-:root[data-theme="dark"] .code-practice-lab__annotation p {
-  color: rgba(255, 247, 207, 0.78);
+:root[data-theme="light"] .code-practice-lab__walkthrough-panel-heading p:last-child,
+:root[data-theme="light"] .code-practice-lab__walkthrough-explanation {
+  color: var(--text-color);
 }
 
 :root[data-theme="light"] .code-practice-lab__annotations {
@@ -6891,34 +7066,85 @@ html {
   color: var(--text-color);
 }
 
-:root[data-theme="light"] .code-practice-lab__annotation {
-  border-color: var(--code-border-color);
-}
-
-:root[data-theme="light"] .code-practice-lab__annotation-marker {
-  border-color: rgba(53, 109, 255, 0.3);
-  color: var(--accent-color);
-}
-
-:root[data-theme="light"] .code-practice-lab__annotation p {
+:root[data-theme="light"] .code-practice-lab__annotations-empty {
   color: var(--text-secondary-color);
 }
 
-@media (max-width: 980px) {
+:root[data-theme="light"] .code-practice-lab__walkthrough-code {
+  border-color: var(--code-border-color);
+  background: #ffffff;
+  color: #245a9b;
+}
+
+:root[data-theme="light"] .code-practice-lab__walkthrough-explanation,
+:root[data-theme="light"] .code-practice-lab__walkthrough-overview {
+  color: var(--text-secondary-color);
+}
+
+:root[data-theme="light"] .code-practice-lab__walkthrough-formula {
+  background: rgba(154, 105, 18, 0.08);
+}
+
+:root[data-theme="light"] .code-practice-lab__walkthrough-formula span,
+:root[data-theme="light"] .code-practice-lab__math {
+  color: #654409;
+}
+
+:root[data-theme="light"] .cm-solution-walkthrough-gutter {
+  border-left-color: rgba(53, 109, 255, 0.14);
+}
+
+:root[data-theme="light"] .cm-solution-line-toggle {
+  background: transparent;
+  color: var(--accent-color);
+}
+
+@media (max-width: 680px) {
   .code-practice-lab__editor-layout {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(24rem, 1fr) auto;
-    overflow: auto;
+    overflow: visible;
   }
 
   .code-practice-lab__annotations {
-    overflow: visible;
     padding: 1rem 0 0;
     border-top: 1px solid rgba(118, 169, 255, 0.18);
     border-left: 0;
   }
 
+  .code-practice-lab__walkthrough-panel-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .code-practice-lab__math {
+    white-space: pre-wrap;
+  }
+
   :root[data-theme="dark"] .code-practice-lab__annotations {
     border-color: rgba(255, 228, 92, 0.18);
   }
+}
+
+.code-practice-lab__editor-layout--single {
+  grid-template-columns: 1fr;
+}
+
+@media (max-width: 640px) {
+  .code-problem-page__navigation {
+    gap: 0.45rem;
+  }
+
+  .code-problem-page__navigation-link {
+    gap: 0.3rem;
+  }
+
+  .code-problem-page__navigation-link strong {
+    font-size: 0.7rem;
+  }
+
+  .code-problem-page__navigation-index {
+    font-size: 0.65rem;
+  }
+
 }

--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -1,6 +1,6 @@
 import React, { startTransition, useEffect, useMemo, useRef, useState } from 'react';
-import { Prec } from '@codemirror/state';
-import { EditorView, keymap } from '@codemirror/view';
+import { Prec, RangeSetBuilder } from '@codemirror/state';
+import { EditorView, GutterMarker, gutter, keymap } from '@codemirror/view';
 import CodeMirror from '@uiw/react-codemirror';
 import { githubDark, githubLight } from '@uiw/codemirror-theme-github';
 import { loadPyodideRuntime } from '../lib/pyodide-loader';
@@ -17,14 +17,6 @@ import type { CodePracticeProblem } from '../lib/code-practice';
 
 interface CodePracticeLabProps {
   problem: CodePracticeProblem;
-}
-
-function createHintCommentBlock(hints: readonly string[]) {
-  if (hints.length === 0) {
-    return '';
-  }
-
-  return ['# Hints', ...hints.map((hint, index) => `# ${index + 1}. ${hint}`)].join('\n');
 }
 
 /**
@@ -56,8 +48,252 @@ function removeTodoCommentBlocks(source: string) {
   return cleaned.join('\n');
 }
 
+interface SolutionWalkthroughAnnotation {
+  lineNumber: number;
+  code: string;
+  explanation: string;
+  formula?: string;
+  overview?: string;
+}
+
+function normalizeCodeLine(line: string) {
+  return line.replace(/\s+/g, ' ').trim();
+}
+
+function inlineCode(text: string) {
+  return text.split(/(`[^`]+`)/g).map((part, index) => {
+    if (part.startsWith('`') && part.endsWith('`')) {
+      return <code key={`${part}-${index}`}>{part.slice(1, -1)}</code>;
+    }
+
+    return part;
+  });
+}
+
+function formulaForSolutionLine(line: string) {
+  const normalized = normalizeCodeLine(line);
+
+  if (/torch\.(amax|max)\(/.test(normalized)) {
+    return String.raw`m_i = \max_j z_{ij},\qquad z'_{ij} = z_{ij} - m_i`;
+  }
+
+  if (/torch\.exp\(/.test(normalized)) {
+    return String.raw`w_{ij} = \exp(z'_{ij}),\qquad z'_{ij} \leq 0`;
+  }
+
+  if (/normalizer|normalizers|sum\(/i.test(normalized) && /exp|exponent/i.test(normalized)) {
+    return String.raw`Z_i = \sum_j \exp(z'_{ij})`;
+  }
+
+  if (/torch\.log\(|log\(/.test(normalized) && /loss|normalizer|target|logit/i.test(normalized)) {
+    return String.raw`\ell_i = \log Z_i - z'_{i,y_i} = -\log p_{i,y_i}`;
+  }
+
+  if (/torch\.mean\(|mean\(/.test(normalized)) {
+    return String.raw`L = \frac{1}{N}\sum_i \ell_i`;
+  }
+
+  if (/intersection|inter_area/.test(normalized) && /union|area/.test(normalized)) {
+    return String.raw`\operatorname{IoU}(A,B) = \frac{|A \cap B|}{|A \cup B|}`;
+  }
+
+  if (/union\s*=/.test(normalized)) {
+    return String.raw`|A \cup B| = |A| + |B| - |A \cap B|`;
+  }
+
+  if (/(?:@\s*torch\.transpose|squared_distances|deltas \* deltas)/.test(normalized)) {
+    return String.raw`\lVert x_i-y_j\rVert^2 = \lVert x_i\rVert^2 + \lVert y_j\rVert^2 - 2x_i\cdot y_j`;
+  }
+
+  if (/torch\.arg(?:max|min)\(/.test(normalized)) {
+    return normalized.includes('argmax')
+      ? String.raw`j^* = \operatorname*{arg\,max}_j\; s_j`
+      : String.raw`j^* = \operatorname*{arg\,min}_j\; d_j^2`;
+  }
+
+  if (/torch\.where\(/.test(normalized) && /delta|magnitude|error/.test(normalized)) {
+    return String.raw`H_\delta(e)=\begin{cases}\frac{1}{2}e^2,& |e|\leq\delta\\ \delta(|e|-\frac{1}{2}\delta),& |e|>\delta\end{cases}`;
+  }
+
+  if (/matmul\(attention|attention\s*=/.test(normalized)) {
+    return String.raw`\operatorname{Attention}(Q,K,V)=\operatorname{softmax}\!\left(\frac{QK^\mathsf{T}}{\sqrt{d_h}}\right)V`;
+  }
+
+  if (/unsqueeze|None|reshape|view\(|transpose|permute/.test(normalized)) {
+    return 'Broadcasting creates one tensor axis for each pair before the reduction.';
+  }
+
+  return undefined;
+}
+
+function getCommentGroups(solutionCode: string) {
+  const lines = solutionCode.split('\n');
+  const groups: Array<{ comments: string[]; code: string }> = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const trimmed = lines[index].trim();
+    if (!trimmed.startsWith('#') || /^#\s*(TODO|Original placeholder)/i.test(trimmed)) {
+      continue;
+    }
+
+    const comments: string[] = [];
+    while (index < lines.length) {
+      const comment = lines[index].trim();
+      if (!comment.startsWith('#') || /^#\s*(TODO|Original placeholder)/i.test(comment)) {
+        break;
+      }
+
+      comments.push(comment.replace(/^#\s?/, ''));
+      index += 1;
+    }
+
+    while (index < lines.length && !lines[index].trim()) {
+      index += 1;
+    }
+
+    if (comments.length > 0 && index < lines.length) {
+      groups.push({ comments, code: lines[index] });
+    }
+
+    index -= 1;
+  }
+
+  return groups;
+}
+
+function findReferenceLineNumber(code: string, sourceLine: string, startAt: number) {
+  const lines = code.split('\n');
+  const markerIndex = lines.findIndex((line) => line.trim() === '# Reference solution');
+  const source = normalizeCodeLine(sourceLine);
+  const firstReferenceLine = markerIndex >= 0 ? markerIndex + 1 : 0;
+
+  for (let index = Math.max(firstReferenceLine, startAt); index < lines.length; index += 1) {
+    if (normalizeCodeLine(lines[index]) === source) {
+      return index + 1;
+    }
+  }
+
+  // Compacting turns simple if/raise guards into assert statements. If an
+  // exact match is unavailable, keep the annotation attached to the next
+  // executable reference line instead of dropping the explanation.
+  for (let index = Math.max(firstReferenceLine, startAt); index < lines.length; index += 1) {
+    const candidate = normalizeCodeLine(lines[index]);
+    const meaningfulWords = source.split(/\W+/).filter((word) => word.length > 3);
+    if (meaningfulWords.length > 0 && meaningfulWords.filter((word) => candidate.includes(word)).length >= 2) {
+      return index + 1;
+    }
+  }
+
+  return Math.min(Math.max(firstReferenceLine + 1, startAt + 1), lines.length);
+}
+
+function getSolutionWalkthroughAnnotations(problem: CodePracticeProblem, code: string) {
+  if (!code.includes('# Reference solution')) {
+    return [];
+  }
+
+  const lines = code.split('\n');
+  const groups = getCommentGroups(problem.walkthroughCode ?? problem.solutionCode);
+  let searchFrom = lines.findIndex((line) => line.trim() === '# Reference solution') + 1;
+  const annotations: SolutionWalkthroughAnnotation[] = [];
+
+  for (const group of groups) {
+    const lineNumber = findReferenceLineNumber(code, group.code, Math.max(searchFrom, 0));
+    const line = lines[lineNumber - 1] ?? group.code;
+    const explanation = group.comments.join(' ');
+    const previous = annotations.at(-1);
+
+    if (previous?.lineNumber === lineNumber) {
+      previous.explanation = `${previous.explanation} ${explanation}`;
+      continue;
+    }
+
+    annotations.push({
+      lineNumber,
+      code: line.trim(),
+      explanation,
+      formula: formulaForSolutionLine(line),
+      overview: annotations.length === 0 ? problem.solutionNotes.join(' ') : undefined,
+    });
+    searchFrom = lineNumber;
+  }
+
+  if (annotations.length === 0) {
+    const firstLine = lines.findIndex(
+      (line, index) => index > searchFrom && line.trim() && !line.trim().startsWith('#'),
+    );
+    if (firstLine >= 0) {
+      annotations.push({
+        lineNumber: firstLine + 1,
+        code: lines[firstLine].trim(),
+        explanation: problem.solutionNotes.join(' '),
+        formula: formulaForSolutionLine(lines[firstLine]),
+      });
+    }
+  }
+
+  return annotations;
+}
+
+class SolutionLineMarker extends GutterMarker {
+  constructor(
+    private readonly lineNumber: number,
+    private readonly isOpen: boolean,
+    private readonly onToggle: (lineNumber: number) => void,
+  ) {
+    super();
+  }
+
+  eq(other: GutterMarker) {
+    return other instanceof SolutionLineMarker && other.lineNumber === this.lineNumber && other.isOpen === this.isOpen;
+  }
+
+  toDOM() {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `cm-solution-line-toggle${this.isOpen ? ' is-open' : ''}`;
+    button.textContent = this.isOpen ? '⌄' : '›';
+    button.setAttribute('aria-label', `${this.isOpen ? 'Collapse' : 'Explain'} solution line ${this.lineNumber}`);
+    button.setAttribute('aria-expanded', String(this.isOpen));
+    button.addEventListener('mousedown', (event) => event.preventDefault());
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      this.onToggle(this.lineNumber);
+    });
+    return button;
+  }
+}
+
+function createSolutionWalkthroughGutter(
+  annotations: readonly SolutionWalkthroughAnnotation[],
+  openLine: number | null,
+  onToggle: (lineNumber: number) => void,
+) {
+  return gutter({
+    class: 'cm-solution-walkthrough-gutter',
+    markers: (view) => {
+      const builder = new RangeSetBuilder<GutterMarker>();
+      for (const annotation of annotations) {
+        if (annotation.lineNumber > view.state.doc.lines) {
+          continue;
+        }
+
+        const line = view.state.doc.line(annotation.lineNumber);
+        builder.add(
+          line.from,
+          line.from,
+          new SolutionLineMarker(annotation.lineNumber, annotation.lineNumber === openLine, onToggle),
+        );
+      }
+      return builder.finish();
+    },
+  });
+}
+
 export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const containerRef = useRef<HTMLElement | null>(null);
+  const walkthroughPanelRef = useRef<HTMLElement | null>(null);
   const runtimeRef = useRef<PyodideRuntime | null>(null);
   const loadingRef = useRef(false);
   const isRunningRef = useRef(false);
@@ -69,13 +305,13 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const [statusMessage, setStatusMessage] = useState('Loading Python...');
   const [isRunning, setIsRunning] = useState(false);
   const [hasRun, setHasRun] = useState(false);
+  const [openWalkthroughLine, setOpenWalkthroughLine] = useState<number | null>(null);
   const [editorTheme, setEditorTheme] = useState(() =>
     getCodeEditorThemeName(
       typeof document === 'undefined' ? 'light' : document.documentElement.getAttribute('data-theme'),
     ),
   );
 
-  const hintCommentBlock = useMemo(() => createHintCommentBlock(problem.hint), [problem.hint]);
   const runShortcutExtension = useMemo(
     () =>
       Prec.highest([
@@ -106,6 +342,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     setOutput('');
     setErrorOutput('');
     setHasRun(false);
+    setOpenWalkthroughLine(null);
   }, [problem]);
 
   useEffect(() => {
@@ -194,7 +431,48 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const editorId = `${problem.id}-editor`;
   const editorThemeExtension = editorTheme === 'dark' ? githubDark : githubLight;
   const isReferenceLoaded = code.includes('# Reference solution');
+  const walkthroughAnnotations = useMemo(
+    () => getSolutionWalkthroughAnnotations(problem, code),
+    [problem, code],
+  );
+  const walkthroughGutter = useMemo(
+    () =>
+      createSolutionWalkthroughGutter(
+        walkthroughAnnotations,
+        openWalkthroughLine,
+        (lineNumber) => setOpenWalkthroughLine((current) => (current === lineNumber ? null : lineNumber)),
+      ),
+    [openWalkthroughLine, walkthroughAnnotations],
+  );
   const hasExecutionResult = hasRun || Boolean(errorOutput);
+  const activeWalkthrough = walkthroughAnnotations.find(
+    (annotation) => annotation.lineNumber === openWalkthroughLine,
+  );
+
+  useEffect(() => {
+    const panel = walkthroughPanelRef.current;
+    if (!panel || typeof window === 'undefined') {
+      return;
+    }
+
+    const renderMath = () => {
+      const renderer = (
+        window as Window & {
+          renderMathInElement?: (element: HTMLElement, options: Record<string, unknown>) => void;
+        }
+      ).renderMathInElement;
+
+      renderer?.(panel, {
+        delimiters: [{ left: '\\(', right: '\\)', display: false }],
+        ignoredTags: ['script', 'style', 'textarea', 'pre', 'code'],
+        throwOnError: false,
+      });
+    };
+
+    renderMath();
+    window.addEventListener('load', renderMath, { once: true });
+    return () => window.removeEventListener('load', renderMath);
+  }, [activeWalkthrough?.lineNumber, activeWalkthrough?.formula]);
 
   async function handleRun() {
     if (isRunningRef.current) {
@@ -236,16 +514,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     setOutput('');
     setErrorOutput('');
     setHasRun(false);
-  }
-
-  function handleAddHints() {
-    if (!hintCommentBlock) {
-      return;
-    }
-
-    setCode((currentCode) =>
-      currentCode.startsWith(hintCommentBlock) ? currentCode : `${hintCommentBlock}\n\n${currentCode}`,
-    );
+    setOpenWalkthroughLine(null);
   }
 
   function handleLoadSolution() {
@@ -253,6 +522,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     setOutput('');
     setErrorOutput('');
     setHasRun(false);
+    setOpenWalkthroughLine(null);
   }
 
   // The CodeMirror keymap is created once, so route it through a ref to the
@@ -317,10 +587,6 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
       <article className="code-practice-lab__workspace">
         <header className="code-practice-lab__workspace-header">
           <div className="code-practice-lab__workspace-identity">
-            <p className="code-practice-lab__eyebrow">
-              {isReferenceLoaded ? 'Reference' : 'Workspace'}
-            </p>
-            <p className="code-practice-lab__file-name">solution.py</p>
             <p
               className={`code-practice-lab__status code-practice-lab__status--${status}`}
               aria-live="polite"
@@ -330,18 +596,11 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
           </div>
           <div className="code-practice-lab__workspace-controls">
             <button
-              className="code-practice-lab__button code-practice-lab__button--secondary"
-              type="button"
-              onClick={handleAddHints}
-            >
-              Add hints
-            </button>
-            <button
               className="code-practice-lab__button code-practice-lab__button--solution"
               type="button"
               onClick={handleLoadSolution}
             >
-              Load solution
+              Solution
             </button>
             <button
               className="code-practice-lab__button code-practice-lab__button--primary"
@@ -364,7 +623,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
           </div>
         </header>
 
-        <div className="code-practice-lab__editor-layout">
+        <div className={`code-practice-lab__editor-layout${isReferenceLoaded ? '' : ' code-practice-lab__editor-layout--single'}`}>
           <div className="code-practice-lab__editor-column">
             <label className="code-practice-lab__editor-label" htmlFor={editorId}>
               solution.py editor
@@ -375,7 +634,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
                 className="code-practice-lab__editor"
                 aria-label="Python solution editor"
                 basicSetup={false}
-                extensions={editorExtensions}
+                extensions={isReferenceLoaded ? [...editorExtensions, walkthroughGutter] : editorExtensions}
                 theme={editorThemeExtension}
                 height="100%"
                 editable
@@ -386,25 +645,51 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
             </div>
           </div>
 
-          <aside
+          {isReferenceLoaded && <aside
             className="code-practice-lab__annotations"
             aria-labelledby={`${problem.id}-annotations-title`}
           >
             <div className="code-practice-lab__annotations-heading">
               <p className="code-practice-lab__section-label">Walkthrough</p>
-              <h2 id={`${problem.id}-annotations-title`}>What the important lines do</h2>
+              <h2 id={`${problem.id}-annotations-title`}>What this solution line is doing</h2>
             </div>
-            <div className="code-practice-lab__annotation-list">
-              {problem.solutionNotes.map((note, index) => (
-                <article className="code-practice-lab__annotation" key={`${index}-${note}`}>
-                  <span className="code-practice-lab__annotation-marker" aria-hidden="true">
-                    {String(index + 1).padStart(2, '0')}
-                  </span>
-                  <p>{note}</p>
-                </article>
-              ))}
-            </div>
-          </aside>
+            {isReferenceLoaded && !activeWalkthrough && (
+              <p className="code-practice-lab__annotations-empty">
+                Select an annotated line to read its reasoning without leaving the code.
+              </p>
+            )}
+            {isReferenceLoaded && activeWalkthrough && (
+              <section
+                className="code-practice-lab__walkthrough-panel"
+                ref={walkthroughPanelRef}
+                aria-label={`Walkthrough for solution line ${activeWalkthrough.lineNumber}`}
+              >
+                <div className="code-practice-lab__walkthrough-panel-heading">
+                  <p className="code-practice-lab__section-label">
+                    Line {String(activeWalkthrough.lineNumber).padStart(2, '0')}
+                  </p>
+                  <p>Why this line matters</p>
+                </div>
+                <pre className="code-practice-lab__walkthrough-code"><code>{activeWalkthrough.code}</code></pre>
+                {activeWalkthrough.formula && (
+                  <div className="code-practice-lab__walkthrough-formula">
+                    <span>Equation / shape intuition</span>
+                    <div className="code-practice-lab__math" aria-label="Equation">
+                      {`\\(${activeWalkthrough.formula}\\)`}
+                    </div>
+                  </div>
+                )}
+                <p className="code-practice-lab__walkthrough-explanation">
+                  {inlineCode(activeWalkthrough.explanation)}
+                </p>
+                {activeWalkthrough.overview && (
+                  <p className="code-practice-lab__walkthrough-overview">
+                    <strong>Big picture:</strong> {inlineCode(activeWalkthrough.overview)}
+                  </p>
+                )}
+              </section>
+            )}
+          </aside>}
         </div>
 
         {hasExecutionResult && (

--- a/src/lib/code-practice.ts
+++ b/src/lib/code-practice.ts
@@ -17,6 +17,8 @@ export interface CodePracticeProblem {
   hint: readonly string[];
   solutionNotes: readonly string[];
   solutionCode: string;
+  /** Full commented reference used to explain the compact editor solution line by line. */
+  walkthroughCode?: string;
   starterCode: string;
   packages?: readonly string[];
   tags?: readonly string[];
@@ -4001,6 +4003,7 @@ class NGramModel:
 export const codePracticeProblems: readonly CodePracticeProblem[] = RAW_CODE_PRACTICE_PROBLEMS.map(
   (problem) => ({
     ...problem,
+    walkthroughCode: problem.solutionCode,
     solutionCode: COMPACT_REFERENCE_SOLUTIONS[problem.id] ?? problem.solutionCode,
   }),
 );

--- a/src/pages/code/[id].astro
+++ b/src/pages/code/[id].astro
@@ -3,7 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import PageControls from '../../components/PageControls.astro';
 import CodePracticeLab from '../../components/CodePracticeLab';
 import type { CodePracticeProblem } from '../../lib/code-practice';
-import { codePracticeProblems } from '../../lib/code-practice';
+import { codePracticeProblems, getCodePracticeProblemPath } from '../../lib/code-practice';
 
 export function getStaticPaths() {
   return codePracticeProblems.map((problem) => ({
@@ -17,17 +17,54 @@ interface Props {
 }
 
 const { problem } = Astro.props;
+const problemIndex = codePracticeProblems.findIndex(({ id }) => id === problem.id);
+const previousProblem = problemIndex > 0 ? codePracticeProblems[problemIndex - 1] : undefined;
+const nextProblem = problemIndex < codePracticeProblems.length - 1 ? codePracticeProblems[problemIndex + 1] : undefined;
 ---
 
 <BaseLayout title={problem.title} description={problem.summary}>
   <PageControls showHomeButton={true} />
   <main class="code-problem-page" aria-label={`${problem.title} interview practice`}>
     <div class="code-problem-page__shell">
-      <p class="code-problem-page__back-link">
-        <a href="/code.html">All problems</a>
-        <span>/</span>
-        <span>{`Problem ${String(problem.order).padStart(2, '0')}`}</span>
-      </p>
+      <nav class="code-problem-page__navigation" aria-label="Problem navigation">
+        {previousProblem ? (
+          <a class="code-problem-page__navigation-link" href={getCodePracticeProblemPath(previousProblem)}>
+            <span aria-hidden="true">←</span>
+            <span>
+              <small>Previous</small>
+              <strong>{`Problem ${String(previousProblem.order).padStart(2, '0')}`}</strong>
+            </span>
+          </a>
+        ) : (
+          <span class="code-problem-page__navigation-link is-disabled" aria-disabled="true">
+            <span aria-hidden="true">←</span>
+            <span>
+              <small>Previous</small>
+              <strong>First problem</strong>
+            </span>
+          </span>
+        )}
+
+        <a class="code-problem-page__navigation-index" href="/code.html">All problems</a>
+
+        {nextProblem ? (
+          <a class="code-problem-page__navigation-link code-problem-page__navigation-link--next" href={getCodePracticeProblemPath(nextProblem)}>
+            <span>
+              <small>Next</small>
+              <strong>{`Problem ${String(nextProblem.order).padStart(2, '0')}`}</strong>
+            </span>
+            <span aria-hidden="true">→</span>
+          </a>
+        ) : (
+          <span class="code-problem-page__navigation-link code-problem-page__navigation-link--next is-disabled" aria-disabled="true">
+            <span>
+              <small>Next</small>
+              <strong>Last problem</strong>
+            </span>
+            <span aria-hidden="true">→</span>
+          </span>
+        )}
+      </nav>
 
       <CodePracticeLab client:visible problem={problem} />
     </div>

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -113,7 +113,7 @@ describe('CodePracticeLab', () => {
     return editor as HTMLElement;
   }
 
-  it('keeps hint and solution actions in the workspace and applies them to the editor', async () => {
+  it('keeps a direct solution action in the workspace and applies it to the editor', async () => {
     loadPyodideRuntime.mockResolvedValueOnce({
       runPythonAsync: vi.fn(),
     });
@@ -122,24 +122,16 @@ describe('CodePracticeLab', () => {
 
     expect(container.textContent).toContain('Problem 01');
     expect(container.textContent).toContain('Stable softmax cross-entropy');
-    expect(container.textContent).toContain('Use a row-wise max shift before the exponentials.');
+    expect(container.textContent).not.toContain('Use a row-wise max shift before the exponentials.');
     expect(container.textContent).not.toContain('return "solution"');
     expect(getEditor().textContent).not.toContain('TODO');
 
     const buttons = Array.from(container.querySelectorAll('button'));
-    const hintButton = buttons.find((button) => button.textContent === 'Add hints');
-    const solutionButton = buttons.find((button) => button.textContent === 'Load solution');
+    const solutionButton = buttons.find((button) => button.textContent === 'Solution');
 
-    expect(hintButton?.closest('.code-practice-lab__workspace')).not.toBeNull();
+    expect(buttons.find((button) => button.textContent === 'Add hints')).toBeUndefined();
+    expect(buttons.find((button) => button.textContent === 'Need help?')).toBeUndefined();
     expect(solutionButton?.closest('.code-practice-lab__workspace')).not.toBeNull();
-
-    await act(async () => {
-      hintButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    expect(getEditor().textContent).toContain('# Hints');
-    expect(getEditor().textContent).toContain('# 1. Subtract the row max first.');
-    expect(getEditor().textContent).toContain('print("starter")');
 
     await act(async () => {
       solutionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -153,6 +145,14 @@ describe('CodePracticeLab', () => {
     expect(getEditor().textContent).not.toMatch(
       /^\s+raise NotImplementedError\("Implement softmax_cross_entropy"\)$/m,
     );
+    expect(container.querySelectorAll('.cm-solution-line-toggle').length).toBeGreaterThan(0);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.cm-solution-line-toggle')?.click();
+    });
+
+    expect(container.querySelector('.code-practice-lab__walkthrough-panel')).not.toBeNull();
+    expect(container.textContent).toContain('Return the reference value after following the stable path.');
   });
 
   it('loads required packages and prints run output', async () => {
@@ -227,7 +227,7 @@ describe('CodePracticeLab', () => {
     expect(container.textContent).toContain('Ctrl / Cmd + Enter');
   });
 
-  it('keeps the editor and walkthrough annotations visible together', async () => {
+  it('keeps the default workspace focused until a reference solution is loaded', async () => {
     loadPyodideRuntime.mockResolvedValueOnce({
       runPythonAsync: vi.fn(),
     });
@@ -235,10 +235,11 @@ describe('CodePracticeLab', () => {
     await render();
 
     expect(container.querySelector('.code-practice-lab__view-toggle')).toBeNull();
-    expect(container.querySelector('.code-practice-lab__editor-layout')).not.toBeNull();
-    expect(container.querySelector('.code-practice-lab__annotations')).not.toBeNull();
-    expect(container.textContent).toContain('What the important lines do');
-    expect(container.textContent).toContain('Use a row-wise max shift before the exponentials.');
+    expect(container.querySelector('.code-practice-lab__editor-layout--single')).not.toBeNull();
+    expect(container.querySelector('.code-practice-lab__annotations')).toBeNull();
+    expect(container.querySelector('.cm-solution-line-toggle')).toBeNull();
+    expect(container.querySelector('.code-practice-lab__walkthrough-panel')).toBeNull();
+    expect(container.textContent).not.toContain('What this solution line is doing');
     expect(container.querySelector('.cm-editor')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## What changed
- Add Previous, All problems, and Next navigation to Code problem pages.
- Reduce default workspace clutter by hiding secondary help actions and deferring walkthrough explanations until a reference solution is loaded.
- Keep the editor, problem requirements, examples, Run, Reset, and solution access available.

## Why
Make the interview-practice screen easier to scan and move between problems without removing the core solving workflow.

## Testing
- `npm run ci`
- Browser QA on Problems 01 and 02, including navigation and collapsed help actions.