### PR TITLE
Use blue-berry colors for site links

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -15,6 +15,10 @@
   --text-color: #10213f;
   --text-secondary-color: #4d628f;
   --accent-color: #356dff;
+  --link-color: #5b4bb7;
+  --link-hover-color: #40349a;
+  --link-visited-color: #775ca6;
+  --link-underline-color: rgba(91, 75, 183, 0.42);
   --icon-color: #356dff;
   --image-border-color: #6c96ff;
   --code-border-color: rgba(53, 109, 255, 0.18);
@@ -48,6 +52,10 @@
   --text-color: #10213f;
   --text-secondary-color: #4d628f;
   --accent-color: #356dff;
+  --link-color: #5b4bb7;
+  --link-hover-color: #40349a;
+  --link-visited-color: #775ca6;
+  --link-underline-color: rgba(91, 75, 183, 0.42);
   --icon-color: #356dff;
   --image-border-color: #6c96ff;
   --code-border-color: rgba(53, 109, 255, 0.18);
@@ -76,6 +84,10 @@
   --text-color: #f6e7a6;
   --text-secondary-color: #b9ab66;
   --accent-color: #ffe45c;
+  --link-color: #b7b2ff;
+  --link-hover-color: #e2e0ff;
+  --link-visited-color: #c7b4ee;
+  --link-underline-color: rgba(183, 178, 255, 0.62);
   --icon-color: #ffe45c;
   --image-border-color: #ffe45c;
   --code-border-color: rgba(255, 228, 92, 0.55);
@@ -1387,51 +1399,51 @@ body.image-viewer-open {
    4) GLOBAL LINK STYLING (Site-wide)
    ------------------------------------------------------ */
 
-/* All <a> tags: light blue by default, no underline */
+/* All <a> tags: blue-berry by default, no underline */
 a {
-  color: #7d9dff;
+  color: var(--link-color);
   text-decoration: none;
 }
 
-/* Hover state: darker blue + underline */
+/* Hover state: blue-berry highlight + underline */
 a:hover {
-  color: #2ac3de;
+  color: var(--link-hover-color);
   text-decoration: underline;
 }
 
 a:visited {
-  color: #7aa2f7 !important; /* Slightly darker for visited links. */
+  color: var(--link-visited-color) !important;
   text-decoration: none;
 }
 
 :root[data-theme="light"] a {
-  color: var(--accent-color);
-  text-decoration-color: rgba(53, 109, 255, 0.4);
+  color: var(--link-color);
+  text-decoration-color: var(--link-underline-color);
 }
 
 :root[data-theme="light"] a:hover {
-  color: #214fcb;
+  color: var(--link-hover-color);
   text-decoration: underline;
-  text-shadow: 0 0 10px rgba(79, 132, 255, 0.16);
+  text-shadow: 0 0 10px rgba(91, 75, 183, 0.16);
 }
 
 :root[data-theme="light"] a:visited {
-  color: #4a58c8 !important;
+  color: var(--link-visited-color) !important;
 }
 
 :root[data-theme="dark"] a {
-  color: var(--accent-color);
-  text-decoration-color: rgba(255, 228, 92, 0.5);
+  color: var(--link-color);
+  text-decoration-color: var(--link-underline-color);
 }
 
 :root[data-theme="dark"] a:hover {
-  color: #fff2a1;
+  color: var(--link-hover-color);
   text-decoration: underline;
-  text-shadow: 0 0 12px rgba(255, 228, 92, 0.34);
+  text-shadow: 0 0 12px rgba(183, 178, 255, 0.34);
 }
 
 :root[data-theme="dark"] a:visited {
-  color: #d8bc45 !important;
+  color: var(--link-visited-color) !important;
 }
 
 /* ------------------------------------------------------

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,7 +14,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 const canonicalUrl = Astro.site
   ? new URL(Astro.url.pathname, Astro.site).toString()
   : Astro.url.toString();
-const themeStylesheetHref = '/css/override.css?v=20260814-code-light-mode';
+const themeStylesheetHref = '/css/override.css?v=20260819-blue-berry-links';
 ---
 
 <!DOCTYPE html>


### PR DESCRIPTION
## What changed
- Add blue-berry link colors for light and dark themes.
- Add hover, visited, and underline variants.
- Bump the stylesheet cache key so deployed pages receive the change.

## Why
Blog and site links should stand apart from the regular yellow dark-theme text.

## Tested
- `npm run ci`
- 34 tests passed
- 297 pages built
- Build verification passed