### PR TITLE
Simplify Blog index into expandable shelves

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2106,69 +2106,101 @@ h3,
   color: var(--text-secondary-color);
 }
 
-.blog-index-nav {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.65rem;
-  margin: 0 0 1.75rem;
+.blog-index-intro {
+  max-width: 66ch;
+  margin: 0 0 2.6rem;
 }
 
-.blog-index-nav a {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.8rem 0.9rem;
-  border: 1px solid var(--button-border);
-  border-radius: 8px;
-  color: var(--text-color);
-  background: var(--panel-bg);
-  text-decoration: none;
+.blog-index-intro h1 {
+  margin: 0 0 1rem;
+  font-size: 2.35rem;
+  line-height: 1.1;
 }
 
-.blog-index-nav a:hover {
-  border-color: var(--link-color);
-}
-
-.blog-index-nav span {
-  font-family: var(--font-reading);
-  font-weight: 500;
-}
-
-.blog-index-nav small,
-.blog-index-group__count {
-  margin: 0;
+.blog-index-intro p {
+  margin: 0.45rem 0 0;
   color: var(--text-secondary-color);
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  white-space: nowrap;
+  font-size: 1.04rem;
+  line-height: 1.65;
 }
 
 .blog-index-groups {
-  display: grid;
-  gap: 2.4rem;
+  border-bottom: 1px solid var(--button-border);
 }
 
 .blog-index-group {
-  scroll-margin-top: 1.25rem;
+  border-top: 1px solid var(--button-border);
 }
 
-.blog-index-group__header {
+.blog-index-group summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 1.15rem 0;
+  cursor: pointer;
+  list-style: none;
+}
+
+.blog-index-group summary::-webkit-details-marker {
+  display: none;
+}
+
+.blog-index-group summary:hover h2 {
+  color: var(--link-color);
+}
+
+.blog-index-group summary:focus-visible {
+  outline: 2px solid var(--link-color);
+  outline-offset: 4px;
+}
+
+.blog-index-group__title {
   display: flex;
-  justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
   align-items: baseline;
-  margin-bottom: 0.8rem;
 }
 
-.blog-index-group__header h2 {
+.blog-index-group__title h2 {
   margin: 0;
-  font-size: 1.45rem;
+  font-size: 1.35rem;
+  line-height: 1.25;
 }
 
-.blog-index-group__header p:not(.blog-index-group__count) {
-  max-width: 64ch;
-  margin: 0.35rem 0 0;
+.blog-index-group__title span {
   color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  white-space: nowrap;
+}
+
+.blog-index-group summary p {
+  max-width: 62ch;
+  margin: 0.32rem 0 0;
+  color: var(--text-secondary-color);
+  line-height: 1.5;
+}
+
+.blog-index-group__toggle {
+  width: 0.55rem;
+  height: 0.55rem;
+  margin: -0.25rem 0.35rem 0 0;
+  border-right: 1.5px solid var(--text-secondary-color);
+  border-bottom: 1.5px solid var(--text-secondary-color);
+  transform: rotate(45deg);
+  transition: transform 160ms ease;
+}
+
+.blog-index-group[open] .blog-index-group__toggle {
+  margin-top: 0.2rem;
+  transform: rotate(225deg);
+}
+
+.blog-index-group > .post-list {
+  margin: 0 0 1rem 1rem;
+  padding-left: 1rem;
+  border-top: 0;
+  border-left: 1px solid var(--button-border);
 }
 
 .paper-field-page {
@@ -3131,13 +3163,10 @@ body.home-page small {
     white-space: normal;
   }
 
-  .blog-index-nav {
-    grid-template-columns: 1fr;
-  }
-
-  .blog-index-group__header {
+  .blog-index-group__title {
     align-items: flex-start;
     flex-direction: column;
+    gap: 0.25rem;
   }
 
   .resource-list span {

--- a/src/lib/blog-index.ts
+++ b/src/lib/blog-index.ts
@@ -3,25 +3,25 @@ export const BLOG_GROUPS = [
     id: 'projects',
     title: 'Projects & systems',
     description:
-      'End-to-end builds, including the local Qwen3-TTS blog narrator and a local-weight agent.',
+      'The useful part starts after the demo: turning a local model into a system I actually rely on.',
   },
   {
     id: 'local-ai-lab',
     title: 'Local AI lab',
     description:
-      'Measured model-fit and inference decisions for running open weights on a 64 GB MacBook Pro.',
+      'What actually fits, how fast it runs, and where a 64 GB Mac stops being enough.',
   },
   {
     id: 'research-guides',
     title: 'Long-form research guides',
     description:
-      'Mechanism-first explanations of attention, scaling, multimodal learning, robot policies, and perception.',
+      'I follow the mechanism until a stack of papers becomes a mental model I can use.',
   },
   {
     id: 'essays',
     title: 'Essays & career',
     description:
-      'Personal experience and working principles for research, engineering, and a career in robotics.',
+      'The harder questions behind the work: what to learn, how to choose, and what remains valuable.',
   },
 ] as const;
 
@@ -54,7 +54,7 @@ export function groupBlogPosts<TPost extends BlogPostLike>(posts: readonly TPost
           {
             id: 'other',
             title: 'Other writing',
-            description: 'Posts awaiting a more specific reading path.',
+            description: 'Writing that has not found a better shelf yet.',
             posts: ungrouped,
           },
         ]

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,7 +1,6 @@
 ---
 import PostLayout from '../layouts/PostLayout.astro';
 import PostList from '../components/PostList.astro';
-import SectionHeader from '../components/SectionHeader.astro';
 import { groupBlogPosts } from '../lib/blog-index';
 import { getPostsBySection } from '../lib/content';
 
@@ -10,34 +9,34 @@ const groups = groupBlogPosts(posts);
 ---
 
 <PostLayout title="Blog" description="Technical guides, local experiments, projects, and essays." showSectionsNav={false}>
-  <SectionHeader
-    eyebrow="Blog"
-    title="Choose a reading path"
-    description="Browse by the kind of question you want to answer, then use the archive when a tag is the better handle."
-    meta={`${posts.length} posts · ${groups.length} paths`}
-  />
-
-  <nav class="blog-index-nav" aria-label="Blog reading paths">
-    {groups.map((group) => (
-      <a href={`#${group.id}`}>
-        <span>{group.title}</span>
-        <small>{group.posts.length} posts</small>
-      </a>
-    ))}
-  </nav>
+  <header class="blog-index-intro">
+    <h1>Blog</h1>
+    <p>
+      I fundamentally believe writing is the way to learn. It forces a half-formed idea into
+      something I can inspect, test, and return to.
+    </p>
+    <p>
+      AI has accelerated that process and empowered me to follow every question further. The
+      curiosity is almost infectious: each experiment becomes a note, and each note opens another
+      question.
+    </p>
+  </header>
 
   <div class="blog-index-groups">
     {groups.map((group) => (
-      <section class="blog-index-group" id={group.id}>
-        <div class="blog-index-group__header">
+      <details class="blog-index-group" id={group.id}>
+        <summary>
           <div>
-            <h2>{group.title}</h2>
+            <div class="blog-index-group__title">
+              <h2>{group.title}</h2>
+              <span>{group.posts.length} posts</span>
+            </div>
             <p>{group.description}</p>
           </div>
-          <p class="blog-index-group__count">{group.posts.length} posts</p>
-        </div>
+          <span class="blog-index-group__toggle" aria-hidden="true"></span>
+        </summary>
         <PostList posts={group.posts} />
-      </section>
+      </details>
     ))}
   </div>
 </PostLayout>


### PR DESCRIPTION
## What changed
- replace the generic Blog index pitch with a direct personal note about writing and AI-assisted learning
- remove the duplicated reading-path navigation
- collapse each category into an accessible expandable shelf with one concise description
- refine desktop, keyboard-focus, and mobile styling

## Tested
- npm run ci
- browser interaction check: all shelves closed on load, one-shelf expansion, no console errors
- responsive check at 390 px with no horizontal overflow