### PR TITLE
Refine Reading and Revision indexes

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2309,6 +2309,77 @@ h3,
   border-left: 1px solid var(--button-border);
 }
 
+.compact-index-shelf {
+  margin: 0 1.1rem 1.1rem;
+  padding: 0.9rem 0 0 1rem;
+  border-top: 1px solid var(--button-border);
+  border-left: 1px solid var(--button-border);
+}
+
+.compact-index-resource {
+  display: inline-block;
+  margin: 0 0 0.9rem;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+}
+
+.compact-index-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.compact-index-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.85rem 0;
+  border-top: 1px solid var(--button-border);
+}
+
+.compact-index-list li:first-child {
+  border-top: 0;
+}
+
+.compact-index-list h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.35;
+}
+
+.compact-index-list p {
+  max-width: 64ch;
+  margin: 0.28rem 0 0;
+  color: var(--text-secondary-color);
+  font-size: 0.94rem;
+  line-height: 1.5;
+}
+
+.compact-index-list small {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.compact-index-link,
+.compact-index-links {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.compact-index-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  justify-content: flex-end;
+}
+
 .writing-index {
   min-width: 0;
 }
@@ -3440,12 +3511,25 @@ body.home-page small {
 
   .writing-index-toolbar,
   .writing-index .blog-index-group > summary,
+  .reading-index .blog-index-group > summary,
+  .revision-index .blog-index-group > summary,
   .writing-index-subgroup > summary {
     grid-template-columns: 1fr;
   }
 
-  .writing-index .blog-index-group__action {
+  .writing-index .blog-index-group__action,
+  .reading-index .blog-index-group__action,
+  .revision-index .blog-index-group__action {
     justify-self: start;
+  }
+
+  .compact-index-list li {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  .compact-index-links {
+    justify-content: flex-start;
   }
 
   .writing-index-subgroup__title {

--- a/src/lib/reading-list.ts
+++ b/src/lib/reading-list.ts
@@ -1,10 +1,32 @@
+export type ReadingListGroupId = 'writing-craft' | 'research-blogs';
+
 export interface ReadingListItem {
   title: string;
   author: string;
   href: string;
   dateLabel: string;
   summary: string;
+  group: ReadingListGroupId;
 }
+
+export interface ReadingListGroup {
+  id: ReadingListGroupId;
+  title: string;
+  description: string;
+}
+
+export const READING_LIST_GROUPS: ReadingListGroup[] = [
+  {
+    id: 'writing-craft',
+    title: 'Writing & craft',
+    description: 'How to think clearly, explain precisely, and use AI without flattening your voice.',
+  },
+  {
+    id: 'research-blogs',
+    title: 'Research blogs',
+    description: 'Writers who turn fast-moving research into durable technical understanding.',
+  },
+];
 
 export const READING_LIST_ITEMS: ReadingListItem[] = [
   {
@@ -14,6 +36,7 @@ export const READING_LIST_ITEMS: ReadingListItem[] = [
     dateLabel: 'Jun 16, 2025',
     summary:
       'A practical essay on writing with LLMs, avoiding low-density prose, and revising for clarity, rhythm, and judgment.',
+    group: 'writing-craft',
   },
   {
     title: "Lil'Log",
@@ -22,5 +45,6 @@ export const READING_LIST_ITEMS: ReadingListItem[] = [
     dateLabel: 'Since 2017',
     summary:
       'Deep learning and AI research notes with careful long-form explainers on agents, alignment, diffusion, scaling laws, and related systems.',
+    group: 'research-blogs',
   },
 ];

--- a/src/pages/reading_list.astro
+++ b/src/pages/reading_list.astro
@@ -1,35 +1,51 @@
 ---
-import SectionHeader from '../components/SectionHeader.astro';
 import PostLayout from '../layouts/PostLayout.astro';
-import { READING_LIST_ITEMS } from '../lib/reading-list';
+import { READING_LIST_GROUPS, READING_LIST_ITEMS } from '../lib/reading-list';
 
-const itemCountLabel = `${READING_LIST_ITEMS.length} ${
-  READING_LIST_ITEMS.length === 1 ? 'item' : 'items'
-}`;
+const groups = READING_LIST_GROUPS.map((group) => ({
+  ...group,
+  items: READING_LIST_ITEMS.filter((item) => item.group === group.id),
+})).filter((group) => group.items.length > 0);
 ---
 
 <PostLayout title="Reading List" showSectionsNav={false}>
-  <SectionHeader
-    eyebrow="Reading List"
-    title="External references"
-    description="Essays, blogs, and references worth returning to, with one reason to read each."
-    meta={itemCountLabel}
-  />
+  <header class="blog-index-intro">
+    <h1>Reading List</h1>
+    <p>Things I have read, learned from, and want to return to.</p>
+  </header>
 
-  <section class="resource-list">
-    <ul>
-      {READING_LIST_ITEMS.map((item) => (
-        <li>
+  <section class="reading-index blog-index-groups" aria-label="Reading list categories">
+    {groups.map((group) => (
+      <details class="blog-index-group no-icon">
+        <summary>
           <div>
-            <strong>{item.title}</strong>
-            <p>{item.summary}</p>
-            <small>{item.author} / {item.dateLabel}</small>
+            <div class="blog-index-group__title">
+              <h2>{group.title}</h2>
+              <span>{group.items.length} {group.items.length === 1 ? 'entry' : 'entries'}</span>
+            </div>
+            <p>{group.description}</p>
           </div>
-          <span>
-            <a href={item.href}>Read</a>
+          <span class="blog-index-group__action" aria-hidden="true">
+            <span class="blog-index-group__action-label--closed">View entries ↓</span>
+            <span class="blog-index-group__action-label--open">Hide entries ↑</span>
           </span>
-        </li>
-      ))}
-    </ul>
+        </summary>
+
+        <div class="compact-index-shelf">
+          <ul class="compact-index-list">
+            {group.items.map((item) => (
+              <li>
+                <div>
+                  <h3><a href={item.href}>{item.title}</a></h3>
+                  <p>{item.summary}</p>
+                  <small>{item.author} · {item.dateLabel}</small>
+                </div>
+                <a class="compact-index-link" href={item.href} aria-label={`Read ${item.title}`}>Read ↗</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </details>
+    ))}
   </section>
 </PostLayout>

--- a/src/pages/revision_notes.astro
+++ b/src/pages/revision_notes.astro
@@ -1,64 +1,102 @@
 ---
 import PostLayout from '../layouts/PostLayout.astro';
-import SectionHeader from '../components/SectionHeader.astro';
+
+const revisionGroups = [
+  {
+    title: 'PyTorch',
+    description: 'Tensor mechanics, autograd, and the systems that make training fast and scalable.',
+    resource: { label: 'PyTorch documentation ↗', href: 'https://docs.pytorch.org/docs/2.13/' },
+    entries: [
+      {
+        title: 'I · Tensors',
+        summary: 'Shapes, strides, storage, views, broadcasting, dtypes, and the contracts behind every tensor program.',
+        links: [
+          { label: 'Notes', href: '/revision notes/2026/08/09/pytorch-tensor-revision-notes.html' },
+        ],
+      },
+      {
+        title: 'II · Autograd and training',
+        summary: 'How PyTorch records computation, propagates gradients, and turns a differentiable graph into a training loop.',
+        links: [
+          { label: 'Notes', href: '/revision notes/2026/08/10/pytorch-autograd-and-training.html' },
+        ],
+      },
+      {
+        title: 'III · Performance and scale',
+        summary: 'Compilation, mixed precision, memory, data loading, and distributed execution—the systems that decide throughput.',
+        links: [
+          { label: 'Notes', href: '/revision notes/2026/08/10/pytorch-systems-and-scale.html' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'CS336',
+    description: 'Tensor efficiency in Lecture 2, then Transformer architecture in Lecture 3.',
+    resource: { label: 'Course website ↗', href: 'https://cs336.stanford.edu/spring2025/' },
+    entries: [
+      {
+        title: 'Lecture 2 · Tensor efficiency',
+        summary: 'Memory layout, dtypes, einsum, and the arithmetic that determines whether tensor code is actually efficient.',
+        links: [
+          { label: 'Notes', href: '/revision notes/2025/05/15/cs336-revision-notes.html' },
+          { label: 'Material', href: 'https://cs336.stanford.edu/spring2025-lectures/?trace=var/traces/lecture_02.json' },
+        ],
+      },
+      {
+        title: 'Lecture 3 · Transformer architecture',
+        summary: 'From the residual stream through attention and MLP blocks to a complete language-model implementation.',
+        links: [
+          { label: 'Notes', href: '/revision notes/2025/05/22/cs336-lecture-3.html' },
+          { label: 'Video', href: 'https://www.youtube.com/watch?v=ptFiH_bHnJw' },
+          { label: 'Slides', href: 'https://github.com/stanford-cs336/spring2025-lectures/blob/e9cb2488fdb53ea37f0e38924ec3a1701925cef3/nonexecutable/2025%20Lecture%203%20-%20architecture.pdf' },
+        ],
+      },
+    ],
+  },
+];
 ---
 
 <PostLayout title="Revision Notes" showSectionsNav={false}>
-  <SectionHeader
-    eyebrow="Revision Notes"
-    title="PyTorch and CS336"
-    description="Course notes, references, and implementation details for PyTorch and language modeling."
-    meta="5 notes"
-  />
+  <header class="blog-index-intro">
+    <h1>Revision Notes</h1>
+    <p>Notes I rebuilt from lectures and documentation so I can return to the ideas quickly.</p>
+  </header>
 
-  <section class="resource-list">
-    <div class="resource-list__header">
-      <h2>PyTorch</h2>
-      <a href="https://docs.pytorch.org/docs/2.13/">Documentation</a>
-    </div>
-    <ul>
-      <li>
-        <div>
-          <strong>PyTorch from tensors to distributed execution</strong>
-          <p>Three connected notes: tensor contracts, differentiable training, then the systems that execute and scale the same program.</p>
-        </div>
-        <span>
-          <a href="/revision notes/2026/08/09/pytorch-tensor-revision-notes.html">I · Tensors</a>
-          <a href="/revision notes/2026/08/10/pytorch-autograd-and-training.html">II · Autograd and training</a>
-          <a href="/revision notes/2026/08/10/pytorch-systems-and-scale.html">III · Performance and scale</a>
-        </span>
-      </li>
-    </ul>
-  </section>
+  <section class="revision-index blog-index-groups" aria-label="Revision note collections">
+    {revisionGroups.map((group) => (
+      <details class="blog-index-group no-icon">
+        <summary>
+          <div>
+            <div class="blog-index-group__title">
+              <h2>{group.title}</h2>
+              <span>{group.entries.length} {group.entries.length === 1 ? 'note' : 'notes'}</span>
+            </div>
+            <p>{group.description}</p>
+          </div>
+          <span class="blog-index-group__action" aria-hidden="true">
+            <span class="blog-index-group__action-label--closed">View notes ↓</span>
+            <span class="blog-index-group__action-label--open">Hide notes ↑</span>
+          </span>
+        </summary>
 
-  <section class="resource-list">
-    <div class="resource-list__header">
-      <h2>Course links</h2>
-      <a href="https://stanford-cs336.github.io/spring2025/">Course website</a>
-    </div>
-    <ul>
-      <li>
-        <div>
-          <strong>Lesson 2</strong>
-          <p>Tensor fundamentals, memory layout, dtypes, and computation efficiency.</p>
+        <div class="compact-index-shelf">
+          <a class="compact-index-resource" href={group.resource.href}>{group.resource.label}</a>
+          <ul class="compact-index-list">
+            {group.entries.map((entry) => (
+              <li>
+                <div>
+                  <h3><a href={entry.links[0].href}>{entry.title}</a></h3>
+                  <p>{entry.summary}</p>
+                </div>
+                <span class="compact-index-links">
+                  {entry.links.map((link) => <a href={link.href}>{link.label}</a>)}
+                </span>
+              </li>
+            ))}
+          </ul>
         </div>
-        <span>
-          <a href="/revision notes/2025/05/15/cs336-revision-notes.html">My notes</a>
-          <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">YouTube</a>
-          <a href="https://stanford-cs336.github.io/spring2025/lectures/2">Material</a>
-        </span>
-      </li>
-      <li>
-        <div>
-          <strong>Lesson 3</strong>
-          <p>Architecture notes and transformer implementation details.</p>
-        </div>
-        <span>
-          <a href="/revision notes/2025/05/22/cs336-lecture-3.html">My notes</a>
-          <a href="https://www.youtube.com/watch?v=ptFiH_bHnJw">YouTube</a>
-          <a href="https://github.com/stanford-cs336/spring2024-lectures/blob/main/nonexecutable/Lecture%203%20-%20architecture.pdf">Slides</a>
-        </span>
-      </li>
-    </ul>
+      </details>
+    ))}
   </section>
 </PostLayout>


### PR DESCRIPTION
## Summary
- turn the Reading List into two compact, expandable categories with sharp item descriptions
- turn Revision Notes into expandable PyTorch and CS336 shelves with one-line note previews
- fix stale CS336 material links and remove the placeholder Lecture 2 video
- share the responsive compact-list treatment across both indexes

## Validation
- `git diff --check`
- `npm run ci`
- desktop and 390px browser interaction checks for both pages
- verified official external resources return HTTP 200