### PR TITLE
Refine Blog intro and expandable shelves

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2205,9 +2205,6 @@ h3,
 }
 
 .blog-index-group__action {
-  display: flex;
-  gap: 0.6rem;
-  align-items: center;
   color: var(--text-secondary-color);
   font-family: var(--font-mono);
   font-size: 0.74rem;
@@ -2215,31 +2212,15 @@ h3,
   text-transform: uppercase;
 }
 
-.blog-index-group__toggle {
-  display: grid;
-  width: 1.65rem;
-  height: 1.65rem;
-  place-items: center;
-  border: 1px solid var(--button-border);
-  border-radius: 50%;
-  color: var(--text-color);
-  font-family: var(--font-mono);
-  font-size: 1rem;
-  line-height: 1;
-}
-
-.blog-index-group__action-label--open,
-.blog-index-group__toggle-open {
+.blog-index-group__action-label--open {
   display: none;
 }
 
-.blog-index-group[open] .blog-index-group__action-label--closed,
-.blog-index-group[open] .blog-index-group__toggle-closed {
+.blog-index-group[open] .blog-index-group__action-label--closed {
   display: none;
 }
 
-.blog-index-group[open] .blog-index-group__action-label--open,
-.blog-index-group[open] .blog-index-group__toggle-open {
+.blog-index-group[open] .blog-index-group__action-label--open {
   display: inline;
 }
 
@@ -3214,10 +3195,6 @@ body.home-page small {
     align-items: flex-start;
     flex-direction: column;
     gap: 0.25rem;
-  }
-
-  .blog-index-group__action-label {
-    display: none !important;
   }
 
   .resource-list span {

--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2137,11 +2137,16 @@ h3,
 }
 
 .blog-index-groups {
-  border-bottom: 1px solid var(--button-border);
+  display: grid;
+  gap: 0.75rem;
 }
 
 .blog-index-group {
-  border-top: 1px solid var(--button-border);
+  overflow: hidden;
+  border: 1px solid var(--button-border);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  box-shadow: var(--button-shadow);
 }
 
 .blog-index-group summary {
@@ -2149,16 +2154,22 @@ h3,
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 1.25rem;
   align-items: center;
-  padding: 1.15rem 0;
+  padding: 1rem 1.1rem;
   cursor: pointer;
   list-style: none;
+  transition: background-color 160ms ease, border-color 160ms ease;
 }
 
 .blog-index-group summary::-webkit-details-marker {
   display: none;
 }
 
-.blog-index-group summary:hover h2 {
+.blog-index-group summary:hover {
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.blog-index-group summary:hover h2,
+.blog-index-group[open] summary h2 {
   color: var(--link-color);
 }
 
@@ -2193,25 +2204,49 @@ h3,
   line-height: 1.5;
 }
 
-.blog-index-group__toggle {
-  width: 0.55rem;
-  height: 0.55rem;
-  margin: -0.25rem 0.35rem 0 0;
-  border-right: 1.5px solid var(--text-secondary-color);
-  border-bottom: 1.5px solid var(--text-secondary-color);
-  transform: rotate(45deg);
-  transition: transform 160ms ease;
+.blog-index-group__action {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
-.blog-index-group[open] .blog-index-group__toggle {
-  margin-top: 0.2rem;
-  transform: rotate(225deg);
+.blog-index-group__toggle {
+  display: grid;
+  width: 1.65rem;
+  height: 1.65rem;
+  place-items: center;
+  border: 1px solid var(--button-border);
+  border-radius: 50%;
+  color: var(--text-color);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.blog-index-group__action-label--open,
+.blog-index-group__toggle-open {
+  display: none;
+}
+
+.blog-index-group[open] .blog-index-group__action-label--closed,
+.blog-index-group[open] .blog-index-group__toggle-closed {
+  display: none;
+}
+
+.blog-index-group[open] .blog-index-group__action-label--open,
+.blog-index-group[open] .blog-index-group__toggle-open {
+  display: inline;
 }
 
 .blog-index-group > .post-list {
-  margin: 0 0 1rem 1rem;
-  padding-left: 1rem;
-  border-top: 0;
+  margin: 0 1.1rem 1rem;
+  padding: 0 0 0 1rem;
+  border-top: 1px solid var(--button-border);
   border-left: 1px solid var(--button-border);
 }
 
@@ -3179,6 +3214,10 @@ body.home-page small {
     align-items: flex-start;
     flex-direction: column;
     gap: 0.25rem;
+  }
+
+  .blog-index-group__action-label {
+    display: none !important;
   }
 
   .resource-list span {

--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -8,8 +8,8 @@ legacyPath: /build intuition/2025/05/25/attention-mechanisms-demystified.html
 tags:
   - Other
 summary: >-
-  How attention evolved from explicit token retrieval to shared, compressed,
-  sparse, and recurrent memory, with efficient PyTorch implementations.
+  How attention retrieves, compresses, sparsifies, and carries context—with
+  runnable PyTorch.
 ---
 import PythonPlayground from '../../components/PythonPlayground';
 import { attentionMechanismsPlayground } from '../../lib/python-playground-examples';

--- a/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
+++ b/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
@@ -11,9 +11,8 @@ tags:
   - Apple Silicon
   - Audio
 summary: >-
-  How this site turns Blog Markdown into static MP3 narration with Qwen3-TTS,
-  keeps a synthetic narrator stable across chunks, excludes visual or code
-  artifacts, and serves playback without a runtime model or API dependency.
+  A local Qwen3-TTS pipeline that turns Blog Markdown into consistent, static
+  narration.
 ---
 
 # Building Local Blog Audio with Qwen3-TTS

--- a/src/content/posts/code-is-cheap-understanding-isnt.md
+++ b/src/content/posts/code-is-cheap-understanding-isnt.md
@@ -12,8 +12,7 @@ tags:
 topics:
   - language-systems
 summary: >-
-  What remains valuable when agents make implementation abundant: context,
-  judgment, task decomposition, efficient orchestration, and ownership.
+  What engineers should learn when AI makes writing code cheap.
 ---
 
 # Code Is Cheap. Understanding Isn't.

--- a/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
+++ b/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
@@ -9,7 +9,7 @@ tags:
   - Reinforcement Learning
   - Reasoning
   - Robotics
-summary: 'How PPO, DPO, GRPO, and on-policy distillation construct their learning signals—and which assumptions survive contact with physical action.'
+summary: 'A practical map of PPO, DPO, GRPO, and on-policy distillation.'
 ---
 
 # PPO, DPO, GRPO, and On-Policy Distillation

--- a/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
+++ b/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
@@ -8,7 +8,7 @@ legacyPath: /blog/2026/07/05/from-seeing-to-doing-the-evolution-of-vision-langua
 tags:
   - Research
   - Vision-Language Models
-summary: How visual representations change as the output contract moves from image-text alignment to generation, grounding, temporal reasoning, and robot action.
+summary: How vision-language models evolved from image-text alignment to robot action.
 ---
 
 # From Image-Text Alignment to Robot Actions

--- a/src/content/posts/how-to-read-scaling-laws-for-language-models.md
+++ b/src/content/posts/how-to-read-scaling-laws-for-language-models.md
@@ -9,7 +9,7 @@ tags:
   - Language Models
   - Scaling Laws
   - Pretraining
-summary: A close reading of cross-entropy, perplexity, Kaplan, and Chinchilla—and why a scaling curve should change an experiment plan, not end the discussion.
+summary: How to interpret scaling curves—and turn them into better experiments.
 ---
 
 # Some Thoughts on Scaling Laws for Language Models

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -12,7 +12,7 @@ tags:
 topics:
   - autonomy
   - multimodal
-summary: How camera, LiDAR, and radar encoders preserve different measurements, align them in metric space, fuse them, and carry scene state through time.
+summary: How camera, LiDAR, and radar become a unified, temporal scene representation.
 ---
 
 # Perception for Autonomous Driving in 2026

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -8,8 +8,7 @@ legacyPath: /blog/2025/02/08/my-journey-so-far-full-story.html
 tags:
   - Other
 summary: >-
-  How failure, depression, hands-on projects, graduate school, DEKA, and Zoox
-  shaped my path into robotics and autonomous driving.
+  How failure, projects, graduate school, and industry led me into robotics.
 ---
 
 # How I Found My Way Into Robotics

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -9,7 +9,7 @@ tags:
   - Multimodal AI
   - Pretraining
   - Research Leadership
-summary: How representations, robot data, action interfaces, objective mixtures, and scaling experiments determine a multimodal robot policy.
+summary: The key decisions behind pretraining multimodal robot policies.
 ---
 
 # How Multimodal Robot Models Are Pretrained

--- a/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
@@ -10,8 +10,7 @@ tags:
   - Apple Silicon
   - Inference
 summary: >-
-  A current fit guide for Muse Glimmer, Ministral, Granite, Nemotron, Mistral
-  Small 4, and DeepSeek V4 Flash on a 64 GB Apple Silicon machine.
+  Which current open-weight models actually fit on a 64 GB Mac.
 ---
 # Which Current Open-Weight Models Fit on a 64 GB MacBook Pro?
 

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -9,7 +9,7 @@ tags:
   - Robotics
   - Post-Training
   - Reinforcement Learning
-summary: How robot rollouts become justified policy updates through correction data, action preferences, process critics, interactive reinforcement learning, and real evaluation.
+summary: How correction data, preferences, critics, and RL improve deployed robot policies.
 ---
 
 # How Vision-Language-Action Models Improve After Deployment

--- a/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
+++ b/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
@@ -10,8 +10,7 @@ tags:
   - LLMs
   - Apple Silicon
 summary: >-
-  How Hermes Agent, an OpenAI-compatible localhost endpoint, llama.cpp, and an
-  already-downloaded Gemma GGUF fit together.
+  How to run Hermes Agent locally with llama.cpp and an existing GGUF.
 ---
 # Running Hermes Agent with a Local GGUF
 

--- a/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
@@ -10,8 +10,7 @@ tags:
   - Apple Silicon
   - Inference
 summary: >-
-  Why DeepSeek V4 Flash 0731 does not fit in 64 GB unified memory, what its
-  13B active parameter count actually means, and the practical serving path.
+  Why DeepSeek V4 Flash 0731 cannot fit in 64 GB—and what can.
 ---
 # Can DeepSeek V4 Flash 0731 Run on a 64 GB MacBook Pro?
 

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -9,8 +9,7 @@ tags:
   - LLMs
   - Apple Silicon
 summary: >-
-  A dated comparison of MLX and llama.cpp latency for Gemma 4 on a 64 GB M5
-  Max, including why long-prompt prefill changes the recommendation.
+  MLX versus llama.cpp performance for Gemma 4 on a 64 GB M5 Max.
 ---
 # Benchmarking Gemma 4 on a 64 GB MacBook Pro
 

--- a/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
@@ -10,8 +10,8 @@ tags:
   - Apple Silicon
   - Inference
 summary: >-
-  A measured llama.cpp benchmark of Meta's official 17 GB Muse Glimmer 30B
-  quant on a 64 GB M5 Max, including reasoning latency and an 8K prompt test.
+  Measured Muse Glimmer 30B latency, memory use, and long-context behavior on
+  an M5 Max.
 ---
 # Benchmarking Muse Glimmer 30B on a 64 GB MacBook Pro
 

--- a/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
@@ -9,8 +9,7 @@ tags:
   - LLMs
   - Apple Silicon
 summary: >-
-  A dated comparison of Qwen 3.5 and Qwen 3 latency on a 64 GB M5 Max,
-  including why long-prompt prefill matters more than whether a model fits.
+  Qwen 3.5 versus Qwen 3 latency and long-prompt performance on an M5 Max.
 ---
 # Benchmarking Qwen 3.5 and Qwen 3 on a 64 GB MacBook Pro
 

--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -9,8 +9,8 @@ tags:
   - Research
   - Career
 summary: >-
-  How research taste, problem choice, collaboration, controlled experiments,
-  and throughput combine into a reliable research system.
+  How taste, problem choice, collaboration, and experiment cadence produce good
+  research.
 ---
 # How Good Research Works in Industry
 

--- a/src/lib/blog-index.ts
+++ b/src/lib/blog-index.ts
@@ -3,25 +3,25 @@ export const BLOG_GROUPS = [
     id: 'research-guides',
     title: 'Long-form research guides',
     description:
-      'I follow the mechanism until a stack of papers becomes a mental model I can use.',
+      'Deep dives into perception, multimodal models, reinforcement learning, and scaling.',
   },
   {
     id: 'essays',
     title: 'Essays & career',
     description:
-      'The harder questions behind the work: what to learn, how to choose, and what remains valuable.',
+      'Notes on research, careers, and what remains valuable as AI changes the work.',
   },
   {
     id: 'projects',
     title: 'Projects & systems',
     description:
-      'The useful part starts after the demo: turning a local model into a system I actually rely on.',
+      'Local agents, Blog audio, and the systems I built around open models.',
   },
   {
     id: 'local-ai-lab',
     title: 'Local AI lab',
     description:
-      'What actually fits, how fast it runs, and where a 64 GB Mac stops being enough.',
+      'Benchmarks and fit checks for running open-weight models on a 64 GB Mac.',
   },
 ] as const;
 

--- a/src/lib/blog-index.ts
+++ b/src/lib/blog-index.ts
@@ -1,17 +1,5 @@
 export const BLOG_GROUPS = [
   {
-    id: 'projects',
-    title: 'Projects & systems',
-    description:
-      'The useful part starts after the demo: turning a local model into a system I actually rely on.',
-  },
-  {
-    id: 'local-ai-lab',
-    title: 'Local AI lab',
-    description:
-      'What actually fits, how fast it runs, and where a 64 GB Mac stops being enough.',
-  },
-  {
     id: 'research-guides',
     title: 'Long-form research guides',
     description:
@@ -22,6 +10,18 @@ export const BLOG_GROUPS = [
     title: 'Essays & career',
     description:
       'The harder questions behind the work: what to learn, how to choose, and what remains valuable.',
+  },
+  {
+    id: 'projects',
+    title: 'Projects & systems',
+    description:
+      'The useful part starts after the demo: turning a local model into a system I actually rely on.',
+  },
+  {
+    id: 'local-ai-lab',
+    title: 'Local AI lab',
+    description:
+      'What actually fits, how fast it runs, and where a 64 GB Mac stops being enough.',
   },
 ] as const;
 

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -12,13 +12,9 @@ const groups = groupBlogPosts(posts);
   <header class="blog-index-intro">
     <h1>Blog</h1>
     <p>
-      I fundamentally believe writing is the way to learn. It forces a half-formed idea into
-      something I can inspect, test, and return to.
-    </p>
-    <p>
-      AI has accelerated that process and empowered me to follow every question further. The
-      curiosity is almost infectious: each experiment becomes a note, and each note opens another
-      question.
+      I fundamentally believe writing is the way to learn. When I write, a half-formed idea in my
+      head becomes something concrete and deeply etched in my memory. Here are some of the ideas I
+      have thought through over the past few years.
     </p>
   </header>
 
@@ -33,7 +29,14 @@ const groups = groupBlogPosts(posts);
             </div>
             <p>{group.description}</p>
           </div>
-          <span class="blog-index-group__toggle" aria-hidden="true"></span>
+          <span class="blog-index-group__action" aria-hidden="true">
+            <span class="blog-index-group__action-label blog-index-group__action-label--closed">Explore</span>
+            <span class="blog-index-group__action-label blog-index-group__action-label--open">Close</span>
+            <span class="blog-index-group__toggle">
+              <span class="blog-index-group__toggle-closed">+</span>
+              <span class="blog-index-group__toggle-open">−</span>
+            </span>
+          </span>
         </summary>
         <PostList posts={group.posts} />
       </details>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -20,7 +20,7 @@ const groups = groupBlogPosts(posts);
 
   <div class="blog-index-groups">
     {groups.map((group) => (
-      <details class="blog-index-group" id={group.id}>
+      <details class="blog-index-group no-icon" id={group.id}>
         <summary>
           <div>
             <div class="blog-index-group__title">
@@ -30,12 +30,8 @@ const groups = groupBlogPosts(posts);
             <p>{group.description}</p>
           </div>
           <span class="blog-index-group__action" aria-hidden="true">
-            <span class="blog-index-group__action-label blog-index-group__action-label--closed">Explore</span>
-            <span class="blog-index-group__action-label blog-index-group__action-label--open">Close</span>
-            <span class="blog-index-group__toggle">
-              <span class="blog-index-group__toggle-closed">+</span>
-              <span class="blog-index-group__toggle-open">−</span>
-            </span>
+            <span class="blog-index-group__action-label--closed">View posts ↓</span>
+            <span class="blog-index-group__action-label--open">Hide posts ↑</span>
           </span>
         </summary>
         <PostList posts={group.posts} />

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -141,8 +141,8 @@ describe('blog index', () => {
     ];
 
     expect(groupBlogPosts(posts).map((group) => [group.id, group.posts.length])).toEqual([
-      ['projects', 1],
       ['research-guides', 1],
+      ['projects', 1],
       ['other', 1],
     ]);
   });


### PR DESCRIPTION
## Summary
- replace the Blog preamble with a concise statement about writing as a way to learn
- make each category visibly expandable with bordered shelves, Explore/Close labels, and plus/minus controls
- lead with Long-form research guides and Essays & career

## Validation
- git diff --check
- npm run ci
- desktop and 390px mobile interaction QA with no console errors or horizontal overflow