### PR TITLE
Rebuild the Writing index

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2309,6 +2309,169 @@ h3,
   border-left: 1px solid var(--button-border);
 }
 
+.writing-index {
+  min-width: 0;
+}
+
+.writing-index-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  margin: 0 0 1rem;
+}
+
+.writing-index-search {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.72rem 0.85rem;
+  border: 1px solid var(--button-border);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  color: var(--text-secondary-color);
+}
+
+.writing-index-search:focus-within {
+  border-color: var(--link-color);
+  box-shadow: 0 0 0 1px var(--link-color);
+}
+
+.writing-index-search input {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-color);
+  font: inherit;
+}
+
+.writing-index-search input::placeholder {
+  color: var(--text-secondary-color);
+}
+
+.writing-index-toolbar output {
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.writing-index-section__body {
+  margin: 0 1.1rem 1.1rem;
+  border-top: 1px solid var(--button-border);
+}
+
+.writing-index-section__body--list {
+  padding-left: 1rem;
+  border-left: 1px solid var(--button-border);
+}
+
+.writing-index-subgroups {
+  display: grid;
+}
+
+.writing-index-subgroup {
+  border-bottom: 1px solid var(--button-border);
+}
+
+.writing-index-subgroup > summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.9rem 0;
+  cursor: pointer;
+  list-style: none;
+}
+
+.writing-index-subgroup > summary::-webkit-details-marker {
+  display: none;
+}
+
+.writing-index-subgroup > summary:hover h3,
+.writing-index-subgroup[open] > summary h3 {
+  color: var(--link-color);
+}
+
+.writing-index-subgroup > summary:focus-visible {
+  outline: 2px solid var(--link-color);
+  outline-offset: 3px;
+}
+
+.writing-index-subgroup__title {
+  display: flex;
+  gap: 0.65rem;
+  align-items: baseline;
+}
+
+.writing-index-subgroup__title h3 {
+  margin: 0;
+  font-size: 1.08rem;
+  line-height: 1.3;
+}
+
+.writing-index-subgroup__title span,
+.writing-index-subgroup__action {
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.writing-index-subgroup summary p {
+  max-width: 60ch;
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary-color);
+  font-size: 0.94rem;
+  line-height: 1.45;
+}
+
+.writing-index-subgroup__action {
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.writing-index-subgroup__action-label--open {
+  display: none;
+}
+
+.writing-index-subgroup[open] .writing-index-subgroup__action-label--closed {
+  display: none;
+}
+
+.writing-index-subgroup[open] .writing-index-subgroup__action-label--open {
+  display: inline;
+}
+
+.writing-index-subgroup > .writing-index-list {
+  margin-left: 1rem;
+  padding-left: 1rem;
+  border-left: 1px solid var(--button-border);
+}
+
+.writing-index-list p {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+[data-writing-section][hidden],
+[data-writing-subgroup][hidden],
+[data-writing-item][hidden],
+.writing-index-empty[hidden] {
+  display: none;
+}
+
+.writing-index-empty {
+  margin: 1.5rem 0 0;
+  color: var(--text-secondary-color);
+}
+
 .paper-field-page {
   display: grid;
   gap: 1rem;
@@ -3273,6 +3436,22 @@ body.home-page small {
     align-items: flex-start;
     flex-direction: column;
     gap: 0.25rem;
+  }
+
+  .writing-index-toolbar,
+  .writing-index .blog-index-group > summary,
+  .writing-index-subgroup > summary {
+    grid-template-columns: 1fr;
+  }
+
+  .writing-index .blog-index-group__action {
+    justify-self: start;
+  }
+
+  .writing-index-subgroup__title {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
   }
 
   .resource-list span {

--- a/src/components/WritingIndexList.astro
+++ b/src/components/WritingIndexList.astro
@@ -1,0 +1,40 @@
+---
+import type { PostEntry } from '../lib/content';
+
+interface Props {
+  posts: PostEntry[];
+  context?: string;
+}
+
+const { posts, context = '' } = Astro.props;
+
+const searchTextFor = (post: PostEntry) =>
+  [
+    post.data.title,
+    post.data.summary,
+    post.data.field,
+    post.data.tags.join(' '),
+    context,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLocaleLowerCase();
+---
+
+<ul class="post-list writing-index-list">
+  {posts.map((post) => (
+    <li data-writing-item data-search-text={searchTextFor(post)}>
+      <a href={post.data.legacyPath}>{post.data.title}</a>
+      <small>
+        {
+          post.data.date.toLocaleDateString('en-US', {
+            month: 'short',
+            day: '2-digit',
+            year: 'numeric',
+          })
+        }
+      </small>
+      {post.data.summary && <p>{post.data.summary}</p>}
+    </li>
+  ))}
+</ul>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,32 +1,226 @@
 ---
+import WritingIndexList from '../components/WritingIndexList.astro';
 import PostLayout from '../layouts/PostLayout.astro';
-import SectionHeader from '../components/SectionHeader.astro';
-import { getAllPosts, groupPostsByTag } from '../lib/content';
+import { groupBlogPosts } from '../lib/blog-index';
+import {
+  getAllPosts,
+  getPostsBySection,
+  groupPostsByField,
+  sortPostsDescending,
+} from '../lib/content';
 
-const posts = await getAllPosts();
-const grouped = groupPostsByTag(posts);
+const allPosts = await getAllPosts('desc');
+const blogPosts = await getPostsBySection('blog', 'desc');
+const paperPosts = await getPostsBySection('paper-shorts', 'desc');
+const revisionPosts = await getPostsBySection('revision-notes', 'desc');
+
+const blogGroups = groupBlogPosts(blogPosts);
+const paperFields = groupPostsByField(paperPosts)
+  .map(({ field, posts }) => ({ field, posts: sortPostsDescending(posts) }))
+  .sort((left, right) => left.field.localeCompare(right.field));
+
+const sections = [
+  {
+    id: 'blog',
+    title: 'Blog',
+    description: 'Long-form technical guides, projects, local experiments, and essays.',
+    count: blogPosts.length,
+  },
+  {
+    id: 'arxiv-notes',
+    title: 'Arxiv Notes',
+    description: 'Compact paper notes, grouped by the research problem they address.',
+    count: paperPosts.length,
+  },
+  {
+    id: 'revision-notes',
+    title: 'Revision Notes',
+    description: 'Lecture and course material rebuilt for fast recall.',
+    count: revisionPosts.length,
+  },
+] as const;
 ---
 
-<PostLayout title="Blog Archive" showSectionsNav={false}>
-  <SectionHeader
-    eyebrow="Archive"
-    title="All writing by tag"
-    description="A compact index for jumping across research notes, essays, explainers, and revision material."
-    meta={`${posts.length} entries`}
-  />
-  {grouped.map(({ tag, items }) => (
-    <section class="section-index-group">
-      <h3>{tag}</h3>
-      <ul class="archive-list">
-        {items.map((post) => (
-          <li>
-            <a href={post.data.legacyPath}>
-              <span>{post.data.title}</span>
-              <small>{post.data.date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}</small>
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
-  ))}
+<PostLayout
+  title="Writing"
+  description="Essays, technical guides, paper notes, and revision material, grouped by form and subject."
+  showSectionsNav={false}
+>
+  <div class="writing-index" data-writing-index>
+    <header class="blog-index-intro">
+      <h1>Writing</h1>
+      <p>Essays, technical guides, paper notes, and revision material, grouped by form and subject.</p>
+    </header>
+
+    <div class="writing-index-toolbar">
+      <label class="writing-index-search">
+        <span aria-hidden="true">⌕</span>
+        <input
+          type="search"
+          placeholder="Search titles, summaries, or fields"
+          autocomplete="off"
+          data-writing-search
+        />
+      </label>
+      <output data-writing-count>{allPosts.length} entries</output>
+    </div>
+
+    <div class="blog-index-groups">
+      <details class="blog-index-group no-icon" id={sections[0].id} data-writing-section>
+        <summary>
+          <div>
+            <div class="blog-index-group__title">
+              <h2>{sections[0].title}</h2>
+              <span>{sections[0].count} posts</span>
+            </div>
+            <p>{sections[0].description}</p>
+          </div>
+          <span class="blog-index-group__action" aria-hidden="true">
+            <span class="blog-index-group__action-label--closed">View entries ↓</span>
+            <span class="blog-index-group__action-label--open">Hide entries ↑</span>
+          </span>
+        </summary>
+        <div class="writing-index-section__body">
+          <div class="writing-index-subgroups">
+            {blogGroups.map((group) => (
+              <details class="writing-index-subgroup no-icon" data-writing-subgroup>
+                <summary>
+                  <div>
+                    <div class="writing-index-subgroup__title">
+                      <h3>{group.title}</h3>
+                      <span>{group.posts.length} posts</span>
+                    </div>
+                    <p>{group.description}</p>
+                  </div>
+                  <span class="writing-index-subgroup__action" aria-hidden="true">
+                    <span class="writing-index-subgroup__action-label--closed">View posts ↓</span>
+                    <span class="writing-index-subgroup__action-label--open">Hide posts ↑</span>
+                  </span>
+                </summary>
+                <WritingIndexList posts={group.posts} context={`Blog ${group.title}`} />
+              </details>
+            ))}
+          </div>
+        </div>
+      </details>
+
+      <details class="blog-index-group no-icon" id={sections[1].id} data-writing-section>
+        <summary>
+          <div>
+            <div class="blog-index-group__title">
+              <h2>{sections[1].title}</h2>
+              <span>{sections[1].count} notes</span>
+            </div>
+            <p>{sections[1].description}</p>
+          </div>
+          <span class="blog-index-group__action" aria-hidden="true">
+            <span class="blog-index-group__action-label--closed">View entries ↓</span>
+            <span class="blog-index-group__action-label--open">Hide entries ↑</span>
+          </span>
+        </summary>
+        <div class="writing-index-section__body">
+          <div class="writing-index-subgroups">
+            {paperFields.map(({ field, posts }) => (
+              <details class="writing-index-subgroup no-icon" data-writing-subgroup>
+                <summary>
+                  <div class="writing-index-subgroup__title">
+                    <h3>{field}</h3>
+                    <span>{posts.length} notes</span>
+                  </div>
+                  <span class="writing-index-subgroup__action" aria-hidden="true">
+                    <span class="writing-index-subgroup__action-label--closed">View notes ↓</span>
+                    <span class="writing-index-subgroup__action-label--open">Hide notes ↑</span>
+                  </span>
+                </summary>
+                <WritingIndexList posts={posts} context={`Arxiv Notes ${field}`} />
+              </details>
+            ))}
+          </div>
+        </div>
+      </details>
+
+      <details class="blog-index-group no-icon" id={sections[2].id} data-writing-section>
+        <summary>
+          <div>
+            <div class="blog-index-group__title">
+              <h2>{sections[2].title}</h2>
+              <span>{sections[2].count} notes</span>
+            </div>
+            <p>{sections[2].description}</p>
+          </div>
+          <span class="blog-index-group__action" aria-hidden="true">
+            <span class="blog-index-group__action-label--closed">View entries ↓</span>
+            <span class="blog-index-group__action-label--open">Hide entries ↑</span>
+          </span>
+        </summary>
+        <div class="writing-index-section__body writing-index-section__body--list">
+          <WritingIndexList posts={revisionPosts} context="Revision Notes" />
+        </div>
+      </details>
+    </div>
+    <p class="writing-index-empty" data-writing-empty hidden>No writing found for that search.</p>
+  </div>
+
+  <script is:inline>
+    (() => {
+      const root = document.querySelector('[data-writing-index]');
+      const input = root?.querySelector('[data-writing-search]');
+      const count = root?.querySelector('[data-writing-count]');
+      const empty = root?.querySelector('[data-writing-empty]');
+
+      if (!(root instanceof HTMLElement) || !(input instanceof HTMLInputElement)) return;
+
+      const sections = [...root.querySelectorAll('[data-writing-section]')];
+      const subgroups = [...root.querySelectorAll('[data-writing-subgroup]')];
+      const items = [...root.querySelectorAll('[data-writing-item]')];
+
+      const update = () => {
+        const query = input.value.trim().toLocaleLowerCase();
+        let matches = 0;
+
+        for (const item of items) {
+          if (!(item instanceof HTMLElement)) continue;
+          const matchesQuery = query === '' || (item.dataset.searchText ?? '').includes(query);
+          item.hidden = !matchesQuery;
+          if (matchesQuery) matches += 1;
+        }
+
+        for (const subgroup of subgroups) {
+          if (!(subgroup instanceof HTMLDetailsElement)) continue;
+          const hasMatch = [...subgroup.querySelectorAll('[data-writing-item]')].some(
+            (item) => item instanceof HTMLElement && !item.hidden,
+          );
+          subgroup.hidden = query !== '' && !hasMatch;
+          subgroup.open = query !== '' && hasMatch;
+        }
+
+        for (const section of sections) {
+          if (!(section instanceof HTMLDetailsElement)) continue;
+          const hasMatch = [...section.querySelectorAll('[data-writing-item]')].some(
+            (item) => item instanceof HTMLElement && !item.hidden,
+          );
+          section.hidden = query !== '' && !hasMatch;
+          section.open = query !== '' && hasMatch;
+        }
+
+        if (count instanceof HTMLOutputElement) {
+          count.textContent = query === ''
+            ? `${items.length} entries`
+            : `${matches} ${matches === 1 ? 'match' : 'matches'}`;
+        }
+
+        if (empty instanceof HTMLElement) {
+          empty.hidden = query === '' || matches > 0;
+        }
+      };
+
+      input.addEventListener('input', update);
+      input.addEventListener('search', update);
+      input.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape' || input.value === '') return;
+        input.value = '';
+        update();
+      });
+    })();
+  </script>
 </PostLayout>


### PR DESCRIPTION
## Summary
- replace the repeated tag archive with one unique entry per piece
- organize Writing into Blog, Arxiv Notes, and Revision Notes shelves
- nest Blog topics and sixteen Arxiv research fields behind explicit disclosure controls
- add search across titles, summaries, tags, and fields with automatic shelf expansion
- add concise entry summaries, an empty state, and responsive layouts

## Validation
- git diff --check
- npm run ci
- desktop and 390px interaction QA
- verified 254 rendered entries, search/reset behavior, zero-result state, and no horizontal overflow