### PR TITLE
Require substantive Blog callouts

### DIFF
--- a/docs/content-authoring.md
+++ b/docs/content-authoring.md
@@ -1,0 +1,15 @@
+# Content authoring
+
+## Blog callouts
+
+Use a Blog blockquote only for one **Deep insight.** It must compress an argument that the surrounding section has already earned: a mechanism and its consequence, a measured result and the decision it changes, or a precise, testable engineering judgment. A memorable line is welcome, but it cannot be a slogan that could be moved unchanged to an unrelated post.
+
+Write the callout as:
+
+```md
+> **Deep insight.** The specific mechanism, evidence, or constraint, followed by the decision it changes.
+```
+
+Do not use blockquotes for an opening thesis, a section label, an example sentence, a diagram, a recommendation list, or ordinary summary prose. Use a paragraph, heading, list, table, or code block for those jobs instead.
+
+Paper-short callouts are different: the `## Summary` blockquote is a compact source-grounded summary, not an editorial deep insight.

--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -91,7 +91,7 @@ Each row of $A$ says where one token looks; the corresponding row of $Y$ is that
 
 Consider the sentence:
 
-> “The animal did not cross the street because it was too tired.”
+“The animal did not cross the street because it was too tired.”
 
 When the model updates `it`, its query can ask for an animate antecedent compatible with being tired. `animal` offers a strong matching key and a useful value; `street` is nearby but semantically implausible; `tired` is not the antecedent but carries causal context. The output is not a hard pointer. It is a mixture whose largest contribution may come from `animal`, with additional information from the rest of the sentence.
 
@@ -485,14 +485,16 @@ Raschka's larger caveat is the right one: there is still no single matched-data,
 
 Attention still answers one question: for this output position, which sources match the current need, and what content should they contribute? The variants differ in where they pay for that answer.
 
-> - MHA pays for independent heads and full token-level memory.
-> - GQA and MQA reduce the number of cached K/V heads.
-> - MLA compresses the cached representation.
-> - Sliding-window and learned sparse attention reduce the positions examined.
-> - Linear and delta-rule methods replace an explicit token history with a fixed-size state.
-> - Hybrid models spend most layers on cheap memory updates and reserve some layers for stronger retrieval.
+- MHA pays for independent heads and full token-level memory.
+- GQA and MQA reduce the number of cached K/V heads.
+- MLA compresses the cached representation.
+- Sliding-window and learned sparse attention reduce the positions examined.
+- Linear and delta-rule methods replace an explicit token history with a fixed-size state.
+- Hybrid models spend most layers on cheap memory updates and reserve some layers for stronger retrieval.
 
 No variant dominates every regime. Full attention preserves exact access but grows expensive with context. Cache-sharing methods are simpler but reduce K/V capacity. Latent, sparse, and recurrent methods buy more efficiency with new approximation, tuning, kernel, or serving burdens. The right comparison is therefore not “which attention name is newest?” but “which bottleneck dominates this model, and which retrieval failure can it afford?”
+
+> **Deep insight.** Attention variants spend the same budget in different places: exact token retrieval, cache capacity, compressed memory, or fixed-size state. The right architecture follows the dominant bottleneck and the retrieval error the system can afford, not the newest name.
 
 ## References
 

--- a/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
+++ b/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
@@ -21,7 +21,7 @@ A read-aloud control looks like a browser feature. The engineering problem is re
 
 I wanted the result to work on a commute. That ruled out a one-off desktop script and ruled out delegating the experience to whatever speech voice happens to be installed in a visitor's browser. The site now generates MP3s locally, commits them as ordinary static assets, and gives every Blog post a native player with play, pause, seeking, and speed controls. The browser only downloads audio. It never loads a model, sends post text to an API, or waits for synthesis.
 
-> The interesting work is not the button. It is the boundary between an authored document and a coherent narration.
+> **Deep insight.** The difficult part is not adding a player. It is preserving the boundary between an authored document and a coherent narration, so synthesis is reproducible and serving stays static.
 
 ## The architecture: export once, serve statically
 

--- a/src/content/posts/code-is-cheap-understanding-isnt.md
+++ b/src/content/posts/code-is-cheap-understanding-isnt.md
@@ -31,7 +31,7 @@ A coding agent can search, inspect a repository, run a test, revise its plan, ca
 
 That changes what it means to be good at using AI for software. Most of us have not calibrated yet. We are still impressed by how much code an agent can produce when code is rapidly becoming the least scarce part of the system.
 
-> The scarce part is deciding what should exist.
+The scarce part is deciding what should exist.
 
 ## Context becomes the scarce input
 
@@ -137,7 +137,7 @@ _Agent manager — imagined by OpenAI ImageGen._
 
 Which one do you retain?
 
-> The answer says a great deal about where the profession is going. The future does not belong to whoever can generate the most code. Code is becoming abundant. The durable skill is understanding what should be built, why it should exist, what context matters, and how to marshal increasingly capable machines to build it well.
+> **Deep insight.** As code generation becomes abundant, the durable advantage moves upstream: deciding what should be built, why it should exist, what context changes the answer, and how to direct capable machines through the resulting constraints.
 
 Writing software was always about building. Code was a tool. Agents are tools too.
 

--- a/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
+++ b/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
@@ -18,7 +18,7 @@ Reinforcement learning for language models can look like a parade of acronyms. P
 
 The useful history is not the sequence of names. It is the sequence of compromises around one estimator:
 
-> Given behavior sampled from the current policy, what evidence should increase or decrease its probability, and relative to what baseline?
+The governing question is: given behavior sampled from the current policy, what evidence should increase or decrease its probability, and relative to what baseline?
 
 This essay follows that question from PPO through verifiable-reward reasoning and into VLA post-training. It is intentionally narrower than [Post-Training VLAs: A Reading Guide to Closed-Loop Improvement](/blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html). That guide covers the whole deployment loop: action interfaces, failure mining, feedback collection, critics, evaluation, and reproducibility. Here, those are held at the boundary. The subject is the update machinery itself—sampling distribution, advantage construction, likelihood ratio, and credit assignment.
 
@@ -261,7 +261,7 @@ PPO learns a critic so each action can be compared with expected return. DPO ass
 
 Reasoning models made GRPO powerful because prompts reset perfectly and verifiers are cheap. VLAs expose the limits because physical state does not reset cleanly, action likelihood may pass through diffusion, and a terminal bit is far from the causal motion. The transferable object is therefore not GRPO itself. It is the estimator-design discipline:
 
-> Sample where the policy will act, compare only what the environment makes comparable, and make feedback no coarser than the decision it is supposed to credit.
+> **Deep insight.** Sample where the policy will act, compare only what the environment makes comparable, and make feedback no coarser than the decision it is supposed to credit. This is the estimator-design constraint that transfers from reasoning RL to VLAs.
 
 That principle explains the past decade of policy optimization better than the acronym sequence—and gives VLA post-training a testable path beyond copying language-model RL.
 

--- a/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
+++ b/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
@@ -45,7 +45,7 @@ This table is the first defense against vague claims. A retrieval model can be e
 
 The shared implementation pattern is simple. An image is converted into visual tokens or features. A connector maps those features into a space that can interact with text. A loss then decides what “interaction” means: contrastive agreement, next-token prediction, region grounding, denoising, or action imitation.
 
-> The loss is the contract. Architecture matters because it determines what evidence remains available to satisfy that contract.
+> **Deep insight.** The loss is the contract. Architecture matters because it decides which evidence remains available to satisfy that contract, so a change in prediction target can invalidate an otherwise successful representation.
 
 The comparison below keeps one mug-and-tray scene fixed. Only the evaluated output changes. Watch which evidence becomes mandatory rather than assuming every later model is simply a larger version of the first.
 

--- a/src/content/posts/how-to-read-scaling-laws-for-language-models.md
+++ b/src/content/posts/how-to-read-scaling-laws-for-language-models.md
@@ -19,8 +19,6 @@ Kaplan and Chinchilla appear in almost every discussion of a model release: some
 
 A scaling law does not say that a model becomes intelligent if we make it larger. It makes a narrower and more useful claim: within a measured training regime, a chosen metric changes predictably as we spend more parameters, data, or compute. That can turn a frontier run from a heroic bet into a resource-allocation problem. A good small sweep tells us whether the next unit of budget should buy a larger model, more tokens, a different data mixture, a better architecture, or more inference-time search.
 
-> A scaling curve should change an experiment plan, not end the discussion.
-
 The phrase *within a measured regime* does most of the work. A fitted curve inherits its architecture, tokenizer, data construction, optimizer, schedule, context length, compute accounting, and evaluation distribution. Change enough of those and we are not moving along the same curve anymore.
 
 I separate four claims that are too often all called a “scaling law.”
@@ -93,6 +91,8 @@ Chinchilla revisited allocation at fixed training compute. Across more than 400 
 Chinchilla used the same training-compute budget as Gopher, with 70B rather than 280B parameters and four times as much training data. It outperformed Gopher and several contemporaries on the paper's downstream suite. The lesson is not that 70B is a magic size. A model can be undertrained *relative to a validation-loss objective at fixed pretraining compute*.
 
 The familiar shorthand of roughly twenty tokens per parameter needs the same qualification. Near-equal fitted exponents make $D/N$ approximately constant in that regime. Its numerical value is a coefficient-level property of those experiments, not a universal exponent or a law of nature.
+
+> **Deep insight.** Chinchilla's approximate token-to-parameter ratio is not an independent law. It follows from a particular fitted loss surface: near-equal data and parameter exponents make the ratio nearly constant, while the coefficients set its value. Change the training regime and the ratio is a hypothesis to remeasure, not a recipe to repeat.
 
 The Kaplan-versus-Chinchilla story is not simply “the old recipe was wrong.” [Porian et al. (2024)](https://arxiv.org/abs/2406.19146) reproduced the Kaplan-style result and traced much of the discrepancy to last-layer compute accounting, warmup duration, and scale-dependent optimizer tuning. A scaling law predicts the optimization frontier represented by its experiments. If the proxy runs are not comparably tuned, it can extrapolate the wrong frontier very cleanly.
 

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -19,7 +19,7 @@ summary: How camera, LiDAR, and radar become a unified, temporal scene represent
 
 An autonomous vehicle receives several partial descriptions of the same scene. Cameras provide dense appearance and semantic detail, but depth has to be inferred and image quality falls under glare, darkness, rain, or fog. LiDAR measures range directly and resolves 3D shape well, but the point cloud becomes sparse with distance and can be degraded by weather, reflectivity, occlusion, and motion during a scan. Radar measures range and radial velocity at long distance and is comparatively tolerant of poor visibility, but its angle estimates are coarse and multipath produces ambiguous returns.
 
-> The central architectural question is therefore not simply how to combine sensors. It is where to preserve their differences, where to establish a shared geometric representation, and where to spend the information that the model can no longer recover. The progression in this article follows that dependency:
+> **Deep insight.** The architectural choice is not merely how to combine sensors. It determines where their differences survive, where geometry becomes shared, and where irrecoverable information is spent. The following progression follows that dependency:
 
 sensor-specific encoders → metric 3D representation → temporal state → task heads
 

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -126,4 +126,4 @@ That transition—from a side project to a team—also changed my role. Moving f
 
 ## Looking Back
 
-> Looking back, the path is less a sequence of triumphs than a sequence of redirects. Failing the IIT exam changed where I studied. A collapsed GPA forced me to rebuild. A mailing mistake closed Germany and eventually opened the United States. Work that initially felt beyond me became a patent, then a route into autonomous driving. The common thread is not that every setback was secretly good. Some were simply painful. What mattered was learning to attach intensity to a problem I cared about, build enough skill to make the next attempt credible, and let small wins accumulate before confidence arrived.
+> **Deep insight.** The path was less a sequence of triumphs than a sequence of redirects: the IIT exam changed where I studied, a collapsed GPA forced a rebuild, and a mailing mistake eventually opened the United States. The transferable lesson is not that setbacks are secretly good; it is that a credible next attempt requires focused skill-building before confidence arrives.

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -16,7 +16,7 @@ summary: The key decisions behind pretraining multimodal robot policies.
 
 A robot can inherit the word “drawer” from the internet. The internet does not tell it how a sticky drawer feels, how far a particular arm can reach, or what to do after the gripper slips. Multimodal pretraining works because semantic and motor experience can transfer. It fails when “put everything in one model” becomes a substitute for deciding what should transfer, through which parameters, and under what evidence.
 
-> The hard choices arrive before the large run. An image can become patches, semantic features, discrete codes, or continuous latents. A robot trajectory can become per-axis bins, compressed action tokens, a diffusion target, or a flow field. A dataset mixture can be counted in examples, tokens, FLOPs, or gradient share; those allocations are not equivalent. A shared trunk can enable transfer while one high-volume modality quietly controls every update.
+> **Deep insight.** The decisive choices arrive before the large run: representation, prediction target, data-accounting unit, and gradient allocation. A shared trunk can enable transfer while a high-volume modality quietly controls every update, so “one model” is not evidence of balanced learning.
 
 This guide is about making those choices legible. Its central claim is that a VLA is not created by adding an action head to a VLM. It is created by combining three priors—semantic, visual, and motor—without letting the cheapest one erase the others.
 

--- a/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
@@ -69,12 +69,12 @@ DeepSeek V4 Flash is even clearer. Its official `0731` checkpoint is about `167 
 
 ## What I would run
 
-> For this `64 GB` M5 Max, my order is:
+For this `64 GB` M5 Max, my order is:
 
-> 1. Start with `Muse Glimmer 30B Q4_K_M` for a current local multimodal generalist.
-> 2. Start with `Ministral 3 14B Q4_K_M` when speed, context headroom, and application co-residency matter more than model scale.
-> 3. Evaluate `Granite 4.1 30B Q4_K_M` for text-heavy retrieval and tool workflows.
-> 4. Treat `Nemotron 3 Nano` as a community-quant experiment unless an official compressed artifact appears.
-> 5. Serve `Mistral Small 4` and `DeepSeek V4 Flash` elsewhere instead of turning SSD swap into an inference strategy.
+1. Start with `Muse Glimmer 30B Q4_K_M` for a current local multimodal generalist.
+2. Start with `Ministral 3 14B Q4_K_M` when speed, context headroom, and application co-residency matter more than model scale.
+3. Evaluate `Granite 4.1 30B Q4_K_M` for text-heavy retrieval and tool workflows.
+4. Treat `Nemotron 3 Nano` as a community-quant experiment unless an official compressed artifact appears.
+5. Serve `Mistral Small 4` and `DeepSeek V4 Flash` elsewhere instead of turning SSD swap into an inference strategy.
 
-> My earlier [Gemma 4 benchmark](/blog/2026/04/04/running-gemma-4-locally-on-a-64-gb-macbook-pro.html) remains relevant if Gemma is already working well. The point of this list is not to replace a stable model every release cycle. It is to make the current capacity boundary explicit: on a `64 GB` Mac, the practical sweet spot is still an official `8–20 GB` quant with enough remaining memory for the context and the application around it.
+> **Deep insight.** The practical limit on a `64 GB` Mac is not parameter count. It is the headroom left after weights for context and the surrounding application. That makes an official `8–20 GB` quant a better default than a larger model that pushes serving into swap.

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -20,7 +20,7 @@ This is why “make the pretrained model behave better” is an inadequate descr
 
 The right object is therefore not an optimizer. It is a closed-loop policy improvement system:
 
-> Base VLA → task SFT → deployment rollouts → failure mining → preference or reward supervision → policy optimization → real evaluation → redeployment.
+`Base VLA → task SFT → deployment rollouts → failure mining → preference or reward supervision → policy optimization → real evaluation → redeployment`
 
 The loop is the product. SFT, DPO, PPO, critics, and distillation are replaceable components inside it.
 
@@ -36,7 +36,7 @@ Neither prior guarantees that the deployed policy occupies familiar states. [DAg
 
 This is the first mental model to keep:
 
-> Supervised fine-tuning learns what to do in the states represented by its data. Interactive post-training changes which states become data.
+> **Deep insight.** Supervised fine-tuning learns what to do in the states represented by its data. Interactive post-training changes which states become data, which is why a small set of recovery trajectories can be worth more than a large set of already-successful demonstrations.
 
 That difference is why another million successful demonstrations may be worth less than ten thousand carefully selected recoveries.
 
@@ -216,7 +216,7 @@ Measure action error, chunk likelihood, critic accuracy, preference accuracy, re
 
 The staff-level metric sits above every level:
 
-> Reliable policy improvement per robot-hour, human-hour, annotation-hour, and unit of compute.
+The staff-level metric is reliable policy improvement per robot-hour, human-hour, annotation-hour, and unit of compute.
 
 ## Reproducible training loops
 

--- a/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
+++ b/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
@@ -153,10 +153,10 @@ The remaining operational work is straightforward:
 - point Hermes at a stronger local model if I want better tool-use quality
 - wire in the local Qwen artifacts the same way, once I decide which exact GGUF or local server path I want to standardize on
 
-> The architecture is now clean:
+The architecture is now clean:
 
-> - Hermes for the agent layer
-> - `llama.cpp` for the local serving layer
-> - existing local weights for inference
+- Hermes for the agent layer
+- `llama.cpp` for the local serving layer
+- existing local weights for inference
 
-> That split is cleaner than asking one tool to own the agent layer, serving layer, and model artifacts at once.
+> **Deep insight.** Separating the agent layer, serving layer, and model artifacts prevents one tool's lifecycle from determining all three. It makes an agent replacement, runtime change, or weight update independently testable.

--- a/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
@@ -16,7 +16,7 @@ summary: >-
 
 I wanted the same practical answer I measured for Qwen and Gemma: can I fit the exact `DeepSeek-V4-Flash-0731` checkpoint on my `64 GB` M5 Max MacBook Pro, and can I serve it at an interactive speed?
 
-> No. The official checkpoint is about `167 GB` on disk, and the maintained vLLM recipe assigns it a `200 GB` minimum accelerator-memory target. That is before leaving room for the inference runtime, activations, and KV cache. A `64 GB` Mac can call the hosted model and can serve a local application backed by that API, but it cannot load the official weights into unified memory.
+> **Deep insight.** A `64 GB` Mac cannot run the official checkpoint: it is about `167 GB` on disk and its maintained vLLM recipe budgets `200 GB` of accelerator memory before runtime state and KV cache. The feasible architecture is local application plus hosted inference, not an imagined local-weight deployment.
 
 This is a sizing analysis dated August 13, 2026, not a benchmark. I did not manufacture latency numbers for a model that cannot load on the machine.
 

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -141,14 +141,14 @@ The linked upstream issue #13460 is now closed, so this result should not be rea
 
 ## Recommendation
 
-> Within this measured snapshot, if I cared about the strongest local Gemma 4 model, I would start with `31B`.
+Within this measured snapshot, if I cared about the strongest local Gemma 4 model, I would start with `31B`.
 
-> If I cared about the model I would actually want to use every day on this machine, I would pay the closest attention to `26B A4B`.
+If I cared about the model I would actually want to use every day on this machine, I would pay the closest attention to `26B A4B`.
 
-> If I cared about the fastest usable runtime on this machine, the answer is no longer "obviously llama.cpp." These measurements point toward:
+If I cared about the fastest usable runtime on this machine, the answer is no longer "obviously llama.cpp." These measurements point toward:
 
-> 1. `MLX` first
-> 2. `llama.cpp` second
-> 3. `Ollama` only after a fresh compatibility run
+1. `MLX` first
+2. `llama.cpp` second
+3. `Ollama` only after a fresh compatibility run
 
-> If you do not want a terminal workflow, this maps cleanly to a tiny local browser chat app. Both `MLX` and `llama.cpp` are reasonable backends if the goal is simply to serve Gemma locally and talk to it.
+> **Deep insight.** The best model, the best daily model, and the best runtime are different optimization targets. The measurements favor `31B` for maximum local capability, `26B A4B` for daily use, and `MLX` for speed on this machine.

--- a/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
@@ -107,7 +107,7 @@ The reusable harness for this run is in [`scripts/bench_llama_server_local.py`](
 
 ## Recommendation
 
-> I would run Glimmer locally when I want one current model that can cover text and images without putting pressure on a `64 GB` memory budget. I would start with the official `17 GB Q4_K_M`, add the projector only when the application needs vision, and keep the context well below the advertised maximum until the workload proves otherwise.
+> **Deep insight.** The `17 GB` Q4_K_M quant makes Glimmer useful on a `64 GB` Mac because it leaves headroom for the application and context, not because the advertised maximum context is automatically usable. Add the projector only when vision is needed, then measure the workload before expanding context.
 
 I would use the full-Metal DFlash configuration for rapid local chat. Nearly `48 tok/s` on the short suite is fluid, and the model still leaves ample memory headroom. I would remain careful with agent loops that repeatedly inject `8K` of state: speculative decoding accelerates generation, not the entire prefill, so the long suite still took almost `18 s` to expose an answer. The next optimization target is prompt reuse or a smaller active context, not a larger quant.
 

--- a/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
@@ -138,11 +138,11 @@ The figure separates three decisions that parameter count often collapses. Memor
 
 ## Recommendation
 
-> For this measured snapshot, my practical recommendation is simple:
+For this measured snapshot, my practical recommendation is simple:
 
-> 1. Start with `Qwen 3 4B` if you want the fastest clean local baseline.
-> 2. Move up to `Qwen 3 14B` if you want a stronger dense model and you can tolerate much slower long-prompt interaction.
-> 3. Keep `Qwen 3.5 9B` in the mix if you specifically care about the 3.5 family behavior and do not mind the extra latency and memory overhead.
-> 4. Prefer `MLX` first on this Mac unless a specific `llama.cpp` model artifact or integration path gives you a reason to switch.
+1. Start with `Qwen 3 4B` if you want the fastest clean local baseline.
+2. Move up to `Qwen 3 14B` if you want a stronger dense model and you can tolerate much slower long-prompt interaction.
+3. Keep `Qwen 3.5 9B` in the mix if you specifically care about the 3.5 family behavior and do not mind the extra latency and memory overhead.
+4. Prefer `MLX` first on this Mac unless a specific `llama.cpp` model artifact or integration path gives you a reason to switch.
 
-> That answer comes from this machine, not parameter counts or release notes.
+> **Deep insight.** Local-model choice is a measured systems decision, not a parameter-count contest. On this machine, long-prompt latency and memory headroom change the recommendation more than the release notes do.

--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -36,7 +36,7 @@ Interest is not the same as comfort. Work that teaches you something usually sit
 
 Serious research increasingly depends on the same coordination as serious engineering. The relevant skill is not simply being agreeable. It is keeping information and decisions moving across people who hold different pieces of the system.
 
-> My simplest rule is: do not block. Surface constraints early, give honest timing, and leave enough context for someone else to proceed. An explicit blocker can be routed or planned around; a hidden one quietly stalls several people at once.
+> **Deep insight.** Surface constraints early, give honest timing, and leave enough context for someone else to proceed. An explicit blocker can be routed or planned around; a hidden one silently stalls every dependent decision.
 
 Apply the same rule to yourself. Ask for help when someone else likely has the missing context. Do not spend days privately rediscovering an answer the team already knows. When the uncertainty is genuinely yours, step away long enough to stop repeating the same failed approach. A walk or a night's sleep often changes the representation of the problem, which is more useful than another hour of force.
 

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -110,7 +110,7 @@ describe('markdown authoring', () => {
     expect(offenders, 'Paper-note summaries should render as callouts.').toEqual([]);
   });
 
-  it('keeps Blog takeaways marked as callouts', async () => {
+  it('keeps one substantive, labeled deep insight in every Blog post', async () => {
     const postFiles = await fg('**/*.{md,mdx}', {
       cwd: postsDir,
       absolute: true,
@@ -119,12 +119,18 @@ describe('markdown authoring', () => {
     const offenders: string[] = [];
     for (const filePath of postFiles) {
       const source = await readFile(filePath, 'utf8');
-      if (/^section: blog$/m.test(source) && !/^> /m.test(source)) {
+      if (
+        /^section: blog$/m.test(source) &&
+        !/^> \*\*Deep insight\.\*\* .+/m.test(source)
+      ) {
         offenders.push(path.relative(projectRoot, filePath));
       }
     }
 
-    expect(offenders, 'Blog takeaways should render as callouts.').toEqual([]);
+    expect(
+      offenders,
+      'Blog callouts must contain a labeled, substantive deep insight.',
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What changed\n- Define the Blog callout rule: one labeled Deep insight grounded in a mechanism, evidence, or constraint and the decision it changes.\n- Audit all 17 Blog posts; convert decorative quotes, headings, lists, and generic theses to their proper Markdown forms.\n- Replace the scaling-laws slogan with a specific Chinchilla allocation insight.\n- Add authoring guidance and a content test enforcing the label.\n\n## Why\nBlog callouts should earn visual emphasis by carrying a precise, reusable technical insight—not merely a memorable sentence.\n\n## Validation\n- npm run ci\n- Custom audit: 17 Blog callouts are labeled and substantive\n- git diff --check