### PR TITLE
Audit and harden Code practice solutions

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -7161,9 +7161,6 @@ html {
   font-family: var(--font-body);
 }
 
-.code-practice-lab code,
-.code-practice-lab pre,
-.code-practice-lab kbd,
 .code-practice-lab__section-label,
 .code-practice-lab__eyebrow {
   font-family: var(--font-mono);
@@ -7200,27 +7197,6 @@ html {
 
 .code-practice-lab--reference .code-practice-lab__editor-layout {
   grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.38fr);
-}
-
-.code-practice-lab__editor,
-.code-practice-lab--reference .code-practice-lab__editor {
-  font-family: var(--font-mono);
-  font-size: 0.92rem;
-}
-
-.code-practice-lab__editor .cm-editor,
-.code-practice-lab__editor .cm-scroller,
-.code-practice-lab--reference .code-practice-lab__editor .cm-scroller {
-  font-family: var(--font-mono);
-  line-height: 1.5;
-}
-
-.code-practice-lab__editor .cm-content,
-.code-practice-lab__editor .cm-gutter,
-.code-practice-lab--reference .code-practice-lab__editor .cm-content,
-.code-practice-lab--reference .code-practice-lab__editor .cm-gutter {
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
 }
 
 /* Preserve Python's visual structure; horizontal scrolling is clearer than

--- a/src/lib/code-practice.ts
+++ b/src/lib/code-practice.ts
@@ -3555,9 +3555,13 @@ def match_predictions(
     for prediction_index in torch.argsort(scores, descending=True).tolist():
         if ground_truth.shape[0] == 0:
             continue
-        best_gt = int(torch.argmax(ious[prediction_index]).item())
-        best_iou = float(ious[prediction_index, best_gt].item())
-        if best_iou >= iou_threshold and best_gt not in used:
+        available = torch.as_tensor([ground_truth_index not in used for ground_truth_index in range(ground_truth.shape[0])], dtype=torch.bool)
+        if not torch.any(available):
+            continue
+        candidate_ious = torch.where(available, ious[prediction_index], torch.full_like(ious[prediction_index], float('-inf')))
+        best_gt = int(torch.argmax(candidate_ious).item())
+        best_iou = float(candidate_ious[best_gt].item())
+        if best_iou >= iou_threshold:
             matches[prediction_index] = best_gt
             used.add(best_gt)
     return matches
@@ -3982,7 +3986,8 @@ class NGramModel:
     def next_token_probs(self, context):
         context = list(context)
         for size in range(min(self.n - 1, len(context)), -1, -1):
-            counts = self.counts.get(tuple(context[-size:]))
+            key = tuple(context[-size:]) if size else ()
+            counts = self.counts.get(key)
             if counts:
                 total = sum(counts.values())
                 return {token: count / total for token, count in counts.items()}

--- a/src/lib/torch-compat.ts
+++ b/src/lib/torch-compat.ts
@@ -102,6 +102,14 @@ class _CompatTensor(_np.ndarray):
     def view(self, *shape):
         return self.reshape(*shape)
 
+    def permute(self, *dims):
+        # Match torch.Tensor.permute(*dims), including its variadic dimension API.
+        return _wrap(_np.transpose(self, axes=tuple(int(dim) for dim in dims)))
+
+    def transpose(self, dim0, dim1):
+        # Tensor.transpose swaps exactly two axes; NumPy's transpose expects all axes.
+        return _wrap(_np.swapaxes(self, int(dim0), int(dim1)))
+
     def add_(self, value):
         self[...] = _np.asarray(self) + value
         return self

--- a/tests/code-practice-primitives.test.ts
+++ b/tests/code-practice-primitives.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { codePracticeProblems } from '../src/lib/code-practice';
+import { TORCH_COMPAT_SOURCE } from '../src/lib/torch-compat';
 
 // These helpers solve the operation being taught instead of exposing its tensor steps.
 const BANNED_CONVENIENCE_CALLS = [
@@ -105,5 +106,19 @@ describe('code-practice primitive-first solutions', () => {
         expect(problem?.solutionCode, `${id} must include ${fragment}`).toContain(fragment);
       }
     }
+  });
+
+  it('handles the two audited edge cases in the reference code', () => {
+    const ngram = codePracticeProblems.find((problem) => problem.id === 'simple-n-gram-language-model');
+    const matching = codePracticeProblems.find((problem) => problem.id === 'greedy-detection-matching');
+
+    expect(ngram?.solutionCode).toContain('key = tuple(context[-size:]) if size else ()');
+    expect(matching?.solutionCode).toContain('candidate_ious = torch.where(available');
+    expect(matching?.solutionCode).not.toContain('best_gt not in used');
+  });
+
+  it('supports tensor transpose methods used by 2D and attention references', () => {
+    expect(TORCH_COMPAT_SOURCE).toContain('def permute(self, *dims):');
+    expect(TORCH_COMPAT_SOURCE).toContain('def transpose(self, dim0, dim1):');
   });
 });


### PR DESCRIPTION
## Summary
- restore PyTorch-style `permute` and two-axis `transpose` in the browser compatibility runtime so 2D image and attention references execute
- fix n-gram unigram backoff and greedy detection matching of unused ground-truth boxes
- preserve the existing code font while retaining the Code-practice workspace layout
- add regression coverage for the audited edge cases and tensor methods

## Validation
- `git diff --check`
- `npm run ci`
- browser execution audit of all 34 Code-practice reference solutions, including adversarial image, attention, loss, metric, language-model, and detection cases