### PR TITLE
Restore Code practice editor font

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -7156,7 +7156,6 @@ html {
 .code-practice-lab li,
 .code-practice-lab button,
 .code-practice-lab label,
-.code-practice-lab span,
 .code-practice-lab strong {
   font-family: var(--font-body);
 }


### PR DESCRIPTION
## Summary
- let CodeMirror syntax-token spans inherit the editor's original monospace font
- retain the clean right-aligned solution layout

## Validation
- npm run ci