### PR TITLE
Remove Deep insight prefix from Blog callouts

### DIFF
--- a/docs/content-authoring.md
+++ b/docs/content-authoring.md
@@ -2,14 +2,14 @@
 
 ## Blog callouts
 
-Use a Blog blockquote only for one **Deep insight.** It must compress an argument that the surrounding section has already earned: a mechanism and its consequence, a measured result and the decision it changes, or a precise, testable engineering judgment. A memorable line is welcome, but it cannot be a slogan that could be moved unchanged to an unrelated post.
+Use a Blog blockquote only for one substantive callout. It must compress an argument that the surrounding section has already earned: a mechanism and its consequence, a measured result and the decision it changes, or a precise, testable engineering judgment. A memorable line is welcome, but it cannot be a slogan that could be moved unchanged to an unrelated post.
 
 Write the callout as:
 
 ```md
-> **Deep insight.** The specific mechanism, evidence, or constraint, followed by the decision it changes.
+> The specific mechanism, evidence, or constraint, followed by the decision it changes.
 ```
 
 Do not use blockquotes for an opening thesis, a section label, an example sentence, a diagram, a recommendation list, or ordinary summary prose. Use a paragraph, heading, list, table, or code block for those jobs instead.
 
-Paper-short callouts are different: the `## Summary` blockquote is a compact source-grounded summary, not an editorial deep insight.
+Paper-short callouts are different: the `## Summary` blockquote is a compact source-grounded summary, not an editorial callout.

--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -494,7 +494,7 @@ Attention still answers one question: for this output position, which sources ma
 
 No variant dominates every regime. Full attention preserves exact access but grows expensive with context. Cache-sharing methods are simpler but reduce K/V capacity. Latent, sparse, and recurrent methods buy more efficiency with new approximation, tuning, kernel, or serving burdens. The right comparison is therefore not “which attention name is newest?” but “which bottleneck dominates this model, and which retrieval failure can it afford?”
 
-> **Deep insight.** Attention variants spend the same budget in different places: exact token retrieval, cache capacity, compressed memory, or fixed-size state. The right architecture follows the dominant bottleneck and the retrieval error the system can afford, not the newest name.
+> Attention variants spend the same budget in different places: exact token retrieval, cache capacity, compressed memory, or fixed-size state. The right architecture follows the dominant bottleneck and the retrieval error the system can afford, not the newest name.
 
 ## References
 

--- a/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
+++ b/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
@@ -21,7 +21,7 @@ A read-aloud control looks like a browser feature. The engineering problem is re
 
 I wanted the result to work on a commute. That ruled out a one-off desktop script and ruled out delegating the experience to whatever speech voice happens to be installed in a visitor's browser. The site now generates MP3s locally, commits them as ordinary static assets, and gives every Blog post a native player with play, pause, seeking, and speed controls. The browser only downloads audio. It never loads a model, sends post text to an API, or waits for synthesis.
 
-> **Deep insight.** The difficult part is not adding a player. It is preserving the boundary between an authored document and a coherent narration, so synthesis is reproducible and serving stays static.
+> The difficult part is not adding a player. It is preserving the boundary between an authored document and a coherent narration, so synthesis is reproducible and serving stays static.
 
 ## The architecture: export once, serve statically
 

--- a/src/content/posts/code-is-cheap-understanding-isnt.md
+++ b/src/content/posts/code-is-cheap-understanding-isnt.md
@@ -137,7 +137,7 @@ _Agent manager — imagined by OpenAI ImageGen._
 
 Which one do you retain?
 
-> **Deep insight.** As code generation becomes abundant, the durable advantage moves upstream: deciding what should be built, why it should exist, what context changes the answer, and how to direct capable machines through the resulting constraints.
+> As code generation becomes abundant, the durable advantage moves upstream: deciding what should be built, why it should exist, what context changes the answer, and how to direct capable machines through the resulting constraints.
 
 Writing software was always about building. Code was a tool. Agents are tools too.
 

--- a/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
+++ b/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
@@ -261,7 +261,7 @@ PPO learns a critic so each action can be compared with expected return. DPO ass
 
 Reasoning models made GRPO powerful because prompts reset perfectly and verifiers are cheap. VLAs expose the limits because physical state does not reset cleanly, action likelihood may pass through diffusion, and a terminal bit is far from the causal motion. The transferable object is therefore not GRPO itself. It is the estimator-design discipline:
 
-> **Deep insight.** Sample where the policy will act, compare only what the environment makes comparable, and make feedback no coarser than the decision it is supposed to credit. This is the estimator-design constraint that transfers from reasoning RL to VLAs.
+> Sample where the policy will act, compare only what the environment makes comparable, and make feedback no coarser than the decision it is supposed to credit. This is the estimator-design constraint that transfers from reasoning RL to VLAs.
 
 That principle explains the past decade of policy optimization better than the acronym sequence—and gives VLA post-training a testable path beyond copying language-model RL.
 

--- a/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
+++ b/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
@@ -45,7 +45,7 @@ This table is the first defense against vague claims. A retrieval model can be e
 
 The shared implementation pattern is simple. An image is converted into visual tokens or features. A connector maps those features into a space that can interact with text. A loss then decides what “interaction” means: contrastive agreement, next-token prediction, region grounding, denoising, or action imitation.
 
-> **Deep insight.** The loss is the contract. Architecture matters because it decides which evidence remains available to satisfy that contract, so a change in prediction target can invalidate an otherwise successful representation.
+> The loss is the contract. Architecture matters because it decides which evidence remains available to satisfy that contract, so a change in prediction target can invalidate an otherwise successful representation.
 
 The comparison below keeps one mug-and-tray scene fixed. Only the evaluated output changes. Watch which evidence becomes mandatory rather than assuming every later model is simply a larger version of the first.
 

--- a/src/content/posts/how-to-read-scaling-laws-for-language-models.md
+++ b/src/content/posts/how-to-read-scaling-laws-for-language-models.md
@@ -92,7 +92,7 @@ Chinchilla used the same training-compute budget as Gopher, with 70B rather than
 
 The familiar shorthand of roughly twenty tokens per parameter needs the same qualification. Near-equal fitted exponents make $D/N$ approximately constant in that regime. Its numerical value is a coefficient-level property of those experiments, not a universal exponent or a law of nature.
 
-> **Deep insight.** Chinchilla's approximate token-to-parameter ratio is not an independent law. It follows from a particular fitted loss surface: near-equal data and parameter exponents make the ratio nearly constant, while the coefficients set its value. Change the training regime and the ratio is a hypothesis to remeasure, not a recipe to repeat.
+> Chinchilla's approximate token-to-parameter ratio is not an independent law. It follows from a particular fitted loss surface: near-equal data and parameter exponents make the ratio nearly constant, while the coefficients set its value. Change the training regime and the ratio is a hypothesis to remeasure, not a recipe to repeat.
 
 The Kaplan-versus-Chinchilla story is not simply “the old recipe was wrong.” [Porian et al. (2024)](https://arxiv.org/abs/2406.19146) reproduced the Kaplan-style result and traced much of the discrepancy to last-layer compute accounting, warmup duration, and scale-dependent optimizer tuning. A scaling law predicts the optimization frontier represented by its experiments. If the proxy runs are not comparably tuned, it can extrapolate the wrong frontier very cleanly.
 

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -19,7 +19,7 @@ summary: How camera, LiDAR, and radar become a unified, temporal scene represent
 
 An autonomous vehicle receives several partial descriptions of the same scene. Cameras provide dense appearance and semantic detail, but depth has to be inferred and image quality falls under glare, darkness, rain, or fog. LiDAR measures range directly and resolves 3D shape well, but the point cloud becomes sparse with distance and can be degraded by weather, reflectivity, occlusion, and motion during a scan. Radar measures range and radial velocity at long distance and is comparatively tolerant of poor visibility, but its angle estimates are coarse and multipath produces ambiguous returns.
 
-> **Deep insight.** The architectural choice is not merely how to combine sensors. It determines where their differences survive, where geometry becomes shared, and where irrecoverable information is spent. The following progression follows that dependency:
+> The architectural choice is not merely how to combine sensors. It determines where their differences survive, where geometry becomes shared, and where irrecoverable information is spent. The following progression follows that dependency:
 
 sensor-specific encoders → metric 3D representation → temporal state → task heads
 

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -126,4 +126,4 @@ That transition—from a side project to a team—also changed my role. Moving f
 
 ## Looking Back
 
-> **Deep insight.** The path was less a sequence of triumphs than a sequence of redirects: the IIT exam changed where I studied, a collapsed GPA forced a rebuild, and a mailing mistake eventually opened the United States. The transferable lesson is not that setbacks are secretly good; it is that a credible next attempt requires focused skill-building before confidence arrives.
+> The path was less a sequence of triumphs than a sequence of redirects: the IIT exam changed where I studied, a collapsed GPA forced a rebuild, and a mailing mistake eventually opened the United States. The transferable lesson is not that setbacks are secretly good; it is that a credible next attempt requires focused skill-building before confidence arrives.

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -16,7 +16,7 @@ summary: The key decisions behind pretraining multimodal robot policies.
 
 A robot can inherit the word “drawer” from the internet. The internet does not tell it how a sticky drawer feels, how far a particular arm can reach, or what to do after the gripper slips. Multimodal pretraining works because semantic and motor experience can transfer. It fails when “put everything in one model” becomes a substitute for deciding what should transfer, through which parameters, and under what evidence.
 
-> **Deep insight.** The decisive choices arrive before the large run: representation, prediction target, data-accounting unit, and gradient allocation. A shared trunk can enable transfer while a high-volume modality quietly controls every update, so “one model” is not evidence of balanced learning.
+> The decisive choices arrive before the large run: representation, prediction target, data-accounting unit, and gradient allocation. A shared trunk can enable transfer while a high-volume modality quietly controls every update, so “one model” is not evidence of balanced learning.
 
 This guide is about making those choices legible. Its central claim is that a VLA is not created by adding an action head to a VLM. It is created by combining three priors—semantic, visual, and motor—without letting the cheapest one erase the others.
 

--- a/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
@@ -77,4 +77,4 @@ For this `64 GB` M5 Max, my order is:
 4. Treat `Nemotron 3 Nano` as a community-quant experiment unless an official compressed artifact appears.
 5. Serve `Mistral Small 4` and `DeepSeek V4 Flash` elsewhere instead of turning SSD swap into an inference strategy.
 
-> **Deep insight.** The practical limit on a `64 GB` Mac is not parameter count. It is the headroom left after weights for context and the surrounding application. That makes an official `8–20 GB` quant a better default than a larger model that pushes serving into swap.
+> The practical limit on a `64 GB` Mac is not parameter count. It is the headroom left after weights for context and the surrounding application. That makes an official `8–20 GB` quant a better default than a larger model that pushes serving into swap.

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -36,7 +36,7 @@ Neither prior guarantees that the deployed policy occupies familiar states. [DAg
 
 This is the first mental model to keep:
 
-> **Deep insight.** Supervised fine-tuning learns what to do in the states represented by its data. Interactive post-training changes which states become data, which is why a small set of recovery trajectories can be worth more than a large set of already-successful demonstrations.
+> Supervised fine-tuning learns what to do in the states represented by its data. Interactive post-training changes which states become data, which is why a small set of recovery trajectories can be worth more than a large set of already-successful demonstrations.
 
 That difference is why another million successful demonstrations may be worth less than ten thousand carefully selected recoveries.
 

--- a/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
+++ b/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
@@ -159,4 +159,4 @@ The architecture is now clean:
 - `llama.cpp` for the local serving layer
 - existing local weights for inference
 
-> **Deep insight.** Separating the agent layer, serving layer, and model artifacts prevents one tool's lifecycle from determining all three. It makes an agent replacement, runtime change, or weight update independently testable.
+> Separating the agent layer, serving layer, and model artifacts prevents one tool's lifecycle from determining all three. It makes an agent replacement, runtime change, or weight update independently testable.

--- a/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
@@ -16,7 +16,7 @@ summary: >-
 
 I wanted the same practical answer I measured for Qwen and Gemma: can I fit the exact `DeepSeek-V4-Flash-0731` checkpoint on my `64 GB` M5 Max MacBook Pro, and can I serve it at an interactive speed?
 
-> **Deep insight.** A `64 GB` Mac cannot run the official checkpoint: it is about `167 GB` on disk and its maintained vLLM recipe budgets `200 GB` of accelerator memory before runtime state and KV cache. The feasible architecture is local application plus hosted inference, not an imagined local-weight deployment.
+> A `64 GB` Mac cannot run the official checkpoint: it is about `167 GB` on disk and its maintained vLLM recipe budgets `200 GB` of accelerator memory before runtime state and KV cache. The feasible architecture is local application plus hosted inference, not an imagined local-weight deployment.
 
 This is a sizing analysis dated August 13, 2026, not a benchmark. I did not manufacture latency numbers for a model that cannot load on the machine.
 

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -151,4 +151,4 @@ If I cared about the fastest usable runtime on this machine, the answer is no lo
 2. `llama.cpp` second
 3. `Ollama` only after a fresh compatibility run
 
-> **Deep insight.** The best model, the best daily model, and the best runtime are different optimization targets. The measurements favor `31B` for maximum local capability, `26B A4B` for daily use, and `MLX` for speed on this machine.
+> The best model, the best daily model, and the best runtime are different optimization targets. The measurements favor `31B` for maximum local capability, `26B A4B` for daily use, and `MLX` for speed on this machine.

--- a/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
@@ -107,7 +107,7 @@ The reusable harness for this run is in [`scripts/bench_llama_server_local.py`](
 
 ## Recommendation
 
-> **Deep insight.** The `17 GB` Q4_K_M quant makes Glimmer useful on a `64 GB` Mac because it leaves headroom for the application and context, not because the advertised maximum context is automatically usable. Add the projector only when vision is needed, then measure the workload before expanding context.
+> The `17 GB` Q4_K_M quant makes Glimmer useful on a `64 GB` Mac because it leaves headroom for the application and context, not because the advertised maximum context is automatically usable. Add the projector only when vision is needed, then measure the workload before expanding context.
 
 I would use the full-Metal DFlash configuration for rapid local chat. Nearly `48 tok/s` on the short suite is fluid, and the model still leaves ample memory headroom. I would remain careful with agent loops that repeatedly inject `8K` of state: speculative decoding accelerates generation, not the entire prefill, so the long suite still took almost `18 s` to expose an answer. The next optimization target is prompt reuse or a smaller active context, not a larger quant.
 

--- a/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
@@ -145,4 +145,4 @@ For this measured snapshot, my practical recommendation is simple:
 3. Keep `Qwen 3.5 9B` in the mix if you specifically care about the 3.5 family behavior and do not mind the extra latency and memory overhead.
 4. Prefer `MLX` first on this Mac unless a specific `llama.cpp` model artifact or integration path gives you a reason to switch.
 
-> **Deep insight.** Local-model choice is a measured systems decision, not a parameter-count contest. On this machine, long-prompt latency and memory headroom change the recommendation more than the release notes do.
+> Local-model choice is a measured systems decision, not a parameter-count contest. On this machine, long-prompt latency and memory headroom change the recommendation more than the release notes do.

--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -36,7 +36,7 @@ Interest is not the same as comfort. Work that teaches you something usually sit
 
 Serious research increasingly depends on the same coordination as serious engineering. The relevant skill is not simply being agreeable. It is keeping information and decisions moving across people who hold different pieces of the system.
 
-> **Deep insight.** Surface constraints early, give honest timing, and leave enough context for someone else to proceed. An explicit blocker can be routed or planned around; a hidden one silently stalls every dependent decision.
+> Surface constraints early, give honest timing, and leave enough context for someone else to proceed. An explicit blocker can be routed or planned around; a hidden one silently stalls every dependent decision.
 
 Apply the same rule to yourself. Ask for help when someone else likely has the missing context. Do not spend days privately rediscovering an answer the team already knows. When the uncertainty is genuinely yours, step away long enough to stop repeating the same failed approach. A walk or a night's sleep often changes the representation of the problem, which is more useful than another hour of force.
 

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -110,7 +110,7 @@ describe('markdown authoring', () => {
     expect(offenders, 'Paper-note summaries should render as callouts.').toEqual([]);
   });
 
-  it('keeps one substantive, labeled deep insight in every Blog post', async () => {
+  it('keeps one substantive callout in every Blog post', async () => {
     const postFiles = await fg('**/*.{md,mdx}', {
       cwd: postsDir,
       absolute: true,
@@ -121,7 +121,7 @@ describe('markdown authoring', () => {
       const source = await readFile(filePath, 'utf8');
       if (
         /^section: blog$/m.test(source) &&
-        !/^> \*\*Deep insight\.\*\* .+/m.test(source)
+        !/^> .+/m.test(source)
       ) {
         offenders.push(path.relative(projectRoot, filePath));
       }
@@ -129,7 +129,7 @@ describe('markdown authoring', () => {
 
     expect(
       offenders,
-      'Blog callouts must contain a labeled, substantive deep insight.',
+      'Blog posts must contain a substantive callout.',
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
### What changed
- Remove the visible `Deep insight.` prefix from all 17 Blog callouts.
- Keep the substantive blockquote callouts and update authoring guidance and tests to match.

### Validation
- `npm run ci`
- Astro check: 0 errors, 0 warnings, 0 hints
- 36 tests passed
- Static build: 302 pages
- Build verification: 9 critical pages, 23 post routes, 237 paper reading paths