### PR TITLE
Group the Blog index by reading path

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2106,6 +2106,71 @@ h3,
   color: var(--text-secondary-color);
 }
 
+.blog-index-nav {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0 0 1.75rem;
+}
+
+.blog-index-nav a {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid var(--button-border);
+  border-radius: 8px;
+  color: var(--text-color);
+  background: var(--panel-bg);
+  text-decoration: none;
+}
+
+.blog-index-nav a:hover {
+  border-color: var(--link-color);
+}
+
+.blog-index-nav span {
+  font-family: var(--font-reading);
+  font-weight: 500;
+}
+
+.blog-index-nav small,
+.blog-index-group__count {
+  margin: 0;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.blog-index-groups {
+  display: grid;
+  gap: 2.4rem;
+}
+
+.blog-index-group {
+  scroll-margin-top: 1.25rem;
+}
+
+.blog-index-group__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  margin-bottom: 0.8rem;
+}
+
+.blog-index-group__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.blog-index-group__header p:not(.blog-index-group__count) {
+  max-width: 64ch;
+  margin: 0.35rem 0 0;
+  color: var(--text-secondary-color);
+}
+
 .paper-field-page {
   display: grid;
   gap: 1rem;
@@ -3064,6 +3129,15 @@ body.home-page small {
   .archive-list small {
     width: fit-content;
     white-space: normal;
+  }
+
+  .blog-index-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .blog-index-group__header {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .resource-list span {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,9 @@ const posts = defineCollection({
     title: z.string(),
     date: z.coerce.date(),
     section: z.enum(['paper-shorts', 'blog', 'revision-notes']),
+    blogGroup: z
+      .enum(['projects', 'local-ai-lab', 'research-guides', 'essays'])
+      .optional(),
     postSlug: z.string(),
     legacyPath: z.string(),
     tags: z.array(z.string()).default(['Other']),
@@ -28,6 +31,9 @@ const posts = defineCollection({
       )
       .default([]),
     summary: z.string().optional(),
+  }).refine((post) => post.section !== 'blog' || post.blogGroup !== undefined, {
+    message: 'Blog posts must declare a blogGroup so they remain findable in the Blog index.',
+    path: ['blogGroup'],
   }),
 });
 

--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -2,6 +2,7 @@
 title: 'How Attention Stores and Retrieves Context'
 date: '2025-05-25T04:00:00.000Z'
 section: blog
+blogGroup: research-guides
 postSlug: attention-mechanisms-demystified
 legacyPath: /build intuition/2025/05/25/attention-mechanisms-demystified.html
 tags:

--- a/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
+++ b/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
@@ -2,6 +2,7 @@
 title: Building Local Blog Audio with Qwen3-TTS
 date: '2026-08-13T23:30:00.000Z'
 section: blog
+blogGroup: projects
 postSlug: building-local-blog-audio-with-qwen3-tts
 legacyPath: /blog/2026/08/13/building-local-blog-audio-with-qwen3-tts.html
 tags:

--- a/src/content/posts/code-is-cheap-understanding-isnt.md
+++ b/src/content/posts/code-is-cheap-understanding-isnt.md
@@ -2,6 +2,7 @@
 title: "Code Is Cheap. Understanding Isn't."
 date: '2026-08-12T04:00:00.000Z'
 section: blog
+blogGroup: essays
 postSlug: code-is-cheap-understanding-isnt
 legacyPath: /blog/2026/08/12/code-is-cheap-understanding-isnt.html
 tags:

--- a/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
+++ b/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
@@ -2,6 +2,7 @@
 title: 'PPO, DPO, GRPO, and On-Policy Distillation'
 date: '2026-07-27T16:00:00.000Z'
 section: blog
+blogGroup: research-guides
 postSlug: from-ppo-to-grpo-rl-for-reasoning-and-vlas
 legacyPath: /blog/2026/07/27/from-ppo-to-grpo-rl-for-reasoning-and-vlas.html
 tags:

--- a/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
+++ b/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
@@ -2,6 +2,7 @@
 title: 'From Image-Text Alignment to Robot Actions'
 date: '2026-07-05T20:00:00.000Z'
 section: blog
+blogGroup: research-guides
 postSlug: from-seeing-to-doing-the-evolution-of-vision-language-models
 legacyPath: /blog/2026/07/05/from-seeing-to-doing-the-evolution-of-vision-language-models.html
 tags:

--- a/src/content/posts/how-to-read-scaling-laws-for-language-models.md
+++ b/src/content/posts/how-to-read-scaling-laws-for-language-models.md
@@ -2,6 +2,7 @@
 title: 'How to Read Scaling Laws for Language Models'
 date: '2026-08-19T12:00:00.000Z'
 section: blog
+blogGroup: research-guides
 postSlug: how-to-read-scaling-laws-for-language-models
 legacyPath: /blog/2026/08/19/how-to-read-scaling-laws-for-language-models.html
 tags:

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -2,6 +2,7 @@
 title: 'Perception for Autonomous Driving'
 date: '2026-07-31T18:00:00.000Z'
 section: blog
+blogGroup: research-guides
 postSlug: how-unified-sensor-models-are-built-for-autonomous-driving
 legacyPath: /blog/2026/07/31/how-unified-sensor-models-are-built-for-autonomous-driving.html
 tags:

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -2,6 +2,7 @@
 title: 'How I Found My Way Into Robotics'
 date: '2025-02-08T05:00:00.000Z'
 section: blog
+blogGroup: essays
 postSlug: my-journey-so-far-full-story
 legacyPath: /blog/2025/02/08/my-journey-so-far-full-story.html
 tags:

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -2,6 +2,7 @@
 title: 'How Multimodal Robot Models Are Pretrained'
 date: '2026-07-15T09:00:00.000Z'
 section: blog
+blogGroup: research-guides
 postSlug: omni-model-pretraining-decisions
 legacyPath: /blog/2026/07/15/omni-model-pretraining-decisions.html
 tags:

--- a/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
@@ -2,6 +2,7 @@
 title: Which Current Open-Weight Models Fit on a 64 GB MacBook Pro?
 date: '2026-08-13T04:00:00.000Z'
 section: blog
+blogGroup: local-ai-lab
 postSlug: open-weight-models-that-fit-on-a-64-gb-macbook-pro
 legacyPath: /blog/2026/08/13/open-weight-models-that-fit-on-a-64-gb-macbook-pro.html
 tags:

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -2,6 +2,7 @@
 title: 'How Vision-Language-Action Models Improve After Deployment'
 date: '2026-07-16T10:00:00.000Z'
 section: blog
+blogGroup: research-guides
 postSlug: post-training-vision-language-action-models-zero-to-hero
 legacyPath: /blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html
 tags:

--- a/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
+++ b/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
@@ -2,6 +2,7 @@
 title: Running Hermes Agent with a Local GGUF
 date: '2026-04-04T17:59:45.000Z'
 section: blog
+blogGroup: projects
 postSlug: replacing-openclaw-with-hermes-agent-using-local-weights
 legacyPath: /blog/2026/04/04/replacing-openclaw-with-hermes-agent-using-local-weights.html
 tags:

--- a/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
@@ -2,6 +2,7 @@
 title: Can DeepSeek V4 Flash 0731 Run on a 64 GB MacBook Pro?
 date: '2026-08-13T04:00:00.000Z'
 section: blog
+blogGroup: local-ai-lab
 postSlug: running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro
 legacyPath: /blog/2026/08/13/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.html
 tags:

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -2,6 +2,7 @@
 title: Benchmarking Gemma 4 on a 64 GB MacBook Pro
 date: '2026-04-04T04:00:00.000Z'
 section: blog
+blogGroup: local-ai-lab
 postSlug: running-gemma-4-locally-on-a-64-gb-macbook-pro
 legacyPath: /blog/2026/04/04/running-gemma-4-locally-on-a-64-gb-macbook-pro.html
 tags:

--- a/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
@@ -2,6 +2,7 @@
 title: Benchmarking Muse Glimmer 30B on a 64 GB MacBook Pro
 date: '2026-08-13T04:00:00.000Z'
 section: blog
+blogGroup: local-ai-lab
 postSlug: running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro
 legacyPath: /blog/2026/08/13/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.html
 tags:

--- a/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
@@ -2,6 +2,7 @@
 title: Benchmarking Qwen 3.5 and Qwen 3 on a 64 GB MacBook Pro
 date: '2026-04-04T04:00:00.000Z'
 section: blog
+blogGroup: local-ai-lab
 postSlug: running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro
 legacyPath: /blog/2026/04/04/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.html
 tags:

--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -2,6 +2,7 @@
 title: How Good Research Works in Industry
 date: '2026-03-22T04:00:00.000Z'
 section: blog
+blogGroup: essays
 postSlug: thoughts-on-good-research-in-industry
 legacyPath: /blog/2026/03/22/thoughts-on-good-research-in-industry.html
 tags:

--- a/src/lib/blog-index.ts
+++ b/src/lib/blog-index.ts
@@ -1,0 +1,63 @@
+export const BLOG_GROUPS = [
+  {
+    id: 'projects',
+    title: 'Projects & systems',
+    description:
+      'End-to-end builds, including the local Qwen3-TTS blog narrator and a local-weight agent.',
+  },
+  {
+    id: 'local-ai-lab',
+    title: 'Local AI lab',
+    description:
+      'Measured model-fit and inference decisions for running open weights on a 64 GB MacBook Pro.',
+  },
+  {
+    id: 'research-guides',
+    title: 'Long-form research guides',
+    description:
+      'Mechanism-first explanations of attention, scaling, multimodal learning, robot policies, and perception.',
+  },
+  {
+    id: 'essays',
+    title: 'Essays & career',
+    description:
+      'Personal experience and working principles for research, engineering, and a career in robotics.',
+  },
+] as const;
+
+export type BlogGroupId = (typeof BLOG_GROUPS)[number]['id'];
+
+interface BlogPostLike {
+  data: {
+    blogGroup?: BlogGroupId;
+  };
+}
+
+export function groupBlogPosts<TPost extends BlogPostLike>(posts: readonly TPost[]) {
+  const groups = BLOG_GROUPS.map((group) => ({ ...group, posts: [] as TPost[] }));
+  const groupById = new Map(groups.map((group) => [group.id, group]));
+  const ungrouped: TPost[] = [];
+
+  for (const post of posts) {
+    const group = post.data.blogGroup ? groupById.get(post.data.blogGroup) : undefined;
+    if (group) {
+      group.posts.push(post);
+    } else {
+      ungrouped.push(post);
+    }
+  }
+
+  return [
+    ...groups.filter((group) => group.posts.length > 0),
+    ...(ungrouped.length > 0
+      ? [
+          {
+            id: 'other',
+            title: 'Other writing',
+            description: 'Posts awaiting a more specific reading path.',
+            posts: ungrouped,
+          },
+        ]
+      : []),
+  ];
+}

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,11 +1,43 @@
 ---
 import PostLayout from '../layouts/PostLayout.astro';
 import PostList from '../components/PostList.astro';
+import SectionHeader from '../components/SectionHeader.astro';
+import { groupBlogPosts } from '../lib/blog-index';
 import { getPostsBySection } from '../lib/content';
 
 const posts = await getPostsBySection('blog', 'desc');
+const groups = groupBlogPosts(posts);
 ---
 
-<PostLayout title="Blog" showSectionsNav={false}>
-  <PostList posts={posts} />
+<PostLayout title="Blog" description="Technical guides, local experiments, projects, and essays." showSectionsNav={false}>
+  <SectionHeader
+    eyebrow="Blog"
+    title="Choose a reading path"
+    description="Browse by the kind of question you want to answer, then use the archive when a tag is the better handle."
+    meta={`${posts.length} posts · ${groups.length} paths`}
+  />
+
+  <nav class="blog-index-nav" aria-label="Blog reading paths">
+    {groups.map((group) => (
+      <a href={`#${group.id}`}>
+        <span>{group.title}</span>
+        <small>{group.posts.length} posts</small>
+      </a>
+    ))}
+  </nav>
+
+  <div class="blog-index-groups">
+    {groups.map((group) => (
+      <section class="blog-index-group" id={group.id}>
+        <div class="blog-index-group__header">
+          <div>
+            <h2>{group.title}</h2>
+            <p>{group.description}</p>
+          </div>
+          <p class="blog-index-group__count">{group.posts.length} posts</p>
+        </div>
+        <PostList posts={group.posts} />
+      </section>
+    ))}
+  </div>
 </PostLayout>

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -10,6 +10,7 @@ import {
   sortPostsDescending,
   toStaticPostSlug,
 } from '../src/lib/post-utils';
+import { groupBlogPosts } from '../src/lib/blog-index';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
@@ -128,5 +129,21 @@ describe('content helpers', () => {
     expect(toStaticPostSlug('/paper shorts/2024/06/03/gamma.html')).toBe(
       'paper shorts/2024/06/03/gamma',
     );
+  });
+});
+
+describe('blog index', () => {
+  it('groups posts into fixed reading paths and preserves any ungrouped post', () => {
+    const posts = [
+      { data: { blogGroup: 'projects' as const } },
+      { data: { blogGroup: 'research-guides' as const } },
+      { data: {} },
+    ];
+
+    expect(groupBlogPosts(posts).map((group) => [group.id, group.posts.length])).toEqual([
+      ['projects', 1],
+      ['research-guides', 1],
+      ['other', 1],
+    ]);
   });
 });


### PR DESCRIPTION
## What changed
- replace the flat chronological Blog list with project, local-AI, research-guide, and essay paths
- add jump links, group descriptions, responsive styling, and a grouping helper test
- require a blog group in post metadata so new entries remain discoverable

## Why
Readers can now find Qwen3-TTS and local agent builds separately from local-model benchmarks and long-form guides such as autonomous-driving perception.

## Tested
- npm run ci
- desktop and 390 px responsive browser checks (no document overflow, no console errors)