### PR TITLE
Update robotics journey narrative

### DIFF
--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -118,7 +118,13 @@ DEKA opened the door to my dream job. The projects taught me technical skills, b
 
 ## Zoox
 
-Joining Zoox realized a long-held goal: working on autonomous driving. I work on the Perception team, which turns camera, LiDAR, and other sensor data into representations the robot can use for planning. My role focuses on scene semantics and agent intent, drawing on ML, software engineering, C++, Python, CUDA, and computer vision research. I learned those skills through self-teaching, graduate school, and my time at DEKA.
+Joining Zoox realized a long-held goal: working on autonomous driving. I am now a technical lead on the Perception team, where I lead a broader initiative to make our autonomy systems more capable and efficient. The work sits at the intersection of machine learning, software engineering, and the practical constraints of deploying models on real vehicles.
+
+Over the last couple of quarters, we shipped a major production improvement that increased system efficiency while improving model quality. The work started as a small side project that I prototyped around the middle of last year. Once we showed that the approach could work, we built a dedicated team and roadmap around it. I moved from an IC role back into technical leadership, built out the team, and we shipped the result earlier this year.
+
+The next phase is about extending the work across more autonomy capabilities and continuing to improve how we develop, evaluate, and deploy these systems. I also participate in a broader research committee across Zoox, which connects this work to technical direction outside my immediate area.
+
+The business value is deliberately practical: the work has to operate on real vehicles, use resources responsibly, improve the quality of the system, and give the organization a credible path to add capability over time. That has changed how I think about technical leadership. Technical depth still matters because I need to understand the constraints well enough to make sound design and evaluation decisions. But the larger leverage comes from turning an uncertain idea into a shared direction, giving a team the context and ownership to execute, and using the results to improve the next decision. The lesson I carry forward is simple: explain why the problem matters, make a concrete bet, understand the tradeoffs, and learn from what reaches production.
 
 One memory from joining Zoox still feels vivid. I was surrounded by incredibly talented people and felt out of place at first. It was classic imposter syndrome. The way through it was not one dramatic breakthrough; it was small wins, one after another. Those wins slowly built confidence. That feeling is common when switching roles, and it is worth recognizing it as part of professional growth, not proof that you do not belong.
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -71,10 +71,10 @@ const timelineEntries = [
       'I led part of perception for last-mile robots, from real-time vision models to CUDA kernels and OpenCL/OpenVINO deployment.',
   },
   {
-    years: '2022–2026',
+    years: '2022–present',
     title: 'Zoox',
     summary:
-      'I build learned scene representations for autonomous navigation, with a focus on general scene embeddings that support downstream planning.',
+      'I lead a perception initiative at Zoox that grew from a side project into a dedicated team and roadmap for more capable, efficient autonomy systems.',
   },
 ] as const;
 


### PR DESCRIPTION
## What changed\n- Refresh the homepage journey timeline to show Zoox as current and frame the work at a high level.\n- Expand the Zoox section of the personal story with technical depth, organizational scope, practical value, context/action/reasoning/learning, and the research committee as a single clause.\n- Keep internal Zoox technical details intentionally generalized.\n\n## Validation\n- npm run ci\n- 61 Astro files checked, 33 tests passed, 273 pages built, and build verification passed.