### PR TITLE
Publish reviewed Paper Radar backlog

### DIFF
--- a/src/content/posts/chronovision-temporal-reasoning-via-latent-state-reconstruction.md
+++ b/src/content/posts/chronovision-temporal-reasoning-via-latent-state-reconstruction.md
@@ -1,0 +1,47 @@
+---
+title: 'ChronoVision: Temporal Reasoning via Latent State Reconstruction'
+date: '2026-08-06T05:58:22.000Z'
+section: paper-shorts
+postSlug: chronovision-temporal-reasoning-via-latent-state-reconstruction
+legacyPath: /paper shorts/2026/08/06/chronovision-temporal-reasoning-via-latent-state-reconstruction.html
+tags: [Other]
+field: 'Vision-Language Models'
+summary: '2026 – ChronoVision trains a VLM to reconstruct latent visual states while reasoning over temporal transformations'
+---
+
+## 2026 – ChronoVision: Temporal Reasoning via Latent State Reconstruction
+
+**arXiv:** [2608.05631](https://arxiv.org/abs/2608.05631)
+
+**Project:** [ChronoVision](https://pediamedai.com/Cognition-MLLM/ChronoVision/)
+
+## Summary
+
+> ChronoVision argues that a textual reasoning trace is a lossy workspace for visual transformations. It trains a 9B VLM to reconstruct the latent representation of a final state, localize the evidence-bearing region, and then optimize a composite reinforcement-learning reward for the answer, latent process alignment, and visual focus. The result is strong on the paper's frame-ordering benchmark, but its scale and its dependence on dense locating supervision remain open limits.
+
+## Core Insights
+
+### Sequence reconstruction creates a stricter temporal task
+
+The paper introduces Vbvr-VQA by turning a video-reasoning problem into ordering six shuffled frames after an initial frame and prompt. Exact-match accuracy requires the entire sequence to be correct, which makes an answer based on only a plausible end state insufficient. During supervised fine-tuning, a Reconstructive Visual Head predicts the latent final state and an ROI Attention Locating module uses semantic span queries to focus attention on relevant regions. GRPO then receives outcome, latent-grounding, and focus rewards.
+
+This is a representation-level auxiliary objective, not a visible image generator. The paper does not claim to render the imagined intermediate states, so its evidence is about the usefulness of latent reconstruction for ordering and physical-reasoning evaluations rather than about interpretable internal visual chains of thought.
+
+### The ablations separate the training stages
+
+On Vbvr-VQA, the full model reports 74.8% in-domain and 71.6% out-of-domain exact-match accuracy. The base system without the reconstructive head reports 66.0% and 65.2%; adding the head yields 69.0% and 68.0%, adding ROI attention reaches 70.2% and 68.8%, and the RL stage reaches the final result. On IntPhys2, ChronoVision reports 55.0% overall versus 48.5% for its Qwen 3.5 9B base.
+
+| Component | Training job | Reported ablation signal |
+| --- | --- | --- |
+| Reconstructive Visual Head | Predicts a final-state latent | Improves the base SFT result. |
+| ROI Attention Locating | Narrows visual attention using locating cues | Adds a further ordering gain. |
+| Composite RL reward | Scores answer, latent alignment, and focus | Reaches the strongest reported ID/OOD scores. |
+| Vbvr-VQA | Requires exact sequence order | Limits partial-credit shortcuts, but is still a constructed benchmark. |
+
+## High-Level Takeaways
+
+- ChronoVision tests the hypothesis that a VLM needs a visual state objective, not just longer textual reasoning, for multi-step transformations.
+- The staged ablation supports each added component on the authors' task, while the IntPhys2 result is a useful cross-domain check. It does not establish that the latent is a causal or generally reusable physical simulator.
+- The current system is evaluated at 9B parameters and relies on semantic locating cues and spatial bounding-box annotations. Annotation cost and transfer to weakly supervised video remain material constraints.
+- A decisive test would preserve the answer supervision while corrupting latent targets or ROI cues, then compare fresh real-video temporal tasks, calibration, and annotation-normalized performance.
+- A temporal VLM may need to learn what visual state should result from a transformation before its language output can reliably explain the transformation.

--- a/src/content/posts/cross-view-sequential-visual-localization-with-spatio-temporal-context-modeling-for-autonomous-driving.md
+++ b/src/content/posts/cross-view-sequential-visual-localization-with-spatio-temporal-context-modeling-for-autonomous-driving.md
@@ -1,0 +1,45 @@
+---
+title: 'Cross-View Sequential Visual Localization with Spatio-Temporal Context Modeling for Autonomous Driving'
+date: '2026-08-11T08:44:42.000Z'
+section: paper-shorts
+postSlug: cross-view-sequential-visual-localization-with-spatio-temporal-context-modeling-for-autonomous-driving
+legacyPath: /paper shorts/2026/08/11/cross-view-sequential-visual-localization-with-spatio-temporal-context-modeling-for-autonomous-driving.html
+tags: [Other]
+field: 'BEV Perception & Mapping'
+summary: '2026 – recurrent temporal context sharpens satellite candidates before cross-view localization refinement'
+---
+
+## 2026 – Cross-View Sequential Visual Localization with Spatio-Temporal Context Modeling for Autonomous Driving
+
+**arXiv:** [2608.10660](https://arxiv.org/abs/2608.10660)
+
+## Summary
+
+> This work moves temporal context before cross-view matching rather than aggregating only a final fused feature. A recurrent module enhances the current ground-view feature with the previous state; hierarchical features then classify satellite-map candidate regions and refine the local offset. On CVIS, the reported mean error falls from 3.80 m for the strongest listed baseline to 1.57 m, but the contribution is tied to six-frame sequences, a particular map-crop protocol, and weak performance in several difficult real-road settings.
+
+## Core Insights
+
+### History sharpens the coarse candidate distribution
+
+The model consumes a sequence of ground images and one satellite map. The current ground feature is the query, while the recurrent previous state supplies keys and values. The resulting context-enhanced coarse feature scores satellite-grid candidates; multi-level features provide local structure for a second-stage offset regressor. The ordering matters: temporal evidence reduces ambiguity before the fine regressor is restricted to selected candidate cells.
+
+The CVIS ablation traces that claim. A DINOv2 matching baseline reports 12.25 m mean error; adding multi-level features reduces it to 5.92 m, a position-aware update to 4.96 m, and full temporal context to 1.57 m. For the top-64 candidate mask, the full model covers 99.98% of ground-truth cells while retaining 17.73% of the 19-by-19 search grid. That is evidence for better candidate recall, not merely trajectory smoothing after localization.
+
+### The transfer and field tests expose the remaining ambiguity
+
+On CVIS test data, the full model reports 1.57 m mean error, 1.21 m median error, and 40.22% R@1 m. Direct transfer to KITTI-CVL reports 2.61 m mean error, improving to 2.27 m after target-domain fine-tuning. A real-vehicle evaluation without model updates reports 2.84 m mean error and 96.86% R@5 m across its scenarios. The same paper identifies intersections, elevated roads, and slopes as harder: elevated roads reach 3.67 m mean error, while uphill segments reach 4.21 m.
+
+| Stage | Function | Main failure risk |
+| --- | --- | --- |
+| Recurrent temporal context | Resolves ambiguous current-frame cues | Carries past-state errors or fails under long interruptions. |
+| Coarse satellite-grid classification | Keeps plausible map regions | A missed true cell prevents downstream recovery. |
+| Fine offset regression | Refines within retained cells | Cannot correct a wrong coarse candidate. |
+| Hierarchical features | Separates global semantics from local textures | Adds coupled design choices beyond temporal context alone. |
+
+## High-Level Takeaways
+
+- The central decision is where temporal context enters the pipeline. Here it improves the candidate distribution before cross-view fusion and offset regression, which is more diagnostic than treating time as a final smoothing pass.
+- The CVIS ablation supports both hierarchical features and temporal context, but it does not fully isolate their interaction, sequence length, map-crop uncertainty, and backbone choice under one matched budget.
+- The direct KITTI-CVL transfer and real-vehicle results are promising deployment checks, yet target-domain fine-tuning improves the former and difficult road topologies remain a clear boundary.
+- A stronger deployment test would vary outages, seasonal imagery, long-horizon drift, and GNSS-prior quality, then compare temporal recurrence with explicit motion constraints at fixed latency.
+- Cross-view localization is most fragile when a single frame has many map lookalikes; temporal context earns its cost when it keeps the true map region alive for refinement.

--- a/src/content/posts/df-3-world-modeling-via-decoder-free-feature-forecasting-in-autonomous-navigation.md
+++ b/src/content/posts/df-3-world-modeling-via-decoder-free-feature-forecasting-in-autonomous-navigation.md
@@ -1,0 +1,45 @@
+---
+title: 'DF$^3$: World Modeling via Decoder-Free Feature Forecasting in Autonomous Navigation'
+date: '2026-08-03T16:08:59.000Z'
+section: paper-shorts
+postSlug: df-3-world-modeling-via-decoder-free-feature-forecasting-in-autonomous-navigation
+legacyPath: /paper shorts/2026/08/03/df-3-world-modeling-via-decoder-free-feature-forecasting-in-autonomous-navigation.html
+tags: [Other]
+field: 'Video & Interactive World Models'
+summary: '2026 – DF³ forecasts future foundation-model features and reads task outputs inside a frozen encoder, without decoders'
+---
+
+## 2026 – DF$^3$: World Modeling via Decoder-Free Feature Forecasting in Autonomous Navigation
+
+**arXiv:** [2608.02428](https://arxiv.org/abs/2608.02428)
+
+## Summary
+
+> DF³ removes both the pixel decoder and the latent-to-task decoder from a visual world-modeling pipeline. Prediction queries forecast the next DINO-style feature state inside a frozen vision transformer; task queries then read a downstream output from that same encoder. The reported Cityscapes trade is small accuracy loss against a decoder-based latent forecaster for much lower latency and memory, but the model forecasts observations only and is not yet action-conditional.
+
+## Core Insights
+
+### Forecast and task readout share the frozen encoder
+
+The method injects learnable spatial prediction queries into terminal blocks of a frozen DINOv3 ViT. Motion-Aware Context Fusion combines coarse optical-flow warping with local latent cross-correlation to align history before those queries forecast the next frame's features. A second set of task queries reads semantic segmentation directly from the forecasted representation. Training uses feature-level cosine and Huber losses; no decoder is trained to map generated pixels or latents back to a task output.
+
+The design is not simply smaller. The ablation compares temporal fusion choices while holding query injection fixed: concatenation reaches 59.9 mIoU, cross-correlation alone 65.7, and the combined warp-plus-cross-correlation module 69.9 on short-term Cityscapes forecasting. The result supports using complementary coarse displacement and fine local matching, not a generic claim that any query interface removes the temporal modeling problem.
+
+### The measured win is an accuracy-efficiency point
+
+Against DINO-Foresight on Cityscapes validation, DF³ reports 69.9 short-term mIoU and 68.7 moving-object mIoU, versus 71.8 and 71.7 for the decoder-based baseline. It reports 1,440.63 GFLOPs, 292.4 ms per frame, 3.1 GB peak GPU memory, and 177 MB of forecast parameters, compared with 2,256.07 GFLOPs, 971.1 ms, 9.5 GB, and 302.5 MB. The paper describes this as 36% fewer FLOPs, 70% lower latency, 67% lower memory, and 41% fewer forecast parameters.
+
+| Design choice | Benefit | Boundary |
+| --- | --- | --- |
+| Frozen foundation encoder | Avoids backbone fine-tuning and decoder weights | Constrains the feature space to existing visual priors. |
+| Prediction queries | Forecasts latent future state | Accuracy trails the cited decoder-based forecaster. |
+| Warp plus cross-correlation | Handles coarse displacement and local alignment | Larger search windows can add false matches. |
+| Task queries | Produces segmentation without a task decoder | Evaluation is still centered on one downstream task. |
+
+## High-Level Takeaways
+
+- DF³ is a world-model architecture for settings where the useful future object is a semantic feature, not a photorealistic frame. Its compute saving comes from refusing decoder stages, not from making future prediction free.
+- The controlled fusion ablation supports the combined motion mechanism; the headline comparison supports an efficiency trade, because DINO-Foresight remains more accurate on the reported short-term metrics.
+- The model is observation-only. A deployment-grade navigation world model needs action-conditioned rollouts and tests of whether forecast errors change planning or control decisions.
+- A matched experiment should compare closed-loop task return, tail latency, and robustness to fast motion and occlusion at equal end-to-end compute. The decoder-free choice fails if decoder outputs improve the downstream decision enough to outweigh their cost.
+- A frozen encoder can become the full world-model workspace when future-state queries and task queries can operate in the same representation.

--- a/src/content/posts/hi-token-hierarchical-coordinate-tokenization-for-generative-visual-grounding.md
+++ b/src/content/posts/hi-token-hierarchical-coordinate-tokenization-for-generative-visual-grounding.md
@@ -1,0 +1,46 @@
+---
+title: 'Hi-Token: Hierarchical Coordinate Tokenization for Generative Visual Grounding'
+date: '2026-08-04T11:07:19.000Z'
+section: paper-shorts
+postSlug: hi-token-hierarchical-coordinate-tokenization-for-generative-visual-grounding
+legacyPath: /paper shorts/2026/08/04/hi-token-hierarchical-coordinate-tokenization-for-generative-visual-grounding.html
+tags: [Other]
+field: 'Vision-Language Models'
+summary: '2026 – Hi-Token makes bounding-box coordinates coarse-to-fine sequences rather than unrelated location symbols'
+---
+
+## 2026 – Hi-Token: Hierarchical Coordinate Tokenization for Generative Visual Grounding
+
+**arXiv:** [2608.03471](https://arxiv.org/abs/2608.03471)
+
+## Summary
+
+> Hi-Token changes the output representation, not the VLM backbone: each normalized box coordinate becomes axis-specific hundreds, tens, and ones tokens. The representation gives autoregressive grounding a coarse-to-fine order and much denser supervision per coordinate type; a training-only GRPO reward then improves low-overlap predictions. The reported strict-localization gains are substantial, but the paper does not isolate hierarchy, axis-specific vocabularies, and vocabulary size from one another.
+
+## Core Insights
+
+### A box is twelve structured tokens
+
+Flat coordinate vocabularies make nearby positions such as 323 and 324 unrelated symbols, often sharing one vocabulary across horizontal and vertical axes. Hi-Token instead emits three digit tokens for each coordinate and separates the $x$ and $y$ vocabularies. A box therefore uses 12 tokens drawn from 60 coordinate types. This increases output length, but it exposes place value and axis role while reusing each token far more often.
+
+Under a matched Qwen2.5-VL-3B setup with 80,000 RefCOCO training examples, Hi-Token SFT raises RefCOCO P@0.95 from 23.0 for flat-token SFT to 31.7. The paper reports a 50-fold mean increase in raw supervision density per coordinate type. A separately tuned flat baseline reaches 26.3, so tuning narrows the gap but does not close it in the reported comparison.
+
+### Hi-GAR targets broad geometric failures
+
+Hi-GAR combines box IoU, coordinate accuracy at multiple tolerances, threshold bonuses, and a validity gate that turns off coordinate-level rewards for nearly non-overlapping boxes. Relative to Hi-Token SFT, full Hi-GAR raises RefCOCO mIoU from 72.4 to 84.3 and P@0.5 from 79.0 to 93.1, while P@0.95 moves from 31.7 to 33.4. Its main role is therefore reducing poor-overlap outputs, not replacing the representation as the source of strict localization.
+
+| Setting on RefCOCO | mIoU | P@0.5 | P@0.95 |
+| --- | ---: | ---: | ---: |
+| Flat SFT, matched recipe | 58.3 | 64.1 | 23.0 |
+| Hi-Token SFT | 72.4 | 79.0 | 31.7 |
+| Full Hi-GAR with gate | 84.3 | 93.1 | 33.4 |
+
+The final Hi-R1 model also reports strong results across RefCOCO, RefCOCO+, and RefCOCOg. Cross-family leaderboard comparisons are contextual rather than controlled, because the systems do not share data or training regimes.
+
+## High-Level Takeaways
+
+- Coordinate tokenization is an architectural decision for generative grounding: it determines whether numerical proximity and axis semantics must be rediscovered from data.
+- The matched SFT comparison supports the tokenization change, while the reward ablation supports Hi-GAR as a low-IoU repair. Neither establishes which part of the representation—digit hierarchy, axis separation, or smaller vocabulary—causes the gain.
+- The fixed 1,000-bin space leaves a visible small-object boundary: ultra-strict localization is highly scale-sensitive, and the paper reports a P@0.95 of 1.30 for its small-object aggregate.
+- A decisive follow-up would vary hierarchy, axis vocabularies, vocabulary size, output length, and compute independently, then measure calibration and latency as well as IoU.
+- Generative grounding improves when the output language carries geometry instead of encoding every location as an unrelated word.

--- a/src/content/posts/wiener-representation-filtering-for-vlm-hallucination-suppression.md
+++ b/src/content/posts/wiener-representation-filtering-for-vlm-hallucination-suppression.md
@@ -1,0 +1,45 @@
+---
+title: 'Wiener Representation Filtering for VLM Hallucination Suppression'
+date: '2026-08-08T14:51:17.000Z'
+section: paper-shorts
+postSlug: wiener-representation-filtering-for-vlm-hallucination-suppression
+legacyPath: /paper shorts/2026/08/08/wiener-representation-filtering-for-vlm-hallucination-suppression.html
+tags: [Other]
+field: 'Vision-Language Models'
+summary: '2026 – Wiener filtering suppresses hallucination-associated directions in a VLM without changing inference cost'
+---
+
+## 2026 – Wiener Representation Filtering for VLM Hallucination Suppression
+
+**arXiv:** [2608.08167](https://arxiv.org/abs/2608.08167)
+
+## Summary
+
+> This paper makes hallucination mitigation an offline weight edit: estimate which deep language-model directions are associated with hallucinated responses, attenuate them with a covariance-derived Wiener filter, and absorb the result into the existing feed-forward projections. The reported CHAIR gains come with unchanged architecture, parameter count, and inference-time cost, but depend on calibration data that pairs truthful and hallucinatory generations.
+
+## Core Insights
+
+### A spectral filter rather than a decoding loop
+
+The method treats a hidden state as a truthful component plus a hallucination-associated distortion. From paired samples, it estimates their second-order statistics, solves a generalized eigendecomposition, and applies a Wiener-style gain that weakens modes with a high distortion-to-signal ratio. The edit is made only to down-projection matrices in selected deep feed-forward blocks. It is calibrated once with forward passes, then folded into the weights; it adds neither a second decoding pass nor an inference module.
+
+That placement is the central empirical choice. On MiniGPT-4, the paper reports sentence-level CHAIR of 23.0 for the baseline, 14.0 when editing layers 14–24, and 13.0 for layers 24–32. Mean subtraction and uniform shrinkage do not reproduce that result, supporting the narrower claim that the useful signal is direction-dependent rather than a global bias or a generic reduction in activation magnitude.
+
+### The evidence is broad, but the calibration contract matters
+
+Across LLaVA-1.5, MiniGPT-4, and mPLUG-Owl2 on CHAIR, the reported edit reaches sentence-level hallucination rates of 14.93, 16.87, and 15.40, respectively; the corresponding instance-level rates are 4.70, 6.13, and 6.07. The paper also reports POPE, MME, video reasoning, and diffusion-language-model experiments. Those are useful transfer checks, but they do not remove the operational dependency on representative calibration pairs, model-specific layer ranges, and a held-out tuning set.
+
+| Decision | Reported choice | Consequence |
+| --- | --- | --- |
+| Intervention | Deep FFN down projections | Reuses the original runtime graph. |
+| Signal | Paired truthful and hallucinatory hidden states | Requires a calibration set that reflects the target failure. |
+| Filter | Covariance-derived, mode-wise attenuation | Preserves some semantic directions that uniform shrinkage removes. |
+| Evaluation | CHAIR, POPE, MME and supplementary transfers | Measures several grounding settings, not every safety-critical hallucination mode. |
+
+## High-Level Takeaways
+
+- The paper shifts a common hallucination trade-off from decoding-time control to a one-time representation edit. Its atomic object is a hidden-state direction, not a token or a retrieved fact.
+- The strongest controlled result is the comparison with mean subtraction, uniform shrinkage, and shallower layer ranges. It supports spectral, deep-layer editing on the tested models; it does not establish a universal hallucination subspace.
+- A deployment decision should hold calibration size, image domain, and latency fixed against decoding-based controls, then test counterfactual images and rare objects. The method's case weakens if the same edit suppresses correct visual details under distribution shift.
+- The unreported scaling question is recalibration: a changing model, data domain, or failure taxonomy may change the covariance estimate and the directions worth preserving.
+- Hallucination reduction can be a weight-space filtering problem, but the filter is only as trustworthy as the contrast data used to estimate it.


### PR DESCRIPTION
## What changed
- Replaced five Paper Radar metadata placeholders with source-grounded Arxiv Notes.
- Added reported evidence, mechanism, boundaries, and decision-oriented takeaways for each paper.
- Corrected fields for DF³ (Video & Interactive World Models) and cross-view localization (BEV Perception & Mapping).

## Why
These papers were queued as drafts and required canonical-source review before publication.

## Validation
- npm run ci
- Rendered all five target routes at desktop and 375px mobile widths; no console errors or horizontal overflow.