### PR TITLE
Deep-scrub Blog prose and structure

### DIFF
--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -8,8 +8,8 @@ legacyPath: /build intuition/2025/05/25/attention-mechanisms-demystified.html
 tags:
   - Other
 summary: >-
-  How attention retrieves, compresses, sparsifies, and carries context—with
-  runnable PyTorch.
+  How attention evolved from explicit token retrieval to shared, compressed,
+  sparse, and recurrent memory, with efficient PyTorch implementations.
 ---
 import PythonPlayground from '../../components/PythonPlayground';
 import { attentionMechanismsPlayground } from '../../lib/python-playground-examples';
@@ -59,7 +59,7 @@ $$
 
 ![Figure 2 from Attention Is All You Need, showing scaled dot-product attention and parallel attention heads](/assets/images/attention-paper-figure-2-scaled-dot-product-and-multi-head.png)
 
-*Figure 2 puts the operations in dependency order: compare queries with keys, scale and normalize the scores, then mix values. The right panel repeats that operation across learned projections before concatenating the results. Source: [Attention Is All You Need](https://arxiv.org/abs/1706.03762), Figure 2.*
+*Figure 2 puts the operations in dependency order: compare queries with keys, scale and normalize the scores, then mix values. Its multi-head diagram repeats that operation across learned projections before concatenating the results. Source: [Attention Is All You Need](https://arxiv.org/abs/1706.03762), Figure 2.*
 
 Each term has one job:
 
@@ -91,7 +91,7 @@ Each row of $A$ says where one token looks; the corresponding row of $Y$ is that
 
 Consider the sentence:
 
-“The animal did not cross the street because it was too tired.”
+> “The animal did not cross the street because it was too tired.”
 
 When the model updates `it`, its query can ask for an animate antecedent compatible with being tired. `animal` offers a strong matching key and a useful value; `street` is nearby but semantically implausible; `tired` is not the antecedent but carries causal context. The output is not a hard pointer. It is a mixture whose largest contribution may come from `animal`, with additional information from the rest of the sentence.
 
@@ -102,13 +102,13 @@ When the model updates `it`, its query can ask for an animate antecedent compati
 | `cross` | Relevant event but not an antecedent | Event context |
 | `tired` | Explains the causal relation | Semantic clue |
 
-In a decoder-only model, a causal mask removes future positions before softmax. The retrieval rule stays the same; the mask changes which keys are admissible. Self-attention also has no built-in sense of token order, so positional encodings such as RoPE must supply that structure. Run the small example below, then step through the raw scores, normalized weights, and mixed value vector.
+In a decoder-only model, a causal mask removes future positions before softmax. The retrieval rule stays the same; the mask changes which keys are admissible. Self-attention also has no built-in sense of token order, so positional encodings such as RoPE must supply that structure. The interactive example that follows exposes the raw scores, normalized weights, and mixed value vector.
 
 <PythonPlayground client:visible {...attentionMechanismsPlayground} />
 
 ## Efficient PyTorch implementation
 
-The equations above are useful for reasoning, but a production implementation should not explicitly build the $T\times T$ score matrix, apply softmax, and save the full probability matrix in high-bandwidth memory. PyTorch's [`scaled_dot_product_attention`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention) keeps the same semantics while dispatching to an appropriate backend, including fused attention kernels when the device, dtype, and tensor layout support them.
+The explicit equations are useful for reasoning, but a production implementation should not build the $T\times T$ score matrix and save the full probability matrix in high-bandwidth memory. PyTorch's [`scaled_dot_product_attention`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention) keeps the same semantics while dispatching to an appropriate backend, including fused attention kernels when the device, dtype, and tensor layout support them.
 
 The complete causal multi-head block is therefore short. The projections produce `[batch, time, 3 * d_model]`; reshaping exposes the head axis expected by SDPA; `is_causal=True` applies the autoregressive mask without allocating a dense mask in Python.
 
@@ -155,7 +155,7 @@ class CausalSelfAttention(nn.Module):
 # attn = torch.compile(CausalSelfAttention(d_model=1024, n_heads=16))
 ```
 
-Three details carry most of the performance. The combined QKV projection reduces kernel launches; the head dimension remains the innermost contiguous dimension; and SDPA avoids a Python-level sequence of matmul, mask, softmax, dropout, and matmul operations. PyTorch selects the backend automatically, so forcing FlashAttention should be a diagnostic or benchmarking choice rather than a default. The dropout argument also requires care: SDPA applies dropout whenever `dropout_p` is nonzero, so evaluation must pass `0.0` explicitly as the module does above.
+Three details carry most of the performance. The combined QKV projection reduces kernel launches; the head dimension remains the innermost contiguous dimension; and SDPA avoids a Python-level sequence of matmul, mask, softmax, dropout, and matmul operations. PyTorch selects the backend automatically, so forcing FlashAttention should be a diagnostic or benchmarking choice rather than a default. The dropout argument also requires care: SDPA applies dropout whenever `dropout_p` is nonzero, so evaluation must pass `0.0` explicitly as this module does.
 
 ## Multi-head and cross-attention
 
@@ -170,9 +170,9 @@ Cross-attention changes the source rather than the scoring rule. Queries come fr
 | Cross-attention | One sequence or modality | Another sequence, modality, or memory | Retrieve external evidence |
 | Multi-head attention (MHA) | Several projected query heads | Separate K/V projections per head | Learn multiple routing patterns in parallel |
 
-These labels describe where information comes from and how many projections are used. Modern variants below change different axes, so a model can use causal self-attention, GQA, and sliding windows simultaneously without contradiction.
+These labels describe where information comes from and how many projections are used. The next variants change different axes, so a model can use causal self-attention, GQA, and sliding windows simultaneously without contradiction.
 
-## Attention variants by bottleneck
+## Change the bottleneck
 
 Full multi-head attention stores a key and value for every previous token and every KV head. During prefill, the model computes a logically dense $T\times T$ pattern of token interactions. During cached autoregressive decoding, one new query reads an ever-growing KV cache, so each step scales linearly with the existing context and cache storage also grows with context length. FlashAttention improves how dense attention moves data and avoids materializing the full matrix in slow memory; it does not remove the underlying all-pairs arithmetic of dense prefill.
 
@@ -187,7 +187,7 @@ That cost created several distinct design families:
 | Layer composition | Hybrid attention | Alternate cheap recurrent/local mixers with periodic full attention | Better efficiency-quality balance, more system complexity |
 | Output control | Gated attention | Scale retrieved features before the residual update | More control and stability, little change to core attention cost |
 
-The table is the map: these methods are not one flat list because they solve different problems. The comparison below holds the incoming token sequence fixed and changes only the representation retained for future queries. Watch what is still individually addressable after each write.
+The table is the map: these methods are not one flat list because they solve different problems. The next comparison holds the incoming token sequence fixed and changes only the representation retained for future queries. Watch what is still individually addressable after each write.
 
 [![Animation comparing the memory retained by multi-head attention, grouped-query attention, multi-head latent attention, and Gated DeltaNet](/assets/images/blog-attention-memory.gif)](/assets/images/blog-attention-memory.gif)
 
@@ -195,7 +195,9 @@ The table is the map: these methods are not one flat list because they solve dif
 
 The irreversible choice is the memory carrier. GQA preserves token-addressable K/V vectors but reduces how many independent copies exist. MLA keeps a token-indexed cache but compresses each token through learned latent projections. Delta-rule models stop retaining a token-indexed history at all: later writes share finite state, so targeted update and forgetting become part of retrieval quality. A hybrid does not erase that distinction; it spends most layers on bounded memory and inserts occasional layers that can still inspect explicit positions.
 
-### Multi-query and grouped-query attention
+> **Deep insight:** Attention variants are memory policies. Each one decides what remains addressable after a write, and its characteristic failure follows from what that policy discards.
+
+### Share the cache
 
 Standard MHA gives every query head its own key and value heads. Multi-query attention (MQA) takes the most aggressive sharing choice: all query heads use one K/V set. Grouped-query attention (GQA) lies between MHA and MQA, with groups of query heads sharing K/V projections.
 
@@ -205,7 +207,7 @@ Standard MHA gives every query head its own key and value heads. Multi-query att
 
 The benefit appears during inference. Reducing the number of KV heads reduces the cache stored per token and the memory traffic required to read it, while leaving the surrounding decoder architecture close to standard attention. The trade-off is a spectrum: MHA preserves the most independent K/V capacity, MQA compresses most aggressively, and GQA chooses an intermediate point that often retains more modeling quality.
 
-PyTorch's SDPA accepts different query-head and KV-head counts through `enable_gqa=True`. The implementation below keeps the K/V tensors at `n_kv_heads`; it does not manually repeat them to the query-head count, which would erase much of the memory-traffic advantage.
+PyTorch's SDPA accepts different query-head and KV-head counts through `enable_gqa=True`. The following implementation keeps the K/V tensors at `n_kv_heads`; it does not manually repeat them to the query-head count, which would erase much of the memory-traffic advantage.
 
 ```python
 class GroupedQueryAttention(nn.Module):
@@ -280,7 +282,7 @@ def gqa_decode_step(q, k, v, k_cache, v_cache, position: int):
 
 For `n_query_heads=32` and `n_kv_heads=8`, four query heads share each stored K/V head, so the K/V portion of the cache is one quarter of the corresponding 32-head MHA cache. The decode helper also preallocates and updates that cache rather than calling `torch.cat` every step, which would repeatedly copy the growing prefix. Current PyTorch documentation still labels native GQA support experimental and lists backend constraints; confirm the target device and version instead of silently expanding K/V heads as a fallback.
 
-### Multi-head latent attention
+### Compress the cache
 
 Multi-head latent attention (MLA), introduced with DeepSeek-V2, attacks the same cache bottleneck differently. GQA stores fewer full K/V heads; MLA stores a lower-dimensional latent representation and reconstructs the state needed by attention. This makes MLA a learned cache-compression mechanism embedded inside the layer.
 
@@ -288,7 +290,7 @@ The distinction matters operationally. GQA is relatively simple and widely suppo
 
 DeepSeek-V2's ablations provide one useful but bounded comparison. In that model family, the authors report that their GQA and MQA variants underperformed MHA, while the tuned MLA configuration slightly exceeded MHA with a much smaller cache. That result supports MLA as a viable learned compression scheme; it does not establish that MLA will beat GQA at smaller scales, under a different training recipe, or on hardware without an optimized MLA path.
 
-### Sliding-window and sparse attention
+### Read fewer positions
 
 Sliding-window attention (SWA) keeps only a fixed local neighborhood visible in selected layers. It changes the number of positions examined, not the representation stored for each position. Architectures often mix local layers with periodic global layers so information can still travel across a long sequence. SWA also composes naturally with GQA: the window reduces how many tokens a layer reads, while grouping reduces how much K/V state each token contributes.
 
@@ -329,7 +331,7 @@ y = flex_attention(q, k, v, block_mask=block_mask)
 
 The mask function is the policy; the block mask is the execution plan. This separation is what lets a readable four-line causal-window rule become block-sparse work instead of dense attention followed by discarded scores. FlexAttention remains a prototype API, so pin and test the PyTorch version when using it in training or serving code.
 
-### Gated attention
+### Gate the retrieved state
 
 Gated full attention keeps the softmax lookup and adds a query-dependent gate to the retrieved features before the output projection. For one head, the update is
 
@@ -356,7 +358,7 @@ def gated_causal_sdpa(q, k, v, gate_logits, dropout_p=0.0):
 
 Raschka's Qwen example places this output gate alongside zero-centered QK-Norm and partial RoPE. Those two choices alter score normalization and positional encoding; they are useful co-designs, not parts of the definition of gating. Keeping the axes separate explains why an architecture can combine gated full attention with GQA, MLA, or a local window.
 
-### Linear attention
+### Replace history with state
 
 Linear attention changes the memory representation more radically. Softmax is applied after $QK^\top$, which couples every query to every key. Kernelized linear attention applies a feature map $\phi$ to queries and keys separately, allowing the multiplication to be reassociated. Instead of retaining every K/V pair, the model can update fixed-size running statistics such as
 
@@ -390,7 +392,7 @@ $$
 
 The write strength $0\leq\beta_t\leq1$ determines how strongly the new association replaces the old one. Gated DeltaNet adds a decay factor before this targeted correction, giving the model two distinct controls: decay weakens existing memory broadly, while the delta rule repairs the association addressed by the current key. Kimi Delta Attention makes the decay finer-grained by moving from one scalar per head toward channel-wise control over the recurrent state.
 
-The recurrent form is easiest to see one decode step at a time. With the positive feature map $\phi(x)=\operatorname{ELU}(x)+1$, the code below updates $S_t$ and $z_t$ without retaining a token-length dimension. It is vectorized over batches and heads, and `torch.compile` can fuse its pointwise and contraction graph on supported backends.
+The recurrent form is easiest to see one decode step at a time. With the positive feature map $\phi(x)=\operatorname{ELU}(x)+1$, the following code updates $S_t$ and $z_t$ without retaining a token-length dimension. It is vectorized over batches and heads, and `torch.compile` can fuse its pointwise and contraction graph on supported backends.
 
 ```python
 @torch.compile
@@ -416,7 +418,7 @@ def linear_attention_step(q, k, v, state, normalizer, eps=1e-6):
     return y, state, normalizer
 ```
 
-This recurrence has constant state size with respect to context length, but it is not a drop-in numerical approximation to every trained softmax-attention model: the feature map changes the retrieval rule, and the state still scales with key dimension times value dimension. During full-sequence training, a production implementation uses a fused associative scan or recurrent kernel rather than calling this Python function in a token loop. The step function is most faithful as a map of the state update and as a compact decode prototype.
+This recurrence has constant state size with respect to context length. It is not a drop-in approximation to every trained softmax-attention model: the feature map changes retrieval, and the state still scales with key dimension times value dimension. During full-sequence training, a production implementation uses a fused associative scan or recurrent kernel rather than calling this Python function in a token loop. The step function is most faithful as a map of the state update and as a compact decode prototype.
 
 The same vectorized shape supports a Gated DeltaNet-style decode step. This educational version uses one learned decay and write strength per head; Kimi Delta Attention's channel-wise decay requires a richer parameterization and a specialized kernel.
 
@@ -450,11 +452,11 @@ def gated_delta_net_step(q, k, v, state, log_decay, write_logits):
 
 Decode is naturally recurrent; prefill must expose parallel matrix work. Yang et al. derive a mathematically equivalent chunkwise algorithm by representing the cumulative state transitions as products of generalized Householder matrices. Tokens within each chunk become batched matrix operations, while a smaller recurrence carries state between chunks. Chunk size therefore changes the execution schedule and hardware utilization, not the DeltaNet retrieval rule. Their Triton implementation reported increasing speedups over a recurrent kernel as sequence length and head dimension grew, which is why a production prefill path should use a fused chunkwise kernel rather than a Python token loop.
 
-### Hybrid attention stacks
+### Mix cheap memory with exact retrieval
 
 Fixed-size recurrent memory is efficient but necessarily capacity-limited. Modern hybrid architectures therefore use cheap sequence mixers for most layers and periodically restore a full or compressed softmax-attention layer. Qwen-style hybrids combine runs of Gated DeltaNet with gated full attention; other systems substitute Lightning Attention or Mamba-style state-space blocks. Ali's Kimi K3 account gives the ratio a concrete form: 23 four-layer groups, each with three Kimi Delta Attention layers followed by one gated MLA layer.
 
-The Gated DeltaNet paper shows the same design choice at two scales: the left and center stacks interleave recurrent modules with sliding-window attention, while the right panel opens the Gated DeltaNet block into its query, key, value, update, and output-gate paths.
+The Gated DeltaNet paper shows the same design choice at two scales. Its H1 and H2 stacks interleave recurrent modules with sliding-window attention; the block diagram then exposes the query, key, value, update, and output-gate paths.
 
 ![Gated DeltaNet hybrid stacks and the internal gated delta-rule block](/assets/images/attention-hybrid-gated-deltanet.png)
 
@@ -468,7 +470,7 @@ Attention Residuals changes a different axis: depth rather than token position. 
 
 This is the modern endpoint of the history. The original RNN bottleneck motivated direct retrieval from an explicit sequence; current long-context systems reintroduce compressed recurrent memory for efficiency, then retain selective attention layers because exact retrieval still matters.
 
-### Evidence and comparison limits
+### What the evidence supports
 
 The most useful empirical results compare one mechanism against a nearby alternative inside the same training recipe. They should not be read as a universal leaderboard across attention families.
 
@@ -481,7 +483,7 @@ The most useful empirical results compare one mechanism against a nearby alterna
 
 Raschka's larger caveat is the right one: there is still no single matched-data, matched-compute study that trains GQA, MLA, sparse attention, gated attention, recurrent memory, and their hybrids under one controlled recipe. Kernel maturity also changes observed throughput. A theoretically cheaper hybrid can lose to conventional GQA on a local system if its recurrent or latent-attention path lacks an optimized kernel.
 
-## What attention variants change
+## Choose the failure you can afford
 
 Attention still answers one question: for this output position, which sources match the current need, and what content should they contribute? The variants differ in where they pay for that answer.
 
@@ -493,8 +495,6 @@ Attention still answers one question: for this output position, which sources ma
 - Hybrid models spend most layers on cheap memory updates and reserve some layers for stronger retrieval.
 
 No variant dominates every regime. Full attention preserves exact access but grows expensive with context. Cache-sharing methods are simpler but reduce K/V capacity. Latent, sparse, and recurrent methods buy more efficiency with new approximation, tuning, kernel, or serving burdens. The right comparison is therefore not “which attention name is newest?” but “which bottleneck dominates this model, and which retrieval failure can it afford?”
-
-> Attention variants spend the same budget in different places: exact token retrieval, cache capacity, compressed memory, or fixed-size state. The right architecture follows the dominant bottleneck and the retrieval error the system can afford, not the newest name.
 
 ## References
 

--- a/src/content/posts/code-is-cheap-understanding-isnt.md
+++ b/src/content/posts/code-is-cheap-understanding-isnt.md
@@ -12,7 +12,8 @@ tags:
 topics:
   - language-systems
 summary: >-
-  What engineers should learn when AI makes writing code cheap.
+  What remains valuable when agents make implementation abundant: context,
+  judgment, task decomposition, efficient orchestration, and ownership.
 ---
 
 # Code Is Cheap. Understanding Isn't.
@@ -23,7 +24,7 @@ That sounds obvious, but software people are unusually easy to seduce by the art
 
 There is a reason needless refactoring has always been frowned upon. There is a reason nobody is nostalgic for punch cards. The interface changes; the work remains. Right now, that interface is changing very quickly.
 
-## From reasoning to action
+## From answers to action
 
 [Junyang Lin describes the transition](https://justinlin610.github.io/blog/from-reasoning-to-agentic-thinking/) as a move from “reasoning thinking” to “agentic thinking.” The first generation of reasoning models taught us to treat intelligence as inference-time compute: give a model a harder problem, let it deliberate for longer, and hope for a better answer. An agentic system changes the objective. The model is no longer thinking only to answer. It is thinking to act, observe what happened, and decide what to do next.
 
@@ -33,7 +34,7 @@ That changes what it means to be good at using AI for software. Most of us have 
 
 The scarce part is deciding what should exist.
 
-## Context becomes the scarce input
+## Context is scarce
 
 As implementation gets cheaper, context gets more valuable. An agent might remember more Kubernetes details than I do. It might know more C++ edge cases. It might produce a CUDA kernel in minutes that would have taken me half a day. What it does not automatically know is why a particular system looks the way it does.
 
@@ -42,6 +43,8 @@ Why is that ugly workaround still there? Which customer depends on that behavior
 That is context, and context engineering is not the same thing as putting more text into a prompt. I increasingly dislike giant base-level instruction files that every agent receives forever because one paragraph was useful for one task six weeks ago. More context is not necessarily better context. Irrelevant context pollutes reasoning in the same way that unnecessary shared state pollutes a software system.
 
 The real skill is deciding what an agent needs to know for this task, right now. Sometimes good context engineering means adding a design decision, production invariant, or failure trace. Sometimes it means deleting an obsolete instruction. The goal is not maximum context. It is the smallest context that preserves the decisions the agent cannot safely rediscover.
+
+> **Deep insight:** Good context engineering is selective memory. Preserve the decisions a system cannot safely rediscover; remove the history that only makes those decisions harder to see.
 
 ## Do not become a slop cannon
 
@@ -60,7 +63,7 @@ Technical debt generated in thirty seconds is still technical debt. A needless a
 
 The adult in the room asks a more boring question: why does this thing need to exist? Sometimes the most successful agentic coding session should end with less code than it started with.
 
-## Match intelligence to the task
+## Match model to task
 
 “Big-model smell” is not what happens when an overpowered model over-engineers a small change. In the model chatter around [Claude Fable 5](https://www.anthropic.com/claude/fable), the phrase is closer to a compliment: the model feels broad enough to understand an underspecified problem, exercise judgment, and keep making sensible decisions without having every intermediate step dictated. [Simon Willison described that impression](https://simonwillison.net/2026/Jun/9/claude-fable-5/) as a combination of slowness, expense, and an unusually deep store of knowledge. [Shlok Khemani's account](https://www.shloked.com/writing/fable-5-first-impressions) emphasizes the more important part for agentic work: given a vague objective, the model inferred the intended result and found a coherent path toward it.
 
@@ -78,7 +81,7 @@ Use the expensive model when ambiguity, consequence, or deep reasoning justifies
 
 This is not only thrift. It is architecture.
 
-## Treat tokens as a system resource
+## Tokens are a system resource
 
 We already reason about CPU, memory, bandwidth, latency, storage, GPU utilization, and cloud spend. Intelligence cost belongs in the same design conversation. Tokens are a resource.
 
@@ -88,7 +91,7 @@ The agent stack may end up looking familiar to anyone who has designed distribut
 
 A company will eventually notice the difference between an engineer who needs enormous amounts of frontier-model inference for every task and one who produces the same or better outcome with a well-designed hierarchy of models and agents. Efficiency will matter because it exposes the quality of the decomposition underneath the bill.
 
-## Parallelism changes the engineer's job
+## Parallel work changes the job
 
 Humans are mostly single-threaded. Agents do not have to be.
 
@@ -108,7 +111,9 @@ For most of programming history, doing the work and learning the work were incon
 
 The task gets completed. The learning never happens.
 
-In a 2026 conversation about the move from vibe coding to agentic engineering, [Andrej Karpathy returns to a useful distinction](https://www.youtube.com/watch?v=96jN2OCOfLs): thinking can be outsourced more readily than understanding. That distinction is the defense against passive competence. Do hard things sometimes. Read the implementation. Follow the stack trace yourself. Debug without immediately reaching for an agent. Go one abstraction lower. Learn enough that when a model proposes something stupid, some part of your brain feels the mismatch before the tests do.
+In a 2026 conversation about the move from vibe coding to agentic engineering, [Andrej Karpathy returns to a useful distinction](https://www.youtube.com/watch?v=96jN2OCOfLs): thinking can be outsourced more readily than understanding. That distinction is the defense against passive competence.
+
+Do hard things sometimes. Read the implementation. Follow the stack trace yourself. Debug without immediately reaching for an agent. Go one abstraction lower. Learn enough that when a model proposes something stupid, some part of your brain feels the mismatch before the tests do.
 
 The better agents become, the easier it becomes to stop learning. The less I learn, the worse I become at directing them. Learning is therefore not a nostalgic attachment to manual work; it is part of the control system.
 
@@ -124,7 +129,7 @@ There is something important in the friction itself. If a machine can generate c
 
 Speed is useful. Tenacity is different.
 
-## What remains valuable
+## What remains
 
 The amount of human labor required to produce software will probably fall. Pretending otherwise does not help anyone. If one engineer can direct five, ten, or twenty capable agents, the economics of engineering organizations change—perhaps unevenly and not all at once, but in a direction that is hard to ignore.
 
@@ -137,7 +142,7 @@ _Agent manager — imagined by OpenAI ImageGen._
 
 Which one do you retain?
 
-> As code generation becomes abundant, the durable advantage moves upstream: deciding what should be built, why it should exist, what context changes the answer, and how to direct capable machines through the resulting constraints.
+The answer says a great deal about where the profession is going. The future does not belong to whoever can generate the most code. Code is becoming abundant. The durable skill is understanding what should be built, why it should exist, what context matters, and how to marshal increasingly capable machines to build it well.
 
 Writing software was always about building. Code was a tool. Agents are tools too.
 

--- a/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
+++ b/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
@@ -9,7 +9,7 @@ tags:
   - Reinforcement Learning
   - Reasoning
   - Robotics
-summary: 'A practical map of PPO, DPO, GRPO, and on-policy distillation.'
+summary: 'How PPO, DPO, GRPO, and on-policy distillation construct their learning signals—and which assumptions survive contact with physical action.'
 ---
 
 # PPO, DPO, GRPO, and On-Policy Distillation
@@ -18,13 +18,13 @@ Reinforcement learning for language models can look like a parade of acronyms. P
 
 The useful history is not the sequence of names. It is the sequence of compromises around one estimator:
 
-The governing question is: given behavior sampled from the current policy, what evidence should increase or decrease its probability, and relative to what baseline?
+> Given behavior sampled from the current policy, what evidence should increase or decrease its probability, and relative to what baseline?
 
 This essay follows that question from PPO through verifiable-reward reasoning and into VLA post-training. It is intentionally narrower than [Post-Training VLAs: A Reading Guide to Closed-Loop Improvement](/blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html). That guide covers the whole deployment loop: action interfaces, failure mining, feedback collection, critics, evaluation, and reproducibility. Here, those are held at the boundary. The subject is the update machinery itself—sampling distribution, advantage construction, likelihood ratio, and credit assignment.
 
 The evidence cutoff is July 27, 2026. PPO, DPO, DeepSeekMath/GRPO, GKD, DeepSeek-R1, and the early VLA-RL systems are reported evidence. The final hybrid design is synthesis: a falsifiable proposal, not a result already established across robots.
 
-## The policy-gradient objective
+## One gradient, four choices
 
 For a trajectory $\tau=(s_0,a_0,\ldots,s_T)$ sampled from policy $\pi_\theta$, a policy-gradient update has the form
 
@@ -57,7 +57,7 @@ The figure holds the prompt fixed and changes only the source of contrast. It is
 
 This controlled view explains why the methods are not interchangeable. PPO and GRPO need fresh policy samples because their advantages describe current behavior. DPO avoids generation because the contrast is already stored in the dataset. GKD is on-policy in state coverage but supervised in its target: teacher logits repair the student's visited prefixes without estimating future return. The later sections differ mainly in how expensive, noisy, or physically defensible each contrast becomes.
 
-## PPO: Value baselines and clipped updates
+## PPO: learn the baseline
 
 [Proximal Policy Optimization](/paper%20shorts/2017/07/01/proximal-policy-optimization-ppo.html) made actor-critic policy gradients operationally simple. The actor collects trajectories under $\pi_{\mathrm{old}}$. A value network estimates expected future return, and Generalized Advantage Estimation turns temporal-difference residuals into lower-variance $\hat A_t$. The actor then reuses the rollout for several minibatch epochs under a clipped surrogate:
 
@@ -80,7 +80,7 @@ That compromise fit early RLHF. A language model supplies tractable token log-pr
 
 PPO therefore established the durable skeleton—online sampling, relative probability updates, and reference control—while making the value model the obvious component to challenge.
 
-## DPO: Offline preference optimization
+## DPO: store the contrast
 
 [Direct Preference Optimization](/paper%20shorts/2023/05/01/direct-preference-optimization-dpo.html) is often placed between PPO and GRPO as if it were a newer policy-gradient algorithm. It changes the problem more radically. DPO assumes the evidence already arrives as fixed pairs: for prompt $x$, response $y_w$ is preferred to $y_l$. Under a Bradley–Terry preference model and KL-regularized reward optimum, the implicit reward can be expressed through policy-to-reference log-ratios. The training objective becomes
 
@@ -100,7 +100,7 @@ DPO belongs in the evolution because it clarified what online RL was buying. If 
 
 For VLAs, the “matched” condition is particularly fragile. Two text answers can share the same prompt. Two physical trajectories rarely share exactly the same camera pose, friction, object state, and intervention history. An apparent preference can encode an environment difference rather than an action difference. DPO remains useful for replayable simulations, local action alternatives from the same logged state, or carefully constructed intervention windows. It is not a generic conversion from “one robot rollout succeeded” and “another failed” into a clean preference pair.
 
-## GRPO: Group-relative baselines
+## GRPO: sample the contrast
 
 [DeepSeekMath](/paper%20shorts/2024/02/05/deepseekmath-group-relative-policy-optimization-grpo.html) makes a different trade. For each question, the current policy samples $G$ answers. An exact or learned verifier produces rewards $r_1,\ldots,r_G$, and GRPO normalizes them within that question:
 
@@ -123,9 +123,9 @@ This is an excellent bargain when three conditions hold:
 
 Math and code fit unusually well. A sampler can produce eight solutions without changing the problem, and an exact checker can often score the final answer. DeepSeekMath reports gains after GRPO-based training across GSM8K, MATH, and multilingual mathematics. [DeepSeek-R1](https://arxiv.org/abs/2501.12948) pushes the idea further: R1-Zero shows that verifiable-reward RL without supervised reasoning traces can elicit longer reasoning, self-checking, and strategy changes. Its language mixing and poor readability also show what correctness-only reward leaves unconstrained. The final R1 recipe adds cold-start data and staged training rather than treating pure RL as sufficient.
 
-GRPO removes a model, not the need for a baseline. The group is the baseline, which makes group composition part of optimization.
+> **Deep insight:** GRPO removes the critic, not the estimation problem. It moves that problem into the sampler because the group now defines the baseline.
 
-## GRPO's zero-gradient failure
+## When the group says nothing
 
 If all sampled answers are correct, every normalized reward is zero. If all are wrong, the same thing happens. Easy and impossible questions consume generation without supplying a gradient. Near-zero variance also makes normalization noisy. A fixed prompt distribution therefore becomes progressively inefficient as the policy improves.
 
@@ -165,7 +165,7 @@ Distillation and RL optimize different evidence:
 
 That hybrid has become more relevant as reasoning policies improve. [Self-Supervised On-Policy Distillation for Reasoning LMs](https://arxiv.org/abs/2605.17497) uses the correct answers inside mixed GRPO groups as teachers for incorrect answers, extracting dense supervision from rollouts that would otherwise provide only a binary contrast. The 2026 paper reports a 65.6 macro Avg@12 for Qwen3-8B, 1.6 points above its GRPO baseline. This is frontier evidence, not yet a settled recipe, but it reveals the direction: reuse on-policy computation to manufacture denser, state-matched targets.
 
-## Comparing feedback and estimation methods
+## The estimators compared
 
 | Method | Training states | Feedback unit | Baseline or anchor | Main cost | Native blind spot |
 | --- | --- | --- | --- | --- | --- |
@@ -177,7 +177,7 @@ That hybrid has become more relevant as reasoning policies improve. [Self-Superv
 
 The table prevents a common category error. DPO is not “GRPO but offline,” because its pairwise reference-relative margin encodes a different statistical object. On-policy distillation is not “RL with soft rewards,” because teacher logits supervise local action distributions without estimating future return. PPO and GRPO are closest: both weight policy ratios with advantages, but they construct the baseline differently.
 
-## Why VLA policies need different assumptions
+## Why robots change the assumptions
 
 Transferring these estimators to a VLA requires more than replacing “token” with “action.” Three assumptions change at once.
 
@@ -199,7 +199,7 @@ Copying one answer reward across 1,000 reasoning tokens is noisy. Copying one su
 
 VLA post-training therefore needs a feedback unit between token and episode: action chunk, skill segment, state transition, or critic-estimated progress. That unit must remain replayable or observable enough to compare alternatives. Otherwise denser reward only creates denser confidence, not better credit.
 
-## VLA reinforcement-learning methods
+## VLA methods
 
 The early VLA-RL literature can be organized by what replaces the critic and where high-quality trajectories come from.
 
@@ -223,7 +223,7 @@ The frontier is moving toward intermediate feedback. [LifeLong-RFT](https://arxi
 
 These systems are recent and heterogeneous. Their reward definitions, simulators, embodiments, action heads, and evaluation protocols differ, so their headline gains should not be ranked as if they were optimizer ablations. What they collectively support is narrower: VLA RL is becoming a joint design of rollout distribution, feedback granularity, and action likelihood.
 
-## Choosing an estimator
+## Choose by evidence
 
 The method decision can be made without starting from an acronym:
 
@@ -238,7 +238,7 @@ The method decision can be made without starting from an acronym:
 
 The last row is deliberately conservative. “On-policy” does not make evidence causal. If two robot episodes cannot be matched well enough for their reward difference to identify a policy decision, a relative advantage is numerically valid and scientifically weak.
 
-## A hybrid training hypothesis
+## A hybrid hypothesis
 
 The evolution suggests a shared endpoint: sparse external reward should select outcomes, while dense on-policy supervision should repair the trajectory states that produced them.
 
@@ -255,13 +255,13 @@ This hypothesis is falsifiable. Compare four methods under identical model initi
 
 Report success and safety, but also zero-variance group rate, critic/teacher calls, policy KL, action entropy, recovery success, real robot-hours, and performance after the teacher or simulator distribution shifts. The hybrid earns its complexity only if it improves reliable success per unit of interaction—not merely final reward after consuming more rollouts and teacher inference.
 
-## Where each method gets its learning signal
+## Where the signal comes from
 
 PPO learns a critic so each action can be compared with expected return. DPO assumes the contrast has already been collected as a chosen/rejected pair. GRPO obtains the contrast from other attempts at the same prompt. On-policy distillation replaces a scalar contrast with a teacher distribution at the learner's own states.
 
 Reasoning models made GRPO powerful because prompts reset perfectly and verifiers are cheap. VLAs expose the limits because physical state does not reset cleanly, action likelihood may pass through diffusion, and a terminal bit is far from the causal motion. The transferable object is therefore not GRPO itself. It is the estimator-design discipline:
 
-> Sample where the policy will act, compare only what the environment makes comparable, and make feedback no coarser than the decision it is supposed to credit. This is the estimator-design constraint that transfers from reasoning RL to VLAs.
+> Sample where the policy will act, compare only what the environment makes comparable, and make feedback no coarser than the decision it is supposed to credit.
 
 That principle explains the past decade of policy optimization better than the acronym sequence—and gives VLA post-training a testable path beyond copying language-model RL.
 

--- a/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
+++ b/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
@@ -8,7 +8,7 @@ legacyPath: /blog/2026/07/05/from-seeing-to-doing-the-evolution-of-vision-langua
 tags:
   - Research
   - Vision-Language Models
-summary: How vision-language models evolved from image-text alignment to robot action.
+summary: How visual representations change as the output contract moves from image-text alignment to generation, grounding, temporal reasoning, and robot action.
 ---
 
 # From Image-Text Alignment to Robot Actions
@@ -29,7 +29,7 @@ Do not read every paper with the same question. For alignment papers, identify t
 
 The recurring exercise is simple: draw the path from raw observation to evaluated output, then circle every irreversible compression step. That picture usually explains more than the model name.
 
-## 1. VLM architectures and interfaces
+## Five output contracts
 
 “Vision-language model” covers several systems with different outputs:
 
@@ -45,17 +45,19 @@ This table is the first defense against vague claims. A retrieval model can be e
 
 The shared implementation pattern is simple. An image is converted into visual tokens or features. A connector maps those features into a space that can interact with text. A loss then decides what “interaction” means: contrastive agreement, next-token prediction, region grounding, denoising, or action imitation.
 
-> The loss is the contract. Architecture matters because it decides which evidence remains available to satisfy that contract, so a change in prediction target can invalidate an otherwise successful representation.
+> **Deep insight:** The loss is the contract. The architecture decides which evidence survives long enough to satisfy it—and which evidence no later stage can recover.
 
-The comparison below keeps one mug-and-tray scene fixed. Only the evaluated output changes. Watch which evidence becomes mandatory rather than assuming every later model is simply a larger version of the first.
+The next comparison keeps one mug-and-tray scene fixed. Only the evaluated output changes. Watch which evidence becomes mandatory rather than assuming every later model is simply a larger version of the first.
 
 [![Animation showing how CLIP, LLaVA, Molmo, and Pi0 require progressively different visual evidence from the same scene](/assets/images/blog-vlm-evidence-contract.gif)](/assets/images/blog-vlm-evidence-contract.gif)
 
 *CLIP's contrastive objective can succeed with global semantic identity; it does not require an inspectable location. LLaVA projects visual features into a language model so they can condition generation. Molmo's point supervision makes a spatial binding externally testable. Pi0 adds temporally conditioned continuous action through a flow-based expert. The panels show output contracts, not a claim that one model literally evolves into the next. Custom explanatory synthesis based on [CLIP](https://arxiv.org/abs/2103.00020), [LLaVA](https://arxiv.org/abs/2304.08485), [Molmo](https://arxiv.org/abs/2409.17146), and [Pi0](https://arxiv.org/abs/2410.24164).*
 
-The progression is therefore not “more modalities.” It is a sequence of stricter information obligations. A global vector may identify the mug while discarding its handle location. A generative assistant needs enough visual tokens to support an answer but may still lack an explicitly supervised binding. Point grounding exposes the binding. Action raises the standard again: the representation must remain useful across changing observations and an embodiment-specific control deadline. Once an earlier compression removes that evidence, downstream fluency cannot reconstruct it.
+The progression is therefore not “more modalities.” It is a sequence of stricter information obligations. A global vector may identify the mug while discarding its handle location. A generative assistant needs enough visual tokens to support an answer but may still lack an explicitly supervised binding. Point grounding exposes the binding.
 
-## 2. Open-vocabulary image-text alignment
+Action raises the standard again. The representation must remain useful across changing observations and an embodiment-specific control deadline. Once an earlier compression removes that evidence, downstream fluency cannot reconstruct it.
+
+## Alignment
 
 Before large-scale image-text pretraining, a vision classifier typically learned a closed vocabulary. Its final layer represented the categories chosen by the dataset designer. Adding a new class meant collecting labels and training again.
 
@@ -78,7 +80,7 @@ The tradeoff sits inside the objective. Batch-softmax contrastive learning treat
 
 What retrieval pretraining does not provide is equally important. A shared embedding can tell us that an image and sentence belong together without preserving which patch supports which phrase, how objects relate spatially, or how to generate a multi-sentence answer. Global semantic alignment is a strong prior, not a complete visual interface.
 
-## 3. Visual instruction tuning
+## Generation
 
 [LLaVA](/paper%20shorts/2023/04/01/visual-instruction-tuning-llava.html) made the next transition legible. Start with a pretrained visual encoder and an instruction-tuned language model. Learn a projector that maps visual features into the language model's token space. Then fine-tune on image-instruction-response examples.
 
@@ -117,7 +119,7 @@ This distinction explains why modern VLM recipes separate several data roles:
 
 The operational question is no longer “How many multimodal examples do we have?” It is “Which behavior does each dataset teach, and which capability regresses when we increase its weight?”
 
-## 4. Visual-token efficiency
+## The visual-token budget
 
 Text tokenization compresses language into a sequence of discrete symbols. Images do not arrive with an obvious equivalent. A $1024\times1024$ image can be divided into patches, encoded into a smaller feature grid, tiled at several resolutions, or compressed through a learned tokenizer. Every choice trades detail for sequence length: more visual tokens can preserve small objects and text but consume attention, memory, and latency; fewer tokens improve throughput but may create an irreversible perceptual bottleneck.
 
@@ -127,7 +129,7 @@ These systems differ in implementation, but they answer one shared question: **w
 
 A convincing comparison must therefore match more than parameter count. It should report visual tokens, input resolution, training and inference FLOPs, latency, and performance on tasks that isolate small text, counting, localization, and global scene reasoning. Otherwise, a “better architecture” may simply be buying more pixels.
 
-## 5. Visual grounding
+## Grounding
 
 A model can answer “the traffic light is red” for at least three reasons: it localized the light and read its state, it used a language prior about the scene, or it guessed from dataset regularities. Standard answer accuracy often fails to distinguish them.
 
@@ -145,7 +147,7 @@ This gives a useful hierarchy for evaluating visual evidence:
 
 The fifth level is the hardest and most revealing. If the answer remains unchanged after the traffic light is masked or its state is edited, the model's explanation was not causally grounded in that evidence.
 
-## 6. Video and temporal modeling
+## Time
 
 Video looks like “more images,” yet it changes the representation problem. Adjacent frames are highly redundant, important events can be brief, and the correct sampling rate depends on the question. Uniformly encoding every frame wastes context; aggressive sampling can delete the event.
 
@@ -162,7 +164,7 @@ For video VLMs, I would separate four tests:
 
 The first three measure temporal understanding. The fourth begins to test a model of action-conditioned worlds.
 
-## 7. VLMs for autonomous driving
+## Driving
 
 Autonomous driving compresses nearly every VLM weakness into one domain: small distant objects, geometry, rules, rare hazards, temporal prediction, uncertainty, and hard latency limits.
 
@@ -180,7 +182,7 @@ These designs should not be collapsed into “VLMs for driving.” They correspo
 
 My current read is that the strongest near-term use is hybrid. VLMs contribute semantic knowledge, intent understanding, rare-scenario interpretation, and supervision. Metric perception, motion forecasting, safety constraints, and high-rate control retain explicit structure. This is not an argument that end-to-end systems cannot work. It is a statement about evidence: fluent rationales and open-loop trajectory metrics do not yet establish reliable closed-loop control.
 
-## 8. Grounding-aware benchmarks
+## Benchmarks that force looking
 
 [DriveBench](/paper%20shorts/2025/01/01/are-vlms-ready-for-autonomous-driving-drivebench.html), [IDKB](/paper%20shorts/2024/09/01/can-lvlms-obtain-a-drivers-license-idkb.html), [TOD3Cap](/paper%20shorts/2024/03/01/tod3cap-towards-3d-dense-captioning-in-outdoor-scenes.html), and [AutoTrust](/paper%20shorts/2024/12/01/autotrust-benchmarking-trustworthiness-in-large-vision-language-models-for-autonomous-driving.html) attack different versions of the same problem: plausible language can hide weak evidence use.
 
@@ -197,7 +199,7 @@ A benchmark that tests only final-answer agreement can reward memorized priors. 
 
 The practical implication is uncomfortable: a higher aggregate VLM score may be less valuable than a lower score with better calibration and causal grounding. Deployment cares about the shape of failure, not only its average frequency.
 
-## 9. VLMs for robotics
+## Action
 
 Robotics completes the transition from description to intervention. Once the model emits actions, its outputs change the next observation. Errors compound under the state distribution created by the policy itself.
 
@@ -217,7 +219,7 @@ A caption has no control frequency. An action does. A robot policy must fit sens
 
 This is where “language as a universal interface” reaches its limit. Language can carry task semantics. It does not make units, embodiment, contact dynamics, or control latency disappear.
 
-## 10. How to read a VLM paper
+## Read by contract
 
 I use six questions to avoid being carried away by a capability collage.
 
@@ -230,9 +232,9 @@ I use six questions to avoid being carried away by a capability collage.
 
 These questions turn a model paper into a decision record. If the answer to question four is “several things,” then the paper may demonstrate a strong recipe without identifying why it works. That is still useful, but it supports adoption more than causal understanding.
 
-## 11. Reading course
+## Reading course
 
-The list below is ordered by conceptual dependency. Each layer has a deliverable; without it, “reading the paper” too easily becomes collecting model names.
+The reading course is ordered by conceptual dependency. Each layer has a deliverable; without it, “reading the paper” too easily becomes collecting model names.
 
 **Layer 1: alignment.** Read [CLIP](/paper%20shorts/2021/02/28/learning-transferable-visual-models-from-natural-language-supervision.html) and [SigLIP](/paper%20shorts/2023/10/01/sigmoid-loss-for-language-image-pre-training-siglip.html). Derive the two losses and write down the unit of competition. Your deliverable is a one-page note explaining how batch composition becomes part of the learning algorithm.
 
@@ -246,7 +248,7 @@ The list below is ordered by conceptual dependency. Each layer has a deliverable
 
 After these five layers, move to [Part II: Pretraining Multimodal Models for Robotics](/blog/2026/07/15/omni-model-pretraining-decisions.html). The VLM literature tells you what visual and semantic priors are available. The robotics literature asks which of those priors survive contact with embodiment.
 
-## The research thesis
+## A testable thesis
 
 VLM progress is a sequence of interface contracts. Contrastive learning made images addressable through language. Visual instruction tuning made that representation conversational. Grounding tried to reconnect fluent words to visible evidence. Video introduced persistence and compression. Driving and robotics exposed every shortcut because a plausible answer can become a bad physical decision.
 

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -1,5 +1,5 @@
 ---
-title: 'Perception for Autonomous Driving'
+title: 'Autonomous-Vehicle Perception, circa 2026'
 date: '2026-07-31T18:00:00.000Z'
 section: blog
 blogGroup: research-guides
@@ -12,37 +12,37 @@ tags:
 topics:
   - autonomy
   - multimodal
-summary: How camera, LiDAR, and radar become a unified, temporal scene representation.
+summary: How camera, LiDAR, and radar encoders preserve different measurements, align them in metric space, fuse them, and carry scene state through time.
 ---
 
-# Perception for Autonomous Driving in 2026
+# Autonomous-Vehicle Perception, circa 2026
 
 An autonomous vehicle receives several partial descriptions of the same scene. Cameras provide dense appearance and semantic detail, but depth has to be inferred and image quality falls under glare, darkness, rain, or fog. LiDAR measures range directly and resolves 3D shape well, but the point cloud becomes sparse with distance and can be degraded by weather, reflectivity, occlusion, and motion during a scan. Radar measures range and radial velocity at long distance and is comparatively tolerant of poor visibility, but its angle estimates are coarse and multipath produces ambiguous returns.
 
-> The architectural choice is not merely how to combine sensors. It determines where their differences survive, where geometry becomes shared, and where irrecoverable information is spent. That dependency is:
+The central architectural question is therefore not simply how to combine sensors. It is where to preserve their differences, where to establish a shared geometric representation, and where to spend the information that the model can no longer recover. The progression in this article follows that dependency:
 
 sensor-specific encoders → metric 3D representation → temporal state → task heads
 
-Fusion sits between the second and third steps. The model should preserve modality-specific evidence first, align it in the vehicle frame, and only then decide whether the shared state should be a dense scene field, a sparse set of object queries, or a learned mixture of both.
+Fusion sits between the second and third steps. The model should preserve modality-specific evidence, then align it in the vehicle frame. Only then should it choose a dense scene field, sparse object queries, or a learned mixture of both.
 
-## From measurements to a driving scene
+## From measurements to a scene
 
-The diagram below shows the runtime path. Each sensor first passes through an encoder designed for its sampling pattern. Intrinsics describe how a camera maps 3D rays to pixels; extrinsics describe where every sensor sits relative to the vehicle; timestamps and ego poses place measurements at a common time. These transformations let the model ask whether an image edge, a LiDAR return, and a radar detection refer to the same location. If calibration is wrong, fusion creates structured errors rather than random noise: a vehicle can acquire a displaced image feature, a lane boundary can shift across the BEV grid, and displacement from an angular error grows with range.
+The runtime diagram shows the complete path. Each sensor first passes through an encoder designed for its sampling pattern. Intrinsics describe how a camera maps 3D rays to pixels; extrinsics describe where every sensor sits relative to the vehicle; timestamps and ego poses place measurements at a common time. These transformations let the model ask whether an image edge, a LiDAR return, and a radar detection refer to the same location. If calibration is wrong, fusion creates structured errors rather than random noise: a vehicle can acquire a displaced image feature, a lane boundary can shift across the BEV grid, and displacement from an angular error grows with range.
 
 After alignment, the model stores the scene as a dense bird's-eye-view (BEV) field, a sparse set of 3D queries, or a mixture of both. BEV gives every ground-plane location a persistent cell, which suits occupancy, free space, lanes, and maps. Queries allocate state to selected actors or map elements, which suits detection, tracking, and motion prediction. A temporal module then aligns previous state to the current ego frame. This step reduces frame-to-frame flicker, exposes velocity through displacement, and preserves evidence through a short occlusion; it can also propagate stale detections or pose error if state is not aged and refreshed carefully.
 
 [![Autonomous-driving perception pipeline from sensor-specific encoders through calibrated metric representations, dense or sparse temporal state, and task heads, with learned latent tokens and a separate training-only graph](/assets/images/autonomous-driving-perception-system.svg)](/assets/images/autonomous-driving-perception-system.svg)
 _The runtime path moves from sensor-specific features to a calibrated BEV field, query set, or learned latent state, then carries that state into task heads. The lower path shows supervision that may exist during training without becoming a deployed sensor input._
 
-## Sensor encoders preserve different evidence
+## Preserve each sensor
 
 The first step is not fusion. It is choosing an encoder that does not erase the measurement that makes a modality useful.
 
-### Cameras: dense semantics at several scales
+### Cameras: semantics at several scales
 
-Camera encoding must recognize visual patterns without discarding the spatial detail needed for 3D placement. Convolutional backbones build local features with translation-equivariant kernels and map well to optimized inference libraries; production-oriented systems such as [NVAutoNet](/paper%20shorts/2023/03/23/nvautonet-fast-and-accurate-360-3d-visual-perception-for-self-driving.html) use efficient CNNs for both image and BEV processing. Vision transformers use content-dependent attention to connect distant image regions, which can help when recognition depends on wider context, but global attention at full surround-camera resolution is expensive. Both families still produce dense per-view feature maps, and neither removes the need for calibrated 3D reasoning downstream.
+Camera encoding must recognize visual patterns without discarding the spatial detail needed for 3D placement. Convolutional backbones build local features with translation-equivariant kernels and map well to optimized inference libraries; production-oriented systems such as [NVAutoNet](https://openaccess.thecvf.com/content/WACV2024/html/Pham_NVAutoNet_Fast_and_Accurate_360deg_3D_Visual_Perception_for_Self_WACV_2024_paper.html) use efficient CNNs for both image and BEV processing. Vision transformers use content-dependent attention to connect distant image regions, which can help when recognition depends on wider context, but global attention at full surround-camera resolution is expensive. Both families still produce dense per-view feature maps, and neither removes the need for calibrated 3D reasoning downstream.
 
-Feature pyramids are especially useful in driving because apparent object size changes sharply with range. A high-resolution level preserves the few pixels that represent a distant pedestrian or traffic light. Lower-resolution levels combine evidence over a larger receptive field and are cheaper to use for large vehicles, road layout, and scene context. [EfficientDet](/paper%20shorts/2020/04/01/efficientdet-scalable-and-efficient-object-detection.html) is a clear 2D example of learned multiscale fusion. [BEVFormer v2](/paper%20shorts/2022/11/18/bevformer-v2-adapting-modern-image-backbones-to-bird-eye-view-recognition.html) shows a separate issue in 3D: modern image backbones benefit from perspective-view supervision because a loss applied only after BEV conversion gives the image features a weak and indirect training signal.
+Feature pyramids are especially useful in driving because apparent object size changes sharply with range. A high-resolution level preserves the few pixels that represent a distant pedestrian or traffic light. Lower-resolution levels combine evidence over a larger receptive field and are cheaper to use for large vehicles, road layout, and scene context. [EfficientDet](/paper%20shorts/2020/04/01/efficientdet-scalable-and-efficient-object-detection.html) is a clear 2D example of learned multiscale fusion. [BEVFormer v2](https://openaccess.thecvf.com/content/CVPR2023/html/Yang_BEVFormer_v2_Adapting_Modern_Image_Backbones_to_Birds-Eye-View_Recognition_via_CVPR_2023_paper.html) shows a separate issue in 3D: modern image backbones benefit from perspective-view supervision because a loss applied only after BEV conversion gives the image features a weak and indirect training signal.
 
 For a 3D point $X$, camera $i$ uses its intrinsics $K_i$ and extrinsics $(R_i,t_i)$ to compute
 
@@ -52,14 +52,12 @@ $$
 
 The same point appears at a different pixel in each camera. If pyramid level $l$ has stride $s_l$, the feature is sampled at $u_i/s_l$. This projection is a correspondence rule, not a source of visual information: it can retrieve a fine boundary only if the backbone retained that boundary, and it can retrieve broad context only if the receptive field encoded it.
 
-> Projection is a correlated failure point. An error in depth, intrinsics, extrinsics, ego pose, or timestamp can move otherwise correct camera evidence into the wrong metric cell, after which every head that consumes the shared geometry may agree on the same wrong scene.
-
 [![Animation showing one metric 3D point projected to different pixels in two calibrated cameras and sampled at stride-adjusted feature-pyramid coordinates](/assets/images/autonomous-perception-vision-encoder.gif)](/assets/images/autonomous-perception-vision-encoder.gif)
 _A single 3D reference point lands at different pixels in different cameras and at different coordinates on each pyramid level. [DETR3D](/paper%20shorts/2021/10/14/detr3d-multiview-images-via-3d-to-2d-queries.html) uses this operation for object queries; [BEVFormer](/paper%20shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html) uses it for BEV queries._
 
 Camera encoders are strongest where appearance matters: class identity, lane paint, signs, lights, and object boundaries. Their main 3D weakness is not a lack of semantics but depth ambiguity. Increasing input resolution or backbone capacity can improve recognition without fixing that ambiguity. The next decision is therefore where to place image evidence in metric space.
 
-### LiDAR: sparse geometry before dense BEV
+### LiDAR: sparse geometry
 
 A LiDAR sweep is already metric, but it is irregular, sparse, and strongly range-dependent. Point encoders preserve individual returns but make neighborhood construction expensive. Pillar encoders group points in vertical columns and collapse height early. Voxel encoders retain a 3D grid for longer, which preserves overpasses, trucks, poles, and other height-dependent structure. The main encoder decision is where to trade 3D detail for the speed and regularity of a 2D BEV backbone.
 
@@ -72,7 +70,7 @@ _PointPillars compresses height before its dense 2D backbone. SECOND and DSVT re
 
 The right encoder depends on the operating envelope. Pillars are a strong latency baseline on mostly planar roads. Sparse voxels are preferable when vertical separation, long range, or dense 3D structure matters. Fully sparse heads save BEV work when occupied cells remain rare, but the wall-clock gain can be much smaller than the FLOP reduction on hardware with weak sparse-kernel support. In every case, intensity, timestamp, and point age should remain attached to the geometry: LiDAR range is direct, but a rotating scan is not an instantaneous snapshot.
 
-### Radar: range and motion under uncertainty
+### Radar: motion under uncertainty
 
 Radar should be modeled around the measurements that distinguish it from LiDAR. A return may contain range, azimuth, elevation, radial velocity, Radar Cross Section (RCS), timestamp, and a sensor-specific confidence estimate. Doppler can reveal a moving actor before image-only temporal inference has enough baseline, and millimeter-wave sensing is less sensitive than cameras to darkness and often more tolerant than cameras or LiDAR in rain and fog. The cost is weak angular localization, sparse semantic evidence, multipath, and ghost returns. Radar supplies useful constraints, not clean 3D boxes.
 
@@ -81,11 +79,11 @@ Three encoder families correspond to three fusion strategies. A point encoder ke
 [![Animation comparing camera-radar interaction at the proposal, depth, and BEV stages in CRAFT, CRN, and RCBEVDet](/assets/images/autonomous-perception-radar-encoder.gif)](/assets/images/autonomous-perception-radar-encoder.gif)
 _[CRAFT](/paper%20shorts/2022/09/14/craft-camera-radar-3d-object-detection-with-spatio-contextual-fusion-transformer.html) associates a soft set of radar returns with each camera proposal. [CRN](/paper%20shorts/2023/04/03/crn-camera-radar-net-for-3d-perception.html) uses radar to refine camera depth before lifting and aligns both BEV maps with deformable attention. [RCBEVDet](/paper%20shorts/2024/03/25/rcbevdet-radar-camera-fusion-in-bev.html) combines point and transformer radar paths before BEV fusion._
 
-Recent radar-camera systems improve less by treating radar as an extra image channel than by deciding where its range and Doppler should change the computation. [Simple-BEV](/paper%20shorts/2022/06/16/simple-bev-what-really-matters-for-multi-sensor-bev-perception.html) found that retaining radar metadata, disabling an aggressive outlier filter, and accumulating aligned sweeps all affected performance. [Doppler-Aware LiDAR–Radar Fusion](/paper%20shorts/2025/10/23/doppler-aware-lidar-radar-fusion-for-weather-robust-3d-detection.html) processes radar power and Doppler as distinct signals during multimodal interaction, while [DinoRADE](/paper%20shorts/2026/04/09/dinorade-full-spectral-radar-camera-fusion.html) combines dense radar tensors with DINOv3 image features in adverse-weather detection. A useful comparison should report adverse-weather and long-range accuracy together with false associations and velocity error; higher average detection is not enough if ghost returns attach to the wrong actor.
+Recent radar-camera systems improve less by treating radar as an extra image channel than by deciding where its range and Doppler should change the computation. [Simple-BEV](/paper%20shorts/2022/06/16/simple-bev-what-really-matters-for-multi-sensor-bev-perception.html) found that retaining radar metadata, disabling an aggressive outlier filter, and accumulating aligned sweeps all affected performance. [Doppler-Aware LiDAR–Radar Fusion](https://openaccess.thecvf.com/content/ICCV2025/html/Chae_Doppler-Aware_LiDAR-RADAR_Fusion_for_Weather-Robust_3D_Detection_ICCV_2025_paper.html) processes radar power and Doppler as distinct signals during multimodal interaction, while [DinoRADE](https://openaccess.thecvf.com/content/CVPR2026W/DriveX/html/Leitgeb_DinoRADE_Full_Spectral_Radar-Camera_Fusion_with_Vision_Foundation_Model_Features_CVPRW_2026_paper.html) combines dense radar tensors with DINOv3 image features in adverse-weather detection. A useful comparison should report adverse-weather and long-range accuracy together with false associations and velocity error; higher average detection is not enough if ghost returns attach to the wrong actor.
 
 The encoders now preserve the right evidence for each modality. The next question is how a camera feature becomes a metric 3D feature before it meets LiDAR or radar.
 
-## Camera to metric 3D: LSS and BEVDepth
+## Camera depth: LSS and BEVDepth
 
 A pixel fixes a ray through the camera center, not a distance along that ray. Camera-based 3D perception must decide where along the ray to place its feature. The first important family makes that uncertainty explicit.
 
@@ -100,11 +98,13 @@ These forward-projection methods preserve dense image evidence, which is useful 
 ![Figure 1 from Lift, Splat, Shoot, showing multiview evidence represented in vehicle-centered BEV](/assets/images/lift-splat-shoot-paper-figure-1.png)
 _Lift, Splat, Shoot predicts depth along every camera ray and pools the lifted features into a vehicle-centered BEV grid. Source: [Lift, Splat, Shoot](/paper%20shorts/2020/08/13/lift-splat-shoot-encoding-images-from-arbitrary-camera-rigs.html), Figure 1._
 
-Pull-based methods start in metric space. [Simple-BEV](/paper%20shorts/2022/06/16/simple-bev-what-really-matters-for-multi-sensor-bev-perception.html) projects each 3D voxel into the cameras and bilinearly samples the visible image features. Its controlled experiments found that input resolution and effective batch size changed vehicle-segmentation IoU more than the lifting operator in that setup. The result warns against reading every benchmark gain as evidence for a better view transformer; training recipe, image resolution, and sensor inputs must be matched first. The same metric representation can instead be queried sparsely.
+Pull-based methods start in metric space. [Simple-BEV](/paper%20shorts/2022/06/16/simple-bev-what-really-matters-for-multi-sensor-bev-perception.html) projects each 3D voxel into the cameras and bilinearly samples the visible image features. Its controlled experiments found that input resolution and effective batch size changed vehicle-segmentation IoU more than the lifting operator in that setup. The result is a useful warning against reading every benchmark gain as evidence for a better view transformer; training recipe, image resolution, and sensor inputs must be matched first.
 
-## Sparse object-centric 3D: DETR3D, PETR, and StreamPETR
+The metric representation can also be queried sparsely. That creates a second branch of the progression.
 
-[DETR](/paper%20shorts/2020/05/26/end-to-end-object-detection-with-transformers.html) introduced the basic object-query idea for 2D detection: a bounded set of learned query vectors asks whether there is an object to represent, and a transformer decoder turns those queries into a set of class and box predictions. [DETR3D](/paper%20shorts/2021/10/14/detr3d-multiview-images-via-3d-to-2d-queries.html) attaches each query to a 3D reference point $(x,y,z)$, projects that point into every camera, and samples image evidence around the projections.
+## Sparse 3D: DETR3D to StreamPETR
+
+[DETR](https://arxiv.org/abs/2005.12872) introduced object queries for 2D detection. A bounded set of learned query vectors asks which objects need representation, and a transformer decoder turns those queries into class and box predictions. [DETR3D](/paper%20shorts/2021/10/14/detr3d-multiview-images-via-3d-to-2d-queries.html) attaches each query to a 3D reference point $(x,y,z)$, projects that point into every camera, and samples image evidence around the projections.
 
 The difference from dense lifting is where the model spends its geometric budget. LSS represents every image location and every candidate depth bin. DETR3D asks only about a bounded set of candidate objects. It can therefore be efficient for detection, but it also inherits a recall risk: if no query acquires support for an actor, later refinement cannot recover evidence that was never represented.
 
@@ -112,9 +112,9 @@ The difference from dense lifting is where the model spends its geometric budget
 
 [StreamPETR](/paper%20shorts/2023/03/21/streampetr-object-centric-temporal-modeling-for-multiview-3d-detection.html) extends the object-query representation through time. Instead of rediscovering every actor from each frame, it retains a bounded queue of foreground queries, conditions them on ego pose, elapsed time, and velocity, and introduces fresh queries for newly visible actors. The temporal state is sparse and object-centric: it improves stability and occlusion handling without storing a full scene grid, but query birth, duplicate removal, aging, and stale false positives become part of the model.
 
-Sparse queries represent selected actors efficiently. Driving perception also needs a representation for everything between those actors: lanes, free space, occupancy, and map structure.
+The sparse branch gives us an efficient answer for selected actors. Driving perception also needs a representation for everything between those actors: lanes, free space, occupancy, and map structure.
 
-## Dense scene-centric 3D: BEVFormer
+## Dense 3D: BEVFormer
 
 BEVFormer changes the unit of representation from an object query to a BEV query. Imagine a learned token for every bird's-eye-view location. Each token asks the image features what appears to exist at that physical location, using calibration-aware attention to sample several heights along the corresponding vertical pillar.
 
@@ -134,9 +134,11 @@ _The highlighted variable is the source of metric support: depth along an image 
 
 No row dominates every task. Dense BEV says “represent the world”; object queries say “represent the candidate actors.” The important question is what evidence each representation has thrown away, and whether a later module can recover it.
 
-The decision does not end at BEV versus object queries. A driving stack also needs different output objects for different questions: tracks for agents with identity and motion, occupancy for free space and unmodelled geometry, and vector roadgraphs for lane topology and routing. [Occ3D](/paper%20shorts/2023/04/27/occ3d-large-scale-3d-occupancy-prediction-benchmark.html) makes the occupancy distinction concrete: every voxel is free, occupied, or unobserved, with semantics where they are known. That makes occupancy a useful interface for low obstacles and open-set geometry, but it does not by itself encode which lane centerline connects to the next intersection. [MapTR](/paper%20shorts/2022/08/30/maptr-structured-modeling-and-learning-for-online-vectorized-hd-map-construction.html) treats map elements as structured point sets instead. A credible shared state therefore need not force every consumer through one universal tensor; it needs compatible representations and an explicit account of what each one preserves.
+> **Deep insight:** A representation is an information budget. Dense BEV spends it on spatial coverage; object queries spend it on selected actors. The failure begins where that budget stops buying evidence.
 
-## Fusion: make the sensors meet in metric space
+The decision does not end at BEV versus object queries. A driving stack also needs different output objects for different questions: tracks for agents with identity and motion, occupancy for free space and unmodelled geometry, and vector roadgraphs for lane topology and routing. [Occ3D](https://arxiv.org/abs/2304.14365) makes the occupancy distinction concrete: every voxel is free, occupied, or unobserved, with semantics where they are known. That makes occupancy a useful interface for low obstacles and open-set geometry, but it does not by itself encode which lane centerline connects to the next intersection. [MapTR](https://arxiv.org/abs/2208.14437) treats map elements as structured point sets instead. A credible shared state therefore need not force every consumer through one universal tensor; it needs compatible representations and an explicit account of what each one preserves.
+
+## Fusion in metric space
 
 Once camera, LiDAR, and radar have metric support, the model must decide where they interact. Early fusion combines near-raw inputs, but pixels, points, and Doppler returns do not naturally share a representation. Late fusion combines independent object predictions, which is modular but loses feature-level complementarity. Intermediate fusion lets each sensor use its own encoder first, then aligns the resulting features and combines them. For heterogeneous driving sensors, this is the most useful conceptual baseline.
 
@@ -151,11 +153,9 @@ BEV becomes a natural meeting room because a camera feature at $(x,y)$ and a LiD
 [![Animation showing the same actor and lane evidence entering point, object-query, and dense-BEV fusion](/assets/images/autonomous-perception-fusion-granularity.gif)](/assets/images/autonomous-perception-fusion-granularity.gif)
 _Point fusion retains camera features only at measured points. Query fusion gathers evidence around selected actors. Dense BEV fusion keeps actor evidence and the surrounding lane or occupancy field._
 
-### Proposal-conditioned fusion and deeper interaction
+## Fusion around proposals
 
 The shared BEV path is not the only way to fuse. Proposal-based fusion spends compute selectively: [TransFusion](/paper%20shorts/2022/03/22/transfusion-robust-lidar-camera-fusion-with-transformers.html) uses LiDAR proposals to retrieve image evidence around candidate objects instead of trusting one calibrated pixel. This can be efficient and robust to small correspondence errors, but it exposes a structural failure mode. If LiDAR misses an object that the camera sees, a LiDAR-controlled proposal stage may never give the camera evidence a chance to recover it.
-
-> Proposal recall can become fusion recall. When one modality controls which hypotheses are allowed to gather cross-modal evidence, an upstream miss is no longer local to that sensor; it removes the recovery path from the rest of the model.
 
 [![Animation comparing LiDAR-controlled proposals, merged proposals from multiple modalities, and shared-BEV fusion before detection](/assets/images/autonomous-perception-proposal-recall.gif)](/assets/images/autonomous-perception-proposal-recall.gif)
 _Proposal-conditioned fusion is selective, but proposal recall can become a ceiling: a missed LiDAR proposal may prevent camera evidence from entering the refinement path. Multi-proposal fusion restores recall at the cost of matching and deduplication; shared BEV fusion preserves both modality fields before detection._
@@ -169,57 +169,22 @@ _BEVFusion keeps camera and LiDAR encoding separate until both modalities occupy
 
 The right fusion design therefore depends on the output and the failure being optimized. Point fusion is tied to measured support, proposal fusion is tied to query recall, and dense BEV fusion is tied to grid cost. The next problem is that even a good fused representation describes only the current sensor window.
 
-### Missing, degraded, and misaligned sensors
+### Missing and degraded sensors
 
 A fusion network trained only with all sensors often becomes dependent on the strongest stream. Zeroing LiDAR at inference does not turn such a network into a competent camera-only model. [UniBEV](/paper%20shorts/2023/09/25/unibev-robust-multimodal-detection-with-uniform-bev-encoders.html) demonstrates this directly: its model trained only in fused mode reaches 3.0 camera-only mAP in the reported ablation, while modality dropout and fusion normalized over the streams that remain produce a usable camera-only path. [MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html) similarly trains full, camera-only, and LiDAR-only modes and lets BEV queries attend to whichever encoders are available. Its reported missing-LiDAR result improves 35.5 NDS over a vanilla BEVFusion comparison, showing that graceful fallback is primarily a training-distribution and routing problem.
 
 [![Animation contrasting modality availability in UniBEV and MetaBEV with reliability gating in Grace-BEV](/assets/images/autonomous-perception-modality-dropout.gif)](/assets/images/autonomous-perception-modality-dropout.gif)
 _Modality dropout covers discrete cases in which a stream is absent. A reliability gate is needed for the harder case shown in the final phase: the camera still arrives, but its evidence is degraded and should receive less weight._
 
-Sensor absence is only one failure mode. Blur, saturation, fog, reduced LiDAR beams, blocked fields of view, packet delay, and calibration drift leave a tensor present but unreliable. [Grace-BEV](/paper%20shorts/2026/05/29/grace-bev-graceful-degradation-under-sensor-failures.html) adds reliability-aware gating, while [MetaBEV](/paper%20shorts/2023/04/19/metabev-solving-sensor-failures-for-bev-perception.html) evaluates several corruptions in addition to missing streams. A production model needs both mechanisms: modality dropout for supported sensor configurations, and corruption training plus an observable health signal for partial degradation. Calibration noise should be included as a separate test because every projected association can be confidently wrong in the same direction.
+Sensor absence is only one failure mode. Blur, saturation, fog, reduced LiDAR beams, blocked fields of view, packet delay, and calibration drift leave a tensor present but unreliable. [Grace-BEV](/paper%20shorts/2026/05/29/grace-bev-graceful-degradation-under-sensor-failures.html) adds reliability-aware gating, while [MetaBEV](https://openaccess.thecvf.com/content/ICCV2023/html/Ge_MetaBEV_Solving_Sensor_Failures_for_3D_Detection_and_Map_Segmentation_ICCV_2023_paper.html) evaluates several corruptions in addition to missing streams. A production model needs both mechanisms: modality dropout for supported sensor configurations, and corruption training plus an observable health signal for partial degradation. Calibration noise should be included as a separate test because every projected association can be confidently wrong in the same direction.
 
-### Shared representations create shared failures
-
-A unified representation becomes most revealing when several outputs fail together. If detection, occupancy, and mapping break on the same frames—especially around construction zones, temporary lanes, unusual road geometry, or calibration perturbations—the shared projection into BEV is a stronger first hypothesis than three independent head bugs. The useful comparison is before and after that boundary: do LiDAR points still align with camera edges and object centers, does radar support the same actor locations, and does the disagreement appear inside each modality or only after projection and fusion? Correlated failures tell us where to look.
-
-> When several heads become wrong in the same place, ask which shared transformation could have made them agree on the wrong scene.
-
-That diagnosis changes what “more data” should mean. The model needs more examples of the geometry it misunderstands—construction zones, temporary lane layouts, unusual intersections—but it also needs examples in which the geometry is observed through imperfect calibration. A simple training perturbation replaces the nominal sensor-to-ego transform with
-
-$$
-T'_{\text{sensor}\rightarrow\text{ego}}
-=T_{\text{sensor}\rightarrow\text{ego}}\,\Delta T,
-$$
-
-where $\Delta T$ is a small sampled translation and rotation. The two interventions are complementary. More unusual roads do not teach tolerance to a shifted camera, and calibration noise on ordinary roads does not teach the topology of a temporary lane split.
-
-Data augmentation still leaves a conceptual problem: most projectors treat the destination of a feature as exact. We usually write
-
-$$
-p_{\text{BEV}}=\Pi(x;K,T),
-$$
-
-even though depth, calibration, ego pose, and timing all introduce uncertainty. The more honest object is
-
-$$
-p_{\text{BEV}}\sim P\!\left(p\mid x,K,T,\Sigma\right).
-$$
-
-This does not require a fully probabilistic projector. It requires the model to carry the evidence that projection may be wrong: depth confidence, calibration health, sensor-validity masks, timestamp uncertainty, and local agreement between modalities. Fusion can then treat cross-modal disagreement as information and reduce the influence of a feature whose geometry is inconsistent, rather than forcing every feature into a common grid with equal confidence.
-
-The same argument applies after fusion. A shared BEV saves compute and gives tasks a common scene, but it also gives one corrupted tensor a wide blast radius. Duplicating the full perception stack would throw away the benefit of sharing. A narrower compromise is to keep lightweight residual paths from modality-specific features or pre-fusion BEV maps into critical heads: enough camera or LiDAR evidence for a head to question the shared state, not enough to rebuild perception twice.
-
-> A shared representation should be an information interface, not a single point of unquestioned truth. Preserve confidence into fusion and a narrow independent path into critical tasks so one geometric error does not have to become every task's error.
-
-Those residual paths matter only if training makes them useful when the shared path is wrong. The result to watch is not merely average accuracy, but whether targeted geometry and calibration failures become less severe and less correlated across tasks. The next boundary makes this harder: once a bad fused feature enters temporal memory, a one-frame alignment error can outlive the sensor measurement that caused it.
-
-## Time: sparse objects or a dense scene?
+## Time: objects or scene?
 
 Camera features and a single LiDAR sweep do not directly provide a complete object velocity, preserve evidence through an occlusion, or stabilize a noisy depth estimate. Radar supplies radial velocity, but not the full motion state of every actor. Temporal modeling fills the remaining gap by comparing evidence across frames. Old features must first be expressed in the current coordinate frame: ego-motion compensation aligns roads and static structures, while independently moving actors require velocity or learned motion updates. Timestamp error, pose error, and rolling-shutter effects appear as residual motion after alignment.
 
 Dense temporal memory stores scene-level BEV features. [BEVDet4D](/paper%20shorts/2022/03/31/bevdet4d-temporal-cues-in-multicamera-3d-detection.html) warps the previous BEV feature into the current ego frame, concatenates it with the current feature, and lets a BEV encoder learn displacement cues. [BEVFormer](/paper%20shorts/2022/03/31/bevformer-learning-birds-eye-view-representation-from-multi-camera-images-via-spatiotemporal-transformers.html) uses temporal attention to update a recurrent BEV field. [SOLOFusion](/paper%20shorts/2022/10/05/solofusion-temporal-multiview-3d-object-detection.html) keeps a short high-resolution history for fine stereo correspondence and a longer low-resolution BEV history for depth and velocity. Dense state retains roads, free space, and weak background evidence that may later support a new detection, but its memory and warp cost scale with BEV area and history.
 
-Sparse temporal memory stores selected objects or queries. The StreamPETR queue introduced above is the clearest example: it keeps a bounded set of foreground representations and introduces fresh queries for actors not already in memory. [Sparse4D v2](/paper%20shorts/2023/05/23/sparse4dv2-recurrent-temporal-fusion-with-sparse-model.html) transforms prior instances into the current frame and combines them with fresh anchors. Sparse memory is lighter and naturally object-centric, but it can discard free space, road structure, undetected objects, and context that has not yet become a confident query.
+Sparse temporal memory stores selected objects or queries. The StreamPETR queue from the sparse-3D section is the clearest example: it keeps a bounded set of foreground representations and introduces fresh queries for actors not already in memory. [Sparse4D v2](/paper%20shorts/2023/05/23/sparse4dv2-recurrent-temporal-fusion-with-sparse-model.html) transforms prior instances into the current frame and combines them with fresh anchors. Sparse memory is lighter and naturally object-centric, but it can discard free space, road structure, undetected objects, and context that has not yet become a confident query.
 
 [![Animation comparing a warped dense BEV field, transformed recurrent instances with fresh anchors, and a bounded foreground-query queue](/assets/images/autonomous-perception-temporal-memory.gif)](/assets/images/autonomous-perception-temporal-memory.gif)
 _Dense recurrence carries every BEV cell. Sparse4D v2 transforms recurrent object instances and adds fresh anchors. StreamPETR carries a bounded queue of foreground queries and introduces new queries for actors that were not already in memory._
@@ -229,11 +194,9 @@ _StreamPETR transforms selected object queries into the current frame, updates t
 
 [SparseBEV](/paper%20shorts/2023/08/18/sparsebev-high-performance-sparse-3d-object-detection.html) keeps sparse object support but retrieves from several stored frames, so its cost still grows with history length. “Sparse temporal” can therefore mean compressing history into recurrent state or retaining history and reading only selected locations; the two designs have different memory, latency, and error-accumulation behavior. StreamPETR remembers objects; SOLOFusion remembers the scene.
 
-> Temporal memory converts a transient error into persistent state. A stale query, bad ego-motion warp, or timestamp offset can survive after the originating measurement disappears, so every recurrent representation needs explicit freshness, aging, and reset behavior.
-
 Sparsity should be reported per component. A sparse LiDAR backbone avoids empty voxels; a sparse camera decoder avoids a full BEV field; a sparse temporal model avoids replaying every frame. None of them removes the dense surround-camera backbone. Sparse operators also pay for indexing, sorting, padding, gathers, and irregular memory access. FLOPs are therefore insufficient: the relevant deployment measurements are component latency, peak memory, P95/P99 end-to-end latency, active-token count in crowded scenes, and recall when the query budget saturates.
 
-## Training contracts shape the deployed model
+## Training is not deployment
 
 The runtime sensor graph is not always the training sensor graph. In [BEVDepth](/paper%20shorts/2022/06/21/bevdepth-acquisition-of-reliable-depth-for-multiview-3d-detection.html), projected LiDAR supervises camera depth and disappears at inference. In [Sparse-to-Dense](/paper%20shorts/2017/09/21/sparse-to-dense-depth-prediction-from-sparse-depth-and-rgb.html), sparse depth remains a deployed input. In [CRKD](/paper%20shorts/2024/06/17/crkd-camera-radar-distillation-from-lidar-camera.html), a camera-LiDAR teacher transfers features, relations, and outputs to a camera-radar student. These systems should not all be described as “using LiDAR”; they have different runtime contracts.
 
@@ -247,9 +210,9 @@ The same BEV feature may feed detection, occupancy, lanes, velocity, tracking, a
 [![Animation comparing loss-scale weighting, GradNorm's training-rate targets, and PCGrad's projection of conflicting gradients](/assets/images/autonomous-perception-multitask-gradients.gif)](/assets/images/autonomous-perception-multitask-gradients.gif)
 _Loss weighting changes gradient magnitude; GradNorm adjusts weights using relative training rates; PCGrad changes direction when task gradients conflict. These methods solve different problems._
 
-## Beyond BEV and queries: a compressed world state
+## Compress the world state
 
-Dense BEV memory preserves spatial structure, while sparse queries preserve selected actors. The next compression step is a smaller learned state that does not collapse the scene into one undifferentiated vector.
+Dense BEV memory preserves a great deal of spatial structure, while sparse queries preserve selected actors. A natural next question is whether the world can be compressed into a smaller learned state without collapsing it into one undifferentiated vector.
 
 [![Animation comparing dense BEV memory, sparse object queries, learned latent tokens, and a single pooled embedding](/assets/images/autonomous-perception-latent-memory.gif)](/assets/images/autonomous-perception-latent-memory.gif)
 _The compression ladder keeps the scene fixed while changing what persists: every BEV cell, selected actors, a small learned token set, or one pooled vector. The further right the representation moves, the more the model must learn which spatial evidence is worth retaining._
@@ -262,7 +225,7 @@ $$
 
 The tokens are a bottleneck: the model must learn which parts of the observation are worth carrying forward for perception, forecasting, or planning. This is related to Perceiver-style bottlenecks, token compression, memory tokens, and latent world models. The benefit is compute that scales with the number of latents rather than every BEV cell or every stored object query.
 
-[Driving on Registers](/paper%20shorts/2026/01/08/driving-on-registers.html) gives a useful planning-oriented example of this choice. It uses camera-aware register tokens to compress multiview ViT features into a compact scene representation, then keeps candidate-trajectory generation separate from scoring. The result is not evidence that a compact token set replaces metric state for every driving task; it is evidence that compression can be task-aware when the downstream contract is explicit. A planner may need a few scene tokens to rank candidate maneuvers, while a validator still needs object, occupancy, and roadgraph state it can inspect geometrically.
+[Driving on Registers](https://arxiv.org/abs/2601.05083) gives a useful planning-oriented example of this choice. It uses camera-aware register tokens to compress multiview ViT features into a compact scene representation, then keeps candidate-trajectory generation separate from scoring. The result is not evidence that a compact token set replaces metric state for every driving task; it is evidence that compression can be task-aware when the downstream contract is explicit. A planner may need a few scene tokens to rank candidate maneuvers, while a validator still needs object, occupancy, and roadgraph state it can inspect geometrically.
 
 Mean-pooling the entire map into one embedding is usually too aggressive for driving. One vector would need to preserve a pedestrian on the left, a stop sign 30 meters ahead, the curvature of the lane, a cyclist approaching from behind, an occluded vehicle, and the free-space topology. Mean pooling removes explicit spatial separation and is better suited to “what kind of scene is this?” than “where exactly is the pedestrian relative to the ego vehicle?”
 
@@ -272,13 +235,13 @@ dense BEV memory → sparse object memory → learned latent memory → single p
 
 Moving right saves memory and compute, but also increases the burden on the learning objective to decide what information matters. The central architectural question returns here in its most compressed form: what is discarded, at what stage, and can a downstream task recover it?
 
-## From perception to a driving foundation model
+## Toward a driving foundation model
 
 The research direction is moving from separate heads toward systems that share state across perception, prediction, simulation, and planning. That is “unified” in four distinct senses: sensors meet in a common geometric frame; time updates a persistent world state; tasks consume compatible state rather than reconstructing it independently; and the Driver, Simulator, and Critic reuse the same semantics. Sharing any one of those does not imply the others.
 
-[UniAD](/paper%20shorts/2022/12/20/uniad-planning-oriented-autonomous-driving.html) makes task sharing planning-oriented: its perception and prediction tasks communicate through unified query interfaces so that their learned state is optimized for the final driving task. [DiffusionDrive](/paper%20shorts/2024/11/22/diffusiondrive-truncated-diffusion-model-for-end-to-end-autonomous-driving.html) changes the planning contract instead, using a short, anchored diffusion process to generate multiple plausible trajectories. [WPT](/paper%20shorts/2025/11/25/wpt-world-to-policy-transfer-via-online-world-model-distillation.html) provides the complementary deployment lesson: a rich online world-model teacher can train a lightweight student policy without retaining the teacher's full runtime graph. These are different transitions—task sharing, multimodal action generation, and teacher-to-student transfer—not interchangeable evidence for a single architectural recipe.
+[UniAD](https://arxiv.org/abs/2212.10156) makes task sharing planning-oriented: its perception and prediction tasks communicate through unified query interfaces so that their learned state is optimized for the final driving task. [DiffusionDrive](https://arxiv.org/abs/2411.15139) changes the planning contract instead, using a short, anchored diffusion process to generate multiple plausible trajectories. [WPT](https://openaccess.thecvf.com/content/CVPR2026/html/Jiang_WPT_World-to-Policy_Transfer_via_Online_World_Model_Distillation_CVPR_2026_paper.html) provides the complementary deployment lesson: a rich online world-model teacher can train a lightweight student policy without retaining the teacher's full runtime graph. These are different transitions—task sharing, multimodal action generation, and teacher-to-student transfer—not interchangeable evidence for a single architectural recipe.
 
-### What Waymo has publicly described
+### Waymo's public design
 
 Waymo has described one version of this system-level design. Its public account names a Sensor Fusion Encoder, a Driving VLM, and a World Decoder; it says the first fuses camera, LiDAR, and radar evidence over time, while the second contributes semantic reasoning for rare or complex situations. Both feed the World Decoder, which Waymo says predicts road-user behavior, produces maps and vehicle trajectories, and emits signals for trajectory validation. This is a useful public architecture description, not a specification of every deployed online component.
 
@@ -295,13 +258,13 @@ The three blocks have different roles:
 
 Waymo also describes a second boundary that is easy to miss: its learned embeddings coexist with compact materialized state, including objects, semantic attributes, and roadgraph elements. It says this structured state supports onboard validation, efficient simulation, and feedback from the Critic. It further describes adapting the foundation model into large Driver, Simulator, and Critic teachers, then distilling smaller student models; the Driver retains a separate onboard trajectory-validation layer. Those claims establish the intended contracts, but they do not reveal the exact online graph or demonstrate closed-loop safety by themselves.
 
-### A concrete system design
+### A concrete design
 
 My read is that the most credible design is hybrid at every important boundary. The fast path should own calibrated geometry, sensor health, freshness, occupancy, tracks, and roadgraph state. A slower VLM should emit grounded semantic hypotheses with confidence and expiry—not unrestricted driving instructions—so its contribution can be fused with, or rejected by, the metric state. Materialized state should coexist with high-bandwidth learned embeddings: the latter preserve nuance for learning, while the former gives a validator an inspectable object to check.
 
 The World Decoder should predict multiple plausible agent futures and ego trajectories rather than one averaged continuation. Generation, scoring, and validation should remain distinct contracts: generate candidate futures, score them against task objectives and uncertainty, then validate the selected trajectory against the materialized state and independent safety constraints. Large world-model and VLM teachers can improve the training signal, but the onboard student must be evaluated as the deployed model. The Driver, Simulator, and Critic should share state semantics rather than merely sharing a large encoder.
 
-That design creates a practical evaluation agenda. Test corrupt and stale sensors separately; report when the query or latent-token budget saturates; measure whether a semantic hypothesis is grounded in the relevant metric state; quantify multimodal future coverage rather than only a mean trajectory error; report P95/P99 end-to-end latency; and log every validator intervention. A result is much less persuasive if it improves one open-loop score while hiding a failure in any of those contracts.
+That design creates a practical evaluation agenda. Test corrupt and stale sensors separately. Report query or latent-token saturation, semantic grounding in metric state, multimodal future coverage, P95/P99 latency, and every validator intervention. A result is much less persuasive if it improves one open-loop score while hiding a failure in any of those contracts.
 
 The foundation-model label does not remove the engineering boundaries established earlier. Sensor encoders still have to preserve modality-specific evidence. Calibration and synchronization still determine whether features refer to the same place and time. Temporal state still needs freshness, birth, and reset rules. [Vision-Language Models: A Reading Guide](/blog/2026/07/05/from-seeing-to-doing-the-evolution-of-vision-language-models.html) covers the adjacent progression from image-text alignment to grounding, video, and action; the driving problem adds metric geometry, real-time recurrence, and closed-loop validation.
 

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -1,5 +1,5 @@
 ---
-title: 'How I Found My Way Into Robotics'
+title: 'The Long Way Into Robotics'
 date: '2025-02-08T05:00:00.000Z'
 section: blog
 blogGroup: essays
@@ -8,10 +8,11 @@ legacyPath: /blog/2025/02/08/my-journey-so-far-full-story.html
 tags:
   - Other
 summary: >-
-  How failure, projects, graduate school, and industry led me into robotics.
+  How failure, depression, hands-on projects, graduate school, DEKA, and Zoox
+  shaped my path into robotics and autonomous driving.
 ---
 
-# How I Found My Way Into Robotics
+# The Long Way Into Robotics
 
 In 2023, I gave [this interview](https://theinterviewportal.com/2024/01/21/perception-roboticist-interview/) about how I became a robotics engineer focused on perception. Looking back, the interview mostly captured the wins. It did not say much about the missteps, low points, and strange detours that shaped the path just as much. This is the fuller version, starting from the beginning.
 
@@ -19,17 +20,21 @@ In 2023, I gave [this interview](https://theinterviewportal.com/2024/01/21/perce
 
 I grew up in Jaipur, a city that shaped much of my early life. I lost my father when I was 5, but my mother and sisters surrounded me with so much love that I never felt like I was missing anything. I was still deeply introverted, and I escaped into games like DOTA and DOTA 2. I logged around **16,000** hours and even reached the **#16 rank in India** at one point. That obsession helped me cope, but it also taught me something useful: the same intensity, pointed at the real world, could probably take me somewhere. That realization eventually pulled me out of my shell and pushed me toward the US.
 
-Most of my schooling was in Jaipur, and like many aspiring engineers, I spent three intense years in Kota preparing for the JEE. Kota is often described as a **factory** ([Netflix show](https://www.netflix.com/title/81249783) / [Wiki](https://en.wikipedia.org/wiki/Kota_Factory)), and that description is not far off. The city runs on academic competition. It is also a perfect breeding ground for [Girard's mimetic theory of desire](https://en.wikipedia.org/wiki/Mimetic_theory), where students absorb each other's ambitions and anxieties until it becomes hard to tell what you actually want. Despite working hard, I did not clear the IIT exam. At 18, that failure felt crushing, like I had let everyone down after years of preparation. Even now, at 33, the memory still makes my body tense up.
+Most of my schooling was in Jaipur, and like many aspiring engineers, I spent three intense years in Kota preparing for the JEE. Kota is often described as a **factory** ([Netflix show](https://www.netflix.com/title/81249783) / [Wiki](https://en.wikipedia.org/wiki/Kota_Factory)), and that description is not far off. The city runs on academic competition. It is also a perfect breeding ground for [Girard's mimetic theory of desire](https://en.wikipedia.org/wiki/Mimetic_theory), where students absorb each other's ambitions and anxieties until it becomes hard to tell what you actually want.
+
+Despite working hard, I did not clear the IIT exam. At 18, that failure felt crushing, like I had let everyone down after years of preparation. Even now, at 33, the memory still makes my body tense up.
 
 The lesson was not simply to work harder. I had already worked hard in Kota. I had to learn that effort can still end in failure, that a failure can feel physically real without becoming a permanent verdict, and that an absorbing escape like DOTA can be both refuge and trap. Resilience began to mean choosing what to do after the result, not denying how much the result hurt.
 
-## Undergrad at MIT Manipal
+## MIT Manipal
 
 I stayed back an extra year, prepared again, and eventually got accepted to MIT, Manipal. It was not an IIT, but it was a solid engineering school, and I had a chance to reset. I did not use that chance immediately. I stayed in my introverted shell, played even more DOTA, often 6-8 hours a day, and picked up smoking cigarettes, which is still the worst habit I have ever had. I skipped many classes during my first two years, and at one point my cumulative GPA was 0.74, not out of 4, but out of 10.
 
 Seeing 0.74 on my report card broke something inside me, but in a useful way. It was a wake-up call. I started going to class, made a few new friends, and began working seriously. I stopped missing lectures, stayed over the summer, and put in the kind of effort I had once reserved for games. By the end of my third year, I had raised my GPA from 0.74 to 7.8. I kept pushing, eventually earned the highest marks in the toughest subject in the course, and got a recommendation for grad school from the head of the department.
 
-My undergrad degree was in Mechatronics Engineering. The theory was fine, but the projects were what pulled me in. That is where I got my first real taste of robotics. In my final year, a couple of friends and I built an areca-nut harvesting robot for our thesis. Areca nut trees are about 30 feet tall, and many harvesters in India climb them by hand. The work is dangerous and causes accidents and fatalities every year. We wanted to make harvesting safer, so we built a rough prototype that could climb the tree and cut the nuts while being controlled with a PlayStation controller.
+My undergrad degree was in Mechatronics Engineering. The theory was fine, but the projects pulled me in. That is where I got my first real taste of robotics.
+
+In my final year, a couple of friends and I built an areca-nut harvesting robot for our thesis. Areca nut trees are about 30 feet tall, and many harvesters in India climb them by hand. The work is dangerous and causes accidents and fatalities every year. We wanted to make harvesting safer, so we built a rough prototype that could climb the tree and cut the nuts while being controlled with a PlayStation controller.
 
 In a bit of a comical twist, we accidentally broke the robot just before filming our final video. So, in a moment of resourcefulness, we filmed it descending the tree, then reversed the footage in editing, and submitted it as our final presentation. We ended up getting an A!
 
@@ -42,13 +47,11 @@ Undergrad changed my direction because the late start still compounded. The GPA 
 
 ## Depression
 
-I think it is as important to acknowledge the lows as it is to celebrate the highs. The lows often teach more, if you can look at them honestly. After college, I went through a period of depression. It was not easy. Depression is better understood in India today than it was a decade ago, but at the time people around me often had no language for it. More than once, when I said I did not feel like getting up or leaving my room, someone told me, "Just take a cold shower; you'll be fine." I wish I could have explained what was happening inside: my brain felt like it was on fire, I felt like screaming from the inside, and I could not see a way out. I am sharing this because someone reading it may need to know they are not alone.
+After college, I went through depression. It is better understood in India today than it was a decade ago, but people around me often had no language for it. More than once, when I said I did not feel like getting up or leaving my room, someone told me, "Just take a cold shower; you'll be fine." I wish I could have explained what was happening inside: my brain felt like it was on fire, I felt like screaming from the inside, and I could not see a way out. I am sharing this because someone reading it may need to know they are not alone.
 
-So, here goes...
+After graduation, I had my heart set on pursuing a master's degree in Germany. The education was free, and many of my friends were heading there—naturally, it seemed like the best reason to go. I returned to Jaipur for what was supposed to be a brief stay, with one goal: apply to colleges in Germany and leave within six months. I took the GRE, prepared my applications, and applied to a few universities, including an ultra-safe option to ensure I'd get in. When the day came, I mailed all five applications together, confident about my future.
 
-After graduation, I had my heart set on pursuing a master's degree in Germany. The education was free, and many of my friends were heading there - naturally, it seemed like the best reason to go. I returned to Jaipur for what was supposed to be a brief stay, with one goal: apply to colleges in Germany and leave within six months. I took the GRE, prepared my applications, and applied to a few universities, including an ultra-safe option to ensure I'd get in. When the day came, I mailed all five applications together, confident about my future.
-
-A month later, I was anxiously waiting for the results. Then, I received an email from my safe school. I opened it, expecting good news, only to read that I was being rejected for missing documents. To my horror, I realized I had accidentally sent the documents meant for the safe school to another university. Slowly, the rejection emails from all five universities trickled in, and the reality set in - I wasn't going to Germany.
+A month later, I was anxiously waiting for the results. Then, I received an email from my safe school. I opened it, expecting good news, only to read that I was being rejected for missing documents. To my horror, I realized I had accidentally sent the documents meant for the safe school to another university. Slowly, the rejection emails from all five universities trickled in, and the reality set in—I wasn't going to Germany.
 
 ![The missing-documents rejection notice that exposed my application mix-up](/assets/images/tuhh.png)
 _The rejection notice that exposed the document mix-up across my German university applications. Source: personal archive._
@@ -65,13 +68,17 @@ I was accepted into three schools. I still remember rereading the first acceptan
 
 Recovery did not arrive as one clean insight. Friends changed my immediate environment, loss changed my sense of time, and robotics supplied a direction concrete enough to act on. Purpose did not make depression trivial; it made the next application, course, or volunteer shift easier to choose. The application mix-up also left me with a practical habit I still keep: verify the mundane details and preserve a backup path, because an administrative error can be as consequential as an academic one.
 
-## Graduate school at Mines
+## Colorado School of Mines
 
 In 2016, I moved to the United States for a Master's degree in Robotics at the Colorado School of Mines (CSM). CSM is a relatively small STEM school, but the program was demanding. During the first few months I felt out of place. The culture was new, the academic environment was unfamiliar, and even the classroom style felt different. As an introvert, the adjustment was hard. Over time, I found my rhythm and began to genuinely enjoy learning.
 
-Before the start of the semester, I looked for on-campus opportunities to become self-reliant as soon as possible. I was persistent in checking the listing board and eventually landed a teaching assistant position. As a TA, I assisted the professor in grading and administrative tasks. It wasn't the most educational role, but it served its purpose. I was also intentional about my goals for the grad program. I knew I wanted to explore robotics and learn how to code, so I tailored my coursework accordingly. I worked hard in my first semester and took a challenging robotics course with Dr. Andrew Petruska, a new professor who was instrumental in building the robotics program at Mines. By excelling in his course, I secured a research assistant position in his lab.
+Before the semester started, I looked for on-campus work so I could become self-reliant. I checked the listing board persistently and eventually landed a teaching assistant position. The grading and administrative work was not especially educational, but the job served its purpose.
 
-In my second semester, I joined Dr. Petruska's lab as a research assistant. Initially, I worked on a project involving magnetic manipulation, but I quickly realized it wasn't something I was passionate about, and my lack of progress reflected that. In my free time, I spent countless hours tinkering with the Husky robot in the lab, even writing my own ROS packages to make it move. Dr. Petruska noticed my interest and transitioned me to that project. That change made all the difference. The lab became my second home, and I spent more time there than at my apartment. I focused on learning the basics and building a solid foundation in C++ programming and ROS. Curiosity was key. One funny story I remember is when we short-circuited the entire onboard compute stack and spent a couple of weeks putting it back together from scratch. It was a lot of fun and a great learning experience.
+I was more deliberate about the degree itself. I wanted to explore robotics and learn to code, so I tailored my coursework around those goals. In my first semester, I took a challenging robotics course with Dr. Andrew Petruska, who was helping build the robotics program at Mines. Excelling in his course earned me a research assistant position in his lab.
+
+In my second semester, I joined Dr. Petruska's lab as a research assistant. I first worked on magnetic manipulation, but the problem did not hold my interest, and my lack of progress showed it. In my free time, I spent countless hours tinkering with the Husky robot and writing my own Robot Operating System (ROS) packages to make it move. Dr. Petruska noticed and moved me onto that project. That change made all the difference.
+
+The lab became my second home. I focused on C++ and ROS, then tested what I learned on the physical system. We once short-circuited the entire onboard compute stack and spent two weeks rebuilding it from scratch. Even the failure was fun because every repair exposed another layer of the robot.
 
 ![Working beside the Clearpath Husky robot in the Colorado School of Mines lab](/assets/images/me_in_lab.jpeg)
 _Working with the Husky platform in the Colorado School of Mines robotics lab. Source: personal archive._
@@ -87,7 +94,7 @@ _The hexapod project paired a 1D LiDAR and Pixy camera with a small mobile platf
 
 Looking back, the best thing I did was build a strong foundation in the skills I cared about and then find practical ways to use them. Grades mattered, but the projects I took on, the problems I solved, and the people I learned from shaped me more. My advice to current graduate students is simple: take on projects that stretch you, use the resources around you, and follow problems that genuinely excite you. That is how progress starts to compound.
 
-## Job search after graduate school
+## Getting hired
 
 Landing your first job out of grad school in the U.S. can be difficult, especially if you want the dream job immediately and you are not coming from a top university. Even if you spent grad school building skills, doing research, and working on relevant projects, the search can still be tough. These are the things that helped me:
 
@@ -124,6 +131,8 @@ One part of that work I am particularly proud of is where it began. Around the m
 
 That transition—from a side project to a team—also changed my role. Moving from an IC role back into technical leadership was intentional. By then, I had enough experience under my belt to be useful in both modes: I could go deep on the hard technical decisions, but I could also set direction, explain tradeoffs, and help other people execute. I also participate in a broader research committee across Zoox, which gives me exposure to technical direction outside my immediate area.
 
-## Looking Back
+> **Deep insight:** Confidence was usually the lagging indicator. I acted before I felt ready, and the evidence from small wins changed what I believed I could do.
 
-> The path was less a sequence of triumphs than a sequence of redirects: the IIT exam changed where I studied, a collapsed GPA forced a rebuild, and a mailing mistake eventually opened the United States. The transferable lesson is not that setbacks are secretly good; it is that a credible next attempt requires focused skill-building before confidence arrives.
+## Looking back
+
+Looking back, the path is less a sequence of triumphs than a sequence of redirects. Failing the IIT exam changed where I studied. A collapsed GPA forced me to rebuild. A mailing mistake closed Germany and eventually opened the United States. Work that initially felt beyond me became a patent, then a route into autonomous driving. The common thread is not that every setback was secretly good. Some were simply painful. What mattered was learning to attach intensity to a problem I cared about, build enough skill to make the next attempt credible, and let small wins accumulate before confidence arrived.

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -1,5 +1,5 @@
 ---
-title: 'How Multimodal Robot Models Are Pretrained'
+title: 'What a Robot Learns Before It Acts'
 date: '2026-07-15T09:00:00.000Z'
 section: blog
 blogGroup: research-guides
@@ -9,14 +9,14 @@ tags:
   - Multimodal AI
   - Pretraining
   - Research Leadership
-summary: The key decisions behind pretraining multimodal robot policies.
+summary: How representations, robot data, action interfaces, objective mixtures, and scaling experiments determine a multimodal robot policy.
 ---
 
-# How Multimodal Robot Models Are Pretrained
+# What a Robot Learns Before It Acts
 
 A robot can inherit the word “drawer” from the internet. The internet does not tell it how a sticky drawer feels, how far a particular arm can reach, or what to do after the gripper slips. Multimodal pretraining works because semantic and motor experience can transfer. It fails when “put everything in one model” becomes a substitute for deciding what should transfer, through which parameters, and under what evidence.
 
-> The decisive choices arrive before the large run: representation, prediction target, data-accounting unit, and gradient allocation. A shared trunk can enable transfer while a high-volume modality quietly controls every update, so “one model” is not evidence of balanced learning.
+The hard choices arrive before the large run. An image can become patches, semantic features, discrete codes, or continuous latents. A robot trajectory can become per-axis bins, compressed action tokens, a diffusion target, or a flow field. A dataset mixture can be counted in examples, tokens, FLOPs, or gradient share; those allocations are not equivalent. A shared trunk can enable transfer while one high-volume modality quietly controls every update.
 
 This guide is about making those choices legible. Its central claim is that a VLA is not created by adding an action head to a VLM. It is created by combining three priors—semantic, visual, and motor—without letting the cheapest one erase the others.
 
@@ -24,7 +24,7 @@ This is Part II of the series. [Part I](/blog/2026/07/05/from-seeing-to-doing-th
 
 The scope is pretraining design, not a catalog of multimodal models. I use papers in two ways: reported experiments establish what happened inside a particular recipe; the decision tests, kill criteria, and preferred architecture are my synthesis. Keeping that boundary visible matters because multimodal papers often change the tokenizer, data, parameter count, and training budget together. A strong result can justify adopting a recipe without identifying which ingredient caused the gain.
 
-## Capability requirements
+## Capabilities
 
 “Multimodal” is not a capability. A contrastive encoder, visual assistant, image generator, video predictor, and robot policy can all consume images and text while solving different problems.
 
@@ -42,7 +42,7 @@ The contract determines what must be shared. [CLIP](/paper%20shorts/2021/02/28/l
 
 No architecture dominates those contracts for free. Before comparing models, write down which behavior must work zero-shot, which can be adapted with a small target dataset, which control rate is non-negotiable, and which regression would kill the program. A vague contract makes every later ablation look positive.
 
-## Robot data and web data
+## Robot data
 
 Internet data offers extraordinary breadth because images and text are cheap to copy. Robot trajectories are expensive, correlated, and attached to hardware. An hour of teleoperation contains the operator's habits, the controller's smoothing, the camera calibration, the reset procedure, and the parts of the state that happened to be logged. “More trajectories” can mean more task coverage, more embodiments, or simply more repetitions of one narrow behavior.
 
@@ -62,7 +62,7 @@ Cross-embodiment learning therefore needs an explicit interface contract. Which 
 
 The most useful dataset table is not trajectory count. It reports task entropy, scene entropy, embodiment coverage, operator coverage, success and recovery rates, control frequencies, action normalization, missing modalities, and effective unique windows after temporal overlap. Those quantities tell you what generalization the corpus can plausibly support.
 
-## Training representations
+## Training units
 
 Before choosing transformer depth, decide what counts as one training unit.
 
@@ -74,7 +74,7 @@ The unit determines sequence length, and sequence length determines attention co
 
 The first useful budget is therefore not “percentage of image data.” It is tokens or FLOPs per capability gain. A 10% video mixture can consume most of the compute if every clip expands into thousands of visual tokens.
 
-### Representations for understanding and generation
+### Understanding versus generation
 
 Understanding rewards invariance. A classifier should ignore texture changes that preserve object identity. Generation punishes lost detail. A tokenizer optimized for semantic invariance can be a poor reconstruction code; a pixel-faithful code can waste sequence budget on information irrelevant to reasoning.
 
@@ -91,7 +91,7 @@ Those designs are three answers to one question: where should modality specializ
 
 The kill experiment is matched compute and matched sequence length. If separate routes win only because they add parameters or visual tokens, the result is capacity, not reduced interference.
 
-## Cross-modal parameter sharing
+## Shared parameters
 
 Architectures often get labeled “early fusion” or “late fusion,” but the operational choices are more granular:
 
@@ -119,7 +119,7 @@ Every cell should report transfer under a matched compute budget, along with gra
 
 This is where [MM1](/paper%20shorts/2024/03/14/mm1-methods-analysis-and-insights-from-multimodal-llm-pre-training.html) is so useful. Its controlled studies suggest that image encoder quality, resolution, visual-token count, and data composition matter more than endlessly modifying the connector. That is an experiment-allocation result: sweep the variables with large causal leverage before polishing the bridge between them.
 
-## Multi-objective training
+## Objectives
 
 A unified transformer does not require a unified objective.
 
@@ -140,7 +140,7 @@ The figure makes the accounting problem concrete with an illustrative equal-exam
 
 *Equal sampled-example shares need not produce equal predicted units, FLOPs, or update norms. Video and action sequences expand differently before they reach shared parameters, so one percentage cannot describe the mixture. Custom explanatory synthesis informed by the controlled data and architecture studies in [MM1](https://arxiv.org/abs/2403.09611), [Scaling Laws for Generative Mixed-Modal Language Models](https://arxiv.org/abs/2301.03728), [Scaling Laws for Optimal Data Mixtures](https://arxiv.org/abs/2507.09404), and [Pi0](https://arxiv.org/abs/2410.24164). Values are illustrative, not paper-reported measurements.*
 
-The deepest error is treating a dataloader share as the amount of learning a modality receives. Sequence expansion decides how many targets are predicted. Representation and model path decide how much compute they consume. Gradient scale and alignment decide how strongly they move the shared trunk. A 10% video sample share can therefore dominate shared updates, while thousands of overlapping robot windows can look numerous without representing thousands of independent decisions.
+> **Deep insight:** A dataloader share is not a learning share. Sequence expansion sets the target count, the model path sets compute, and gradient alignment decides who moves the shared trunk.
 
 Normalize and log at three levels:
 
@@ -152,7 +152,7 @@ Then measure parameter-level conflict. If video gradients are ten times larger i
 
 This distinction becomes acute in robotics. Overlapping windows from one trajectory can produce thousands of training examples without thousands of independent decisions. A long action chunk can contribute many supervised dimensions while representing one correlated maneuver. The cleanest dashboard keeps four ledgers side by side: sampled examples, predicted units, consumed FLOPs, and update norm by module. A mixture is balanced only relative to a capability objective, not because its percentages sum to 100.
 
-## Data mixture design
+## Mixtures
 
 An omni corpus is not a pile of datasets. It is a sampling policy over modalities, domains, quality levels, sequence lengths, and training stages.
 
@@ -172,13 +172,13 @@ The proxy study should vary:
 
 Report uncertainty on extrapolated rankings, not only fitted loss. The expensive decision is whether candidate A will still beat candidate B at target scale. If confidence intervals overlap, the proxy run did not justify a nine-figure allocation.
 
-### Training curricula
+### Curriculum
 
 Data mixtures are often nonstationary. A model may first learn vision-language alignment, then high-resolution grounding, then video, then action. [VideoLLaMA 3](/paper%20shorts/2025/01/01/videollama-3-frontier-multimodal-foundation-models.html) uses strong image-text alignment as the base for video and compresses redundant temporal tokens. [PaliGemma](/paper%20shorts/2024/07/10/paligemma-a-versatile-3b-vlm-for-transfer.html) upcycles resolution in stages. [Eagle 2](/paper%20shorts/2025/01/01/eagle-2-post-training-data-strategies-for-frontier-vision-language-models.html) shows how post-training ordering and curation can make a smaller VLM competitive.
 
 Order can reduce optimization difficulty, but it can also cause forgetting. A staged curriculum needs retention evals after every transition and a controlled comparison with an interleaved mixture under equal compute.
 
-## Video models and world models
+## Video is not a world model
 
 Video generation produces plausible futures. A world model preserves action-conditioned consequences. A policy chooses actions that achieve an outcome.
 
@@ -197,7 +197,7 @@ The evaluation contract must change when control enters. FID and visual preferen
 
 A model that produces a plausible door opening after any action is a video generator with weak conditioning, not a useful world model.
 
-## Action representations
+## Actions
 
 Actions change the data distribution, carry embodiment-specific units, and operate under a control deadline. Treating them as ordinary tokens hides those constraints behind a convenient interface.
 
@@ -218,7 +218,7 @@ The action-interface memo should compare:
 
 The pretraining question is which action prior should be learned across robots. The answer cannot be read from imitation loss alone. Reconstruct a short trajectory with each representation, compare spectral and contact-heavy errors, measure effective horizon and wall-clock control rate, and test whether a small target dataset can change the embodiment without erasing semantic transfer. The post-training question comes later: does the chosen distribution expose the likelihoods and responsiveness required by the improvement loop?
 
-## Testing scaling claims
+## Scaling claims
 
 A smooth curve is not the same as a causal law. Every scaling claim should name:
 
@@ -242,7 +242,7 @@ For every candidate architecture, write a kill criterion before the proxy runs:
 
 That habit converts paper reading into capital allocation.
 
-## Fault-tolerant training
+## Training failures
 
 Once the architecture and mixture are chosen, the research question becomes operational: can the training system preserve the intended experiment for months?
 
@@ -263,7 +263,7 @@ The runbook should cover:
 
 Every checkpoint must bind model state to optimizer, scheduler, data cursor, mixture policy, tokenizer, code commit, and evaluation config. A weight file without that lineage is not a recoverable experiment.
 
-## Proxy experiments before large runs
+## Proxy runs
 
 Before a massive run, build a 100M–1B prototype program with at least text prediction, image-text understanding, visual generation, and a lightweight video or action objective.
 
@@ -298,7 +298,7 @@ There is no single best order after the foundations. Choose a route based on the
 
 Then move to [Part III: Post-Training VLAs](/blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html). Pretraining decides what the policy can represent and which behaviors are nearby. Deployment reveals which nearby behaviors are actually useful.
 
-## The research thesis
+## A testable thesis
 
 The strongest multimodal robot model will probably not make every modality identical. It will share the parameters that benefit from transfer and specialize the interfaces where fidelity, time, geometry, and control impose different requirements.
 

--- a/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
@@ -10,7 +10,8 @@ tags:
   - Apple Silicon
   - Inference
 summary: >-
-  Which current open-weight models actually fit on a 64 GB Mac.
+  A current fit guide for Muse Glimmer, Ministral, Granite, Nemotron, Mistral
+  Small 4, and DeepSeek V4 Flash on a 64 GB Apple Silicon machine.
 ---
 # Which Current Open-Weight Models Fit on a 64 GB MacBook Pro?
 
@@ -33,9 +34,11 @@ This is a fit guide dated August 13, 2026. File sizes are from the linked model 
 
 “Comfortable” does not mean “load a 128K context for free.” It means the weights leave a credible working budget. The KV cache, Metal buffers, multimodal projector, speculative draft model, application processes, and macOS all draw from the same physical memory. A model whose files consume `60+ GB` is not a `64 GB` laptop model merely because the operating system can swap.
 
+> **Deep insight:** Model fit is an application budget, not a weight-file test. The useful model is the one that leaves memory for its context, runtime, tools, and the rest of the machine.
+
 I am using *open-weight* deliberately. These releases do not all use the same license, publish the same training information, or provide equally official Mac artifacts. A downloadable checkpoint is a deployment property, not a blanket claim that every part of the model is open source.
 
-## Muse Glimmer 30B is the interesting new default
+## Glimmer is the new default
 
 Meta's [`Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B) is a `29.6B` dense vision-language model with a `131K` context window. The official [GGUF repository](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF) makes the laptop decision unusually clean: the recommended `Q4_K_M` file is `16,756,683,904` bytes, while the higher-quality dynamic `Q4_K_XL` file is `19,653,960,832` bytes. Both leave far more headroom than this machine needs for text serving.
 
@@ -43,25 +46,25 @@ Vision adds an approximately `1.4 GB` multimodal projector. Meta also publishes 
 
 That does not make Glimmer automatically better than every smaller specialist. It makes it the model in this list whose capability envelope is widest without making the fit decision uncomfortable. With full Metal offload, I measured the official `17 GB` quant at `27.9 tok/s`, rising to `48.3 tok/s` with the official DFlash drafter in [my Glimmer benchmark](/blog/2026/08/13/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.html).
 
-## Ministral 3 14B is the low-friction choice
+## Ministral is low friction
 
 The official [`Ministral-3-14B-Instruct-2512-GGUF`](https://huggingface.co/mistralai/Ministral-3-14B-Instruct-2512-GGUF) repository provides a `Q4_K_M` file of `8,239,593,024` bytes. That is the healthiest memory ratio in the shortlist: the runtime can keep a useful context and still leave most of the machine available for an IDE, browser, retrieval index, and local tools.
 
 I would start here when multimodality and maximum model size are not requirements. A `14B` model that remains responsive inside a real application is more useful than a nominally stronger checkpoint that forces the laptop into memory pressure. This is a sizing recommendation; I have not put Ministral through the identical M5 Max harness yet.
 
-## Granite 4.1 30B is the text-and-tools alternative
+## Granite for text and tools
 
-IBM's official [`granite-4.1-30b-GGUF`](https://huggingface.co/ibm-granite/granite-4.1-30b-GGUF) release includes a `17,490,240,736`-byte `Q4_K_M` artifact. Its weight budget is almost the same as Glimmer's smaller quant, but the product decision is different: Granite is the text-centric candidate I would inspect for retrieval, tool use, and controlled enterprise workflows rather than for native image understanding.
+IBM's official [`granite-4.1-30b-GGUF`](https://huggingface.co/ibm-granite/granite-4.1-30b-GGUF) release includes a `17,490,240,736`-byte `Q4_K_M` artifact. Its weight budget is almost the same as Glimmer's smaller quant. The product decision differs: Granite is the text-centric candidate for retrieval, tool use, and controlled enterprise workflows, not native image understanding.
 
 The fit is easy; model selection still depends on the task. I would evaluate Granite on the actual retrieval documents, function schemas, and refusal behavior before replacing a known-good deployment. Capacity tells me it can participate in that evaluation, not that it wins it.
 
-## Nemotron fits only after a packaging decision
+## Nemotron needs a packaging choice
 
 NVIDIA's [`Nemotron-3-Nano-30B-A3B`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16) is a sparse model: roughly `30B` total parameters with about `3B` active per token. The official BF16 repository is approximately `63.2 GB`, which is not a credible `64 GB` deployment after runtime overhead. A community [4-bit MLX conversion](https://huggingface.co/mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit) is about `17.8 GB` and does fit.
 
 That distinction matters. I would use the conversion for experimentation, but I would record the converter, quantization settings, revision, and hashes in any reproducible deployment. “The model fits” and “the vendor ships an official Mac-ready artifact” are separate claims.
 
-## The two tempting models I would not force onto the Mac
+## Do not force these two
 
 Sparse activation does not rescue resident-weight capacity. The official [`Mistral-Small-4-119B-2603-NVFP4`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4) repository is about `70.8 GB`. Its `6B` active parameter count helps per-token compute, but the quantized expert bank still exceeds total unified memory before the runtime and cache exist.
 
@@ -77,4 +80,4 @@ For this `64 GB` M5 Max, my order is:
 4. Treat `Nemotron 3 Nano` as a community-quant experiment unless an official compressed artifact appears.
 5. Serve `Mistral Small 4` and `DeepSeek V4 Flash` elsewhere instead of turning SSD swap into an inference strategy.
 
-> The practical limit on a `64 GB` Mac is not parameter count. It is the headroom left after weights for context and the surrounding application. That makes an official `8–20 GB` quant a better default than a larger model that pushes serving into swap.
+My earlier [Gemma 4 benchmark](/blog/2026/04/04/running-gemma-4-locally-on-a-64-gb-macbook-pro.html) remains relevant if Gemma is already working well. The point of this list is not to replace a stable model every release cycle. It is to make the current capacity boundary explicit: on a `64 GB` Mac, the practical sweet spot is still an official `8–20 GB` quant with enough remaining memory for the context and the application around it.

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -1,5 +1,5 @@
 ---
-title: 'How Vision-Language-Action Models Improve After Deployment'
+title: 'When Robot Failure Becomes Training Data'
 date: '2026-07-16T10:00:00.000Z'
 section: blog
 blogGroup: research-guides
@@ -9,10 +9,10 @@ tags:
   - Robotics
   - Post-Training
   - Reinforcement Learning
-summary: How correction data, preferences, critics, and RL improve deployed robot policies.
+summary: How robot rollouts become justified policy updates through correction data, action preferences, process critics, interactive reinforcement learning, and real evaluation.
 ---
 
-# How Vision-Language-Action Models Improve After Deployment
+# When Robot Failure Becomes Training Data
 
 A robot fails while closing a drawer. The episode gives us an outcome: failure. It does not tell us whether the camera missed the handle, the language model chose the wrong subtask, the trajectory approached at a bad angle, the gripper slipped, or the success detector fired too early. Post-training begins in that gap between outcome and explanation.
 
@@ -20,7 +20,7 @@ This is why “make the pretrained model behave better” is an inadequate descr
 
 The right object is therefore not an optimizer. It is a closed-loop policy improvement system:
 
-`Base VLA → task SFT → deployment rollouts → failure mining → preference or reward supervision → policy optimization → real evaluation → redeployment`
+> Base VLA → task SFT → deployment rollouts → failure mining → preference or reward supervision → policy optimization → real evaluation → redeployment.
 
 The loop is the product. SFT, DPO, PPO, critics, and distillation are replaceable components inside it.
 
@@ -28,7 +28,7 @@ This is Part III of a three-part reading course. [Part I](/blog/2026/07/05/from-
 
 The scope is policy improvement after a broadly pretrained VLA exists. Paper-reported algorithms and results are the evidence layer. The failure taxonomy, evaluation pyramid, and recommended order of operations are my synthesis. I mark frontier work separately because a result in one simulator, embodiment, or reward setup is not yet a general robot-training recipe.
 
-## Closed-loop distribution shift
+## The policy changes the data
 
 A modern VLA begins with two useful priors. Vision-language pretraining supplies objects, concepts, instructions, and scene semantics. Robot pretraining supplies a distribution over physically plausible behavior. [RT-2](/paper%20shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html) demonstrates the first transfer by expressing actions in the language-token interface. [Open X-Embodiment](/paper%20shorts/2023/10/13/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.html), [Octo](/paper%20shorts/2024/05/20/octo-an-open-source-generalist-robot-policy.html), and [OpenVLA](/paper%20shorts/2024/06/01/openvla-open-source-vision-language-action-model.html) make the second transfer concrete across heterogeneous robot data.
 
@@ -36,11 +36,11 @@ Neither prior guarantees that the deployed policy occupies familiar states. [DAg
 
 This is the first mental model to keep:
 
-> Supervised fine-tuning learns what to do in the states represented by its data. Interactive post-training changes which states become data, which is why a small set of recovery trajectories can be worth more than a large set of already-successful demonstrations.
+> Supervised fine-tuning learns what to do in the states represented by its data. Interactive post-training changes which states become data.
 
 That difference is why another million successful demonstrations may be worth less than ten thousand carefully selected recoveries.
 
-## The supervised baseline
+## Start with SFT
 
 Supervised fine-tuning hides most of its engineering inside the action target. Is the target a scalar joint bin, a whole action chunk, a diffusion denoising target, or a continuous regression vector? How much observation history is available? Does the policy act at 3 Hz or 50 Hz? Does it predict one step, replan a receding horizon, or temporally ensemble overlapping chunks? Those choices determine both the likelihood interface and the states the policy can recover from.
 
@@ -70,7 +70,7 @@ The supervised baseline should therefore be an adaptation matrix, not one ceremo
 
 Measure success, robot-data efficiency, control frequency, latency, forgetting, and semantic retention together. A policy that succeeds 3% more often but halves the control rate may be worse before the first rollout.
 
-## Language-model alignment methods
+## Text feedback does not transfer cleanly
 
 The classic language pipeline is documented by [InstructGPT](/paper%20shorts/2022/02/28/training-language-models-to-follow-instructions-with-human-feedback.html): supervised fine-tuning, a Bradley–Terry preference model, then [PPO](/paper%20shorts/2017/07/01/proximal-policy-optimization-ppo.html) against the learned reward with a KL penalty. [DPO](/paper%20shorts/2023/05/01/direct-preference-optimization-dpo.html) removes the explicit reward model and expresses the KL-regularized optimum directly through chosen and rejected responses.
 
@@ -106,7 +106,7 @@ The feedback interface should match what deployment actually observed:
 
 The central question is not “Can DPO be applied?” It is “What event has a defensible likelihood and a defensible preference label?” The method should follow the evidence unit, not the fashion cycle.
 
-## Feedback attribution
+## Which action caused the failure?
 
 Suppose the gripper misses the handle at step 42 and a human takes over at step 47. The binary episode label says the rollout failed. The intervention says the policy became unacceptable by step 47. Neither observation proves that every earlier action was wrong. Penalizing the whole trajectory can erase a good approach because of one bad contact. Training only on the human suffix can also be misleading if the human begins from a state the policy would never deliberately create.
 
@@ -120,7 +120,7 @@ This is the post-training lineage in one picture. Language-style DPO begins with
 
 The safest useful label is therefore local. Preserve the prefix that still made progress. Mark the first defensible failure window. Record the reached state and the corrective continuation. If a paired alternative cannot be replayed from a matched state, use an unpaired outcome or correction objective rather than pretending to possess a counterfactual.
 
-### Failure mining
+### Mine the boundary
 
 Rollouts are not automatically useful. A thousand identical successes provide little gradient. A thousand catastrophic failures may be unsafe and too far outside the policy's recoverable region. The valuable middle consists of near-boundary states: recoverable mistakes, ambiguous objects, distribution shifts, and action segments where a different local decision changes the outcome.
 
@@ -138,7 +138,7 @@ That taxonomy routes data. Semantic failures may need web/VLM retention or instr
 
 The next 1,000 robot hours should go where expected marginal information is highest: high-uncertainty critic regions, recoverable failures, rare safety cases, new environments, and tasks that discriminate between candidate post-training methods. Uniform collection is easy to schedule and often a poor research allocation.
 
-## Choosing a method by feedback type
+## Choose by feedback
 
 Once failures are labeled, four families cover most practical updates.
 
@@ -174,7 +174,7 @@ For diffusion actors, [DPPO](/paper%20shorts/2024/09/01/dppo-diffusion-policy-po
 
 That observation produces a systems requirement: rollout scheduling must create informative contrasts. Sample tasks near the competence boundary, record policy versions, prevent correlated environments from masquerading as independent evidence, and reject groups with no reward variance.
 
-## Reward models and environment design
+## Who judges the policy?
 
 A terminal success detector is sparse. A generic VLM reward can miss geometry, contact, occlusion, and temporal progress. A dense hand-engineered reward can teach the simulator rather than the task. The right critic is rarely “a bigger VLM asked whether the robot did well.”
 
@@ -188,27 +188,27 @@ A serious process critic should not collapse progress, completion, failure, safe
 
 Never celebrate rising critic reward alone. Track ground-truth task success, human judgment, critic disagreement, intervention rate, unsafe contact, entropy, KL from SFT, and the causal content of high-reward rollouts. If the policy can change what the critic sees, the critic is no longer a passive metric. It is part of the environment being optimized.
 
-## Evaluation levels
+## An evaluation ladder
 
 Post-training claims are only as strong as the next evaluation layer they predict.
 
-### Level 1: Offline diagnostics
+### Offline diagnostics
 
 Measure action error, chunk likelihood, critic accuracy, preference accuracy, representation probes, and instruction/object grounding. These are cheap debugging tools. They do not measure recovery from the model's own actions.
 
-### Level 2: Closed-loop simulation
+### Closed-loop simulation
 
 [LIBERO](/paper%20shorts/2023/06/05/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.html) separates spatial, object, goal, and mixed transfer across 130 tasks. [RoboTwin 2.0](/paper%20shorts/2025/06/20/robotwin-2-scalable-data-generator-and-benchmark.html) adds bimanual tasks, structured domain randomization, and synthetic data generation. Report success by failure category and shift, not only the mean.
 
-### Level 3: Real-to-sim correlation
+### Real-to-sim correlation
 
 [SIMPLER](/paper%20shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html) asks whether simulation preserves real policy rankings and failure sensitivities. That correlation must be measured prospectively for every new policy family. A simulator calibrated for RT-style discrete actions may not rank a new flow policy correctly.
 
-### Level 4: Reproducible real trials
+### Reproducible real trials
 
 [VLA-REPLICA](/paper%20shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html) standardizes an inexpensive physical setup so independent labs can reproduce the result. Measure success with confidence intervals, intervention frequency, unsafe contacts, time, smoothness, latency, and hardware-versus-policy faults.
 
-### Level 5: Natural interaction robustness
+### Natural variation
 
 [LIBERO-Para](/paper%20shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html) reveals 22–52 point drops under instruction paraphrases and attributes most failures to planning divergence. A policy that succeeds only when the user repeats the fine-tuning phrase has not retained semantic grounding.
 
@@ -216,9 +216,9 @@ Measure action error, chunk likelihood, critic accuracy, preference accuracy, re
 
 The staff-level metric sits above every level:
 
-The staff-level metric is reliable policy improvement per robot-hour, human-hour, annotation-hour, and unit of compute.
+> Reliable policy improvement per robot-hour, human-hour, annotation-hour, and unit of compute.
 
-## Reproducible training loops
+## Remember every rollout
 
 An RL trainer is one component of an online VLA program. The surrounding system needs versioned policies, rollout workers, environment and robot calibration records, synchronized video/state/action logs, feedback provenance, immutable dataset snapshots, critic versions, and rollback.
 
@@ -264,15 +264,15 @@ Do not read the following papers as a chronology. Read them as five passes throu
 
 **Pass 5: test which evidence survives deployment.** Read [LIBERO](/paper%20shorts/2023/06/05/libero-benchmarking-knowledge-transfer-for-lifelong-robot-learning.html), [SIMPLER](/paper%20shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html), [RoboTwin 2.0](/paper%20shorts/2025/06/20/robotwin-2-scalable-data-generator-and-benchmark.html), [VLA-REPLICA](/paper%20shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html), and [LIBERO-Para](/paper%20shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html). **Output:** an evaluation ladder in which every cheap metric names the expensive deployment decision it is expected to predict.
 
-## Emerging methods
+## Frontier methods
 
 Several 2026 papers extend the loop toward fleet-scale asynchronous training, model-based optimization, continual reinforcement fine-tuning, and learned robot rewards: [SOP](https://arxiv.org/abs/2601.03044), [LifeLong-RFT](https://arxiv.org/abs/2602.10503), [VLA-MBPO](https://arxiv.org/abs/2603.20607), [Large Reward Models](https://arxiv.org/abs/2603.16065), [BORA](https://arxiv.org/abs/2605.30226), [ProcVLM](https://arxiv.org/abs/2605.08774), and [Advantage Collapse in GRPO](https://arxiv.org/abs/2605.21125). These are useful research signals, but their claims should be re-tested under common robot-hour, compute, and evaluation budgets before they become default infrastructure.
 
-## The research thesis
+## A testable thesis
 
 The strongest VLA post-training program will not be the one with the fanciest optimizer. It will be the one that closes attribution gaps.
 
-The policy needs broad pretrained semantics. The action head needs the right temporal and continuous interface. Deployment needs to expose the states the policy actually creates. Failure mining needs to locate the causal segment. Feedback needs to preserve what a human, success detector, or critic truly observed. Optimization needs to respect the policy distribution. Evaluation needs to predict real deployment. The system needs to remember which version produced every piece of evidence.
+The chain starts with broad pretrained semantics and an action head that matches the temporal, continuous control problem. Deployment must then expose the states the policy actually creates. Failure mining locates the causal segment, and feedback preserves only what a human, detector, or critic truly observed. Optimization must respect the policy distribution; evaluation must predict real deployment. Through every update, the system must remember which version produced each piece of evidence.
 
 My strongest bet is a structured, uncertainty-aware process critic: keep the VLA broad and end-to-end, but let the critic see persistent entities, geometry, contact, controller state, and task progress. Use that critic to find high-value failures and conservative updates, then distill the improvement into the deployable policy.
 

--- a/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
+++ b/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
@@ -10,7 +10,8 @@ tags:
   - LLMs
   - Apple Silicon
 summary: >-
-  How to run Hermes Agent locally with llama.cpp and an existing GGUF.
+  How Hermes Agent, an OpenAI-compatible localhost endpoint, llama.cpp, and an
+  already-downloaded Gemma GGUF fit together.
 ---
 # Running Hermes Agent with a Local GGUF
 
@@ -42,7 +43,9 @@ The figure shows the boundary that resolved the setup. A prompt does not travel 
 
 This separation also changes how to debug. If Hermes cannot reach `/v1/chat/completions`, inspect the endpoint and configuration. If the endpoint returns HTTP `500` while loading a model, inspect the runtime, artifact, and hardware path. If text is generated but tools appear as plain text, inspect the server's chat template and tool-call support. Treating those as three different contracts avoids reinstalling the wrong layer.
 
-## Installing Hermes Agent
+> **Deep insight:** The API boundary is also the debugging boundary. Agent behavior, serving behavior, and model loading can fail independently, so each needs its own test.
+
+## Install Hermes
 
 The Hermes install was not the hard part:
 
@@ -60,7 +63,7 @@ That bootstrapped:
 
 The real question was what local model server Hermes should talk to.
 
-## Why Ollama did not work
+## Why Ollama failed
 
 Since I already had Ollama installed and local Gemma tags visible, I tried the most obvious route first.
 
@@ -68,7 +71,7 @@ Hermes could see the local endpoint. Ollama listed local Gemma models. But actua
 
 The key realization: Hermes was not the problem. My local model server choice was.
 
-## `llama-server` with a local Gemma GGUF
+## Serve the local GGUF
 
 The machine already had local Gemma GGUF artifacts in the Hugging Face cache, including:
 
@@ -108,7 +111,7 @@ http://127.0.0.1:18080/v1
 
 That split worked: Hermes stayed as the agent shell, and `llama.cpp` handled local serving.
 
-## Point Hermes at the local API
+## Point Hermes at localhost
 
 The current Hermes setup path is `hermes model`, then **Custom endpoint**. I originally pointed Hermes at `llama-server` by editing `~/.hermes/config.yaml` directly:
 
@@ -143,7 +146,7 @@ READY
 
 That was enough proof: Hermes was running locally against weights already on disk.
 
-## What the test establishes
+## What the test proves
 
 The `READY` response proves the inference path, not full agent quality. A useful next pass should separately test model loading, ordinary chat, structured tool calls, long-context behavior, and recovery when the local server restarts. Those checks locate regressions at the same boundaries shown in the figure.
 
@@ -159,4 +162,4 @@ The architecture is now clean:
 - `llama.cpp` for the local serving layer
 - existing local weights for inference
 
-> Separating the agent layer, serving layer, and model artifacts prevents one tool's lifecycle from determining all three. It makes an agent replacement, runtime change, or weight update independently testable.
+That split is cleaner than asking one tool to own the agent layer, serving layer, and model artifacts at once.

--- a/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
@@ -10,13 +10,14 @@ tags:
   - Apple Silicon
   - Inference
 summary: >-
-  Why DeepSeek V4 Flash 0731 cannot fit in 64 GB—and what can.
+  Why DeepSeek V4 Flash 0731 does not fit in 64 GB unified memory, what its
+  13B active parameter count actually means, and the practical serving path.
 ---
 # Can DeepSeek V4 Flash 0731 Run on a 64 GB MacBook Pro?
 
 I wanted the same practical answer I measured for Qwen and Gemma: can I fit the exact `DeepSeek-V4-Flash-0731` checkpoint on my `64 GB` M5 Max MacBook Pro, and can I serve it at an interactive speed?
 
-> A `64 GB` Mac cannot run the official checkpoint: it is about `167 GB` on disk and its maintained vLLM recipe budgets `200 GB` of accelerator memory before runtime state and KV cache. The feasible architecture is local application plus hosted inference, not an imagined local-weight deployment.
+No. The official checkpoint is about `167 GB` on disk, and the maintained vLLM recipe assigns it a `200 GB` minimum accelerator-memory target. That is before leaving room for the inference runtime, activations, and KV cache. A `64 GB` Mac can call the hosted model and can serve a local application backed by that API, but it cannot load the official weights into unified memory.
 
 This is a sizing analysis dated August 13, 2026, not a benchmark. I did not manufacture latency numbers for a model that cannot load on the machine.
 
@@ -35,7 +36,9 @@ The official [`DeepSeek-V4-Flash-0731` repository](https://huggingface.co/deepse
 
 This table separates storage from inference. Downloading `167 GB` to the SSD proves only that the files fit on disk. It does not make them resident in memory, and macOS swap does not convert a `64 GB` laptop into a `200 GB` inference server. An experimental engine could offload experts and stream weights, but a deficit above `100 GB` moves the problem from GPU or unified-memory bandwidth to transfers from much slower storage. That is a systems experiment, not a sensible daily serving plan.
 
-## Why 13B active does not mean 13B resident
+> **Deep insight:** Active parameters price the arithmetic for one token. Total parameters price residency. Sparse experts change the first number, not the second.
+
+## Active is not resident
 
 The `13B` active count is still useful: it explains why DeepSeek can reduce the arithmetic performed for each token. It answers a compute question, not the fit question.
 
@@ -51,7 +54,7 @@ $$
 
 Active parameters mainly affect the work to generate the next token. Total stored parameters dominate whether the checkpoint can load at all.
 
-## What self-hosting actually requires
+## What self-hosting requires
 
 DeepSeek's model card demonstrates the exact `0731` checkpoint with vLLM on one `4 × GB300` node. The maintained vLLM recipe also documents hardware-specific deployments and requires vLLM `0.25.0` for the fused DSpark checkpoint. These are accelerator-server configurations, not Apple Silicon paths.
 
@@ -71,7 +74,7 @@ vllm serve deepseek-ai/DeepSeek-V4-Flash-0731 \
 
 That command is evidence of the intended serving stack, not a command to paste into the Mac. It assumes supported CUDA hardware, specialized MoE and sparse-attention kernels, and enough aggregate memory for the weights plus serving state. MLX and `llama.cpp` were meaningful choices in my Qwen and Gemma benchmarks because those checkpoints fit. Runtime preference is secondary when the DeepSeek checkpoint misses the machine's memory budget by more than `100 GB`.
 
-## The serving path I would use
+## The serving path
 
 On this laptop, I would treat DeepSeek as a remote inference backend. DeepSeek's API currently maps the model name `deepseek-v4-flash` to `DeepSeek-V4-Flash-0731`, exposes an OpenAI-compatible base URL, and supports the one-million-token context window. The model uses thinking mode by default, so I would set that behavior explicitly instead of allowing hidden reasoning work to distort latency and token cost.
 
@@ -103,7 +106,7 @@ print(response.choices[0].message.content)
 
 This still lets a local browser app expose a service on the Mac: the UI, retrieval, tools, logging, and request policy run locally, while model inference runs behind DeepSeek's endpoint. It is not private local inference, but it is the only practical way to use the exact `0731` checkpoint on this hardware without renting a large accelerator server.
 
-DeepSeek's pricing changes on August 16, 2026, so I would read the [live pricing page](https://api-docs.deepseek.com/quick_start/pricing/) rather than freeze a cost comparison that will be stale three days after publication. The durable comparison is architectural: API use converts a large fixed hardware commitment into metered requests, while self-hosting becomes rational only when privacy, sustained utilization, or deployment control repays a server with at least roughly `200 GB` of accelerator memory.
+DeepSeek's pricing changes on August 16, 2026, so I would read the [live pricing page](https://api-docs.deepseek.com/quick_start/pricing/) rather than freeze a comparison that will age within days. The durable comparison is architectural. API use converts a large fixed hardware commitment into metered requests. Self-hosting becomes rational only when privacy, sustained use, or deployment control repays a server with at least roughly `200 GB` of accelerator memory.
 
 ## Recommendation
 

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -9,13 +9,14 @@ tags:
   - LLMs
   - Apple Silicon
 summary: >-
-  MLX versus llama.cpp performance for Gemma 4 on a 64 GB M5 Max.
+  A dated comparison of MLX and llama.cpp latency for Gemma 4 on a 64 GB M5
+  Max, including why long-prompt prefill changes the recommendation.
 ---
 # Benchmarking Gemma 4 on a 64 GB MacBook Pro
 
 I wanted one concrete answer: on a 64 GB M5 Max MacBook Pro, which Gemma 4 model should I actually run locally, and through which runtime?
 
-The measurements below are a hardware-and-software snapshot from April 4, 2026, not a permanent runtime leaderboard. Google subsequently released Gemma 4 12B Unified on June 3, so that model is outside this benchmark. I also have not rerun the earlier Ollama failure on current releases.
+These measurements are a hardware-and-software snapshot from April 4, 2026, not a permanent runtime leaderboard. Google subsequently released Gemma 4 12B Unified on June 3, so that model is outside this benchmark. I also have not rerun the earlier Ollama failure on current releases.
 
 Within the measured snapshot:
 
@@ -90,9 +91,11 @@ The animation keeps the model/runtime rows fixed while the input grows from `512
 
 [![Animation comparing short- and long-prompt time to first token and decode throughput for Gemma 4 on MLX and llama.cpp](/assets/images/local-gemma-long-prompt-latency.gif)](/assets/images/local-gemma-long-prompt-latency.gif)
 
-*Long prompts expose prefill as the practical bottleneck. The `31B` weights fit, but TTFT rises to `13.5 s` on MLX and `24.2 s` on llama.cpp in the measured long suite. `26B A4B` retains roughly `100 tok/s` decode while reaching the first token much sooner. Custom visualization of the benchmark tables below; measurements are from one 64 GB M5 Max on April 4, 2026.*
+*Long prompts expose prefill as the practical bottleneck. The `31B` weights fit, but TTFT rises to `13.5 s` on MLX and `24.2 s` on llama.cpp in the measured long suite. `26B A4B` retains roughly `100 tok/s` decode while reaching the first token much sooner. Custom visualization of this post's benchmark tables; measurements are from one 64 GB M5 Max on April 4, 2026.*
 
 This is the distinction the memory table cannot show. Capacity answers whether a model can load. Decode throughput answers how quickly it continues once generation has started. Prefill latency answers whether an `8K` document or agent state feels interactive at all. For daily use, the last quantity makes `26B A4B` a different product from `31B` even though both fit comfortably.
+
+> **Deep insight:** Local inference has three thresholds: load, start, and continue. Weight memory controls the first; prefill controls the second; decode throughput controls the third.
 
 ### Short-context results
 
@@ -124,7 +127,7 @@ MLX wins the small-model tests by a healthy margin. `26B A4B` is the exception t
 
 `31B` changes the model choice more than the runtime choice. It fits comfortably, but its long-prompt TTFT is roughly six times the `26B A4B` MLX result and more than seven times the corresponding llama.cpp result. MLX is still better behaved, yet the larger conclusion is that “weights fit” and “this feels good to use” are separate thresholds.
 
-## Ollama failure in the measured setup
+## The measured Ollama failure
 
 I wanted a clean Ollama column here. I could not get one.
 
@@ -151,4 +154,4 @@ If I cared about the fastest usable runtime on this machine, the answer is no lo
 2. `llama.cpp` second
 3. `Ollama` only after a fresh compatibility run
 
-> The best model, the best daily model, and the best runtime are different optimization targets. The measurements favor `31B` for maximum local capability, `26B A4B` for daily use, and `MLX` for speed on this machine.
+If you do not want a terminal workflow, this maps cleanly to a tiny local browser chat app. Both `MLX` and `llama.cpp` are reasonable backends if the goal is simply to serve Gemma locally and talk to it.

--- a/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
@@ -10,8 +10,8 @@ tags:
   - Apple Silicon
   - Inference
 summary: >-
-  Measured Muse Glimmer 30B latency, memory use, and long-context behavior on
-  an M5 Max.
+  A measured llama.cpp benchmark of Meta's official 17 GB Muse Glimmer 30B
+  quant on a 64 GB M5 Max, including reasoning latency and an 8K prompt test.
 ---
 # Benchmarking Muse Glimmer 30B on a 64 GB MacBook Pro
 
@@ -71,13 +71,15 @@ I report two first-token measurements. *First generated token* includes hidden r
 
 The largest correction was explicit placement. `--gpu-layers all` lifted the short decode rate from `9.92` to `27.90 tok/s`, a `2.8×` change before speculation entered the comparison. It also cut the long prompt's first generated token from `32.26 s` to `17.10 s`. A model that fits in unified memory can still run slowly if the engine chooses a conservative CPU/GPU split.
 
+> **Deep insight:** Fit is only the first threshold. Runtime placement decides whether resident weights become an interactive product or a slow systems demo.
+
 DFlash then changed decode rather than fit. With `--spec-type draft-dflash` active, the server accepted `87.9%` of proposed short-suite draft tokens and `79.8%` on the long suite. Short decode rose from `27.90` to `48.31 tok/s`; long decode rose from `26.62` to `35.47 tok/s`. The speedup is smaller at `8K` because prompt processing is unchanged by speculative generation and dominates more of the request.
 
 Reasoning creates a second latency boundary. In the short DFlash suite, the server began hidden generation at `1.01 s`, while the first visible integer arrived at `2.67 s`. A client that reports only transport-level time to first token still makes the chat experience look faster than it feels, although the gap is no longer severe.
 
 Meta reports `26.6 tok/s` without DFlash and `50.2 tok/s` with DFlash on an M5 Max, using ExecuTorch, batch size one, and greedy decoding. My short `llama.cpp` results of `27.90` and `48.31 tok/s` are remarkably close, but they remain separate measurements from a different runtime and harness. The agreement is useful evidence that the optimized local path is working; it is not a cross-runtime benchmark victory.
 
-## Serving Glimmer locally
+## Serve Glimmer locally
 
 The text-only OpenAI-compatible server I validated is:
 
@@ -107,7 +109,7 @@ The reusable harness for this run is in [`scripts/bench_llama_server_local.py`](
 
 ## Recommendation
 
-> The `17 GB` Q4_K_M quant makes Glimmer useful on a `64 GB` Mac because it leaves headroom for the application and context, not because the advertised maximum context is automatically usable. Add the projector only when vision is needed, then measure the workload before expanding context.
+I would run Glimmer locally when I want one current model that can cover text and images without putting pressure on a `64 GB` memory budget. I would start with the official `17 GB Q4_K_M`, add the projector only when the application needs vision, and keep the context well below the advertised maximum until the workload proves otherwise.
 
 I would use the full-Metal DFlash configuration for rapid local chat. Nearly `48 tok/s` on the short suite is fluid, and the model still leaves ample memory headroom. I would remain careful with agent loops that repeatedly inject `8K` of state: speculative decoding accelerates generation, not the entire prefill, so the long suite still took almost `18 s` to expose an answer. The next optimization target is prompt reuse or a smaller active context, not a larger quant.
 

--- a/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
@@ -9,7 +9,8 @@ tags:
   - LLMs
   - Apple Silicon
 summary: >-
-  Qwen 3.5 versus Qwen 3 latency and long-prompt performance on an M5 Max.
+  A dated comparison of Qwen 3.5 and Qwen 3 latency on a 64 GB M5 Max,
+  including why long-prompt prefill matters more than whether a model fits.
 ---
 # Benchmarking Qwen 3.5 and Qwen 3 on a 64 GB MacBook Pro
 
@@ -29,7 +30,7 @@ Within this benchmark snapshot:
 - `MLX` is the first runtime I would reach for on this Mac.
 - `4B` is the speed-first choice, but `14B` is where the local quality conversation starts getting more interesting.
 
-## Models included in the snapshot
+## Models in the snapshot
 
 The open lineup available on the measurement date narrowed the realistic local targets.
 
@@ -106,9 +107,11 @@ The animation holds every measured model/runtime row fixed and changes only the 
 
 [![Animation comparing short- and long-prompt time to first token and decode throughput for Qwen 3.5 and Qwen 3 on MLX and llama.cpp](/assets/images/local-qwen-long-prompt-latency.gif)](/assets/images/local-qwen-long-prompt-latency.gif)
 
-*The `4B` models remain the interactive tier. `Qwen 3 14B` still fits easily, but TTFT reaches `4.9 s` on MLX and `11.1 s` on llama.cpp in the `8K` suite. Custom visualization of the benchmark tables below; measurements are from one 64 GB M5 Max on April 4, 2026. Qwen 3.6 is intentionally absent because it was released after the run.*
+*The `4B` models remain the interactive tier. `Qwen 3 14B` still fits easily, but TTFT reaches `4.9 s` on MLX and `11.1 s` on llama.cpp in the `8K` suite. Custom visualization of this post's benchmark tables; measurements are from one 64 GB M5 Max on April 4, 2026. Qwen 3.6 is intentionally absent because it was released after the run.*
 
 The figure separates three decisions that parameter count often collapses. Memory determines whether a model loads. Decode throughput determines continuation speed. Prefill determines whether document-scale prompts feel responsive. On this machine, moving from `4B` to `14B` changes the third quantity most sharply, which is why the quality-versus-latency decision should be made with realistic prompt lengths.
+
+> **Deep insight:** A short-prompt benchmark prices generation. An agent workload also prices the history it must reread before every turn. That second bill can dominate the experience.
 
 ### Short-context results
 
@@ -145,4 +148,4 @@ For this measured snapshot, my practical recommendation is simple:
 3. Keep `Qwen 3.5 9B` in the mix if you specifically care about the 3.5 family behavior and do not mind the extra latency and memory overhead.
 4. Prefer `MLX` first on this Mac unless a specific `llama.cpp` model artifact or integration path gives you a reason to switch.
 
-> Local-model choice is a measured systems decision, not a parameter-count contest. On this machine, long-prompt latency and memory headroom change the recommendation more than the release notes do.
+That answer comes from this machine, not parameter counts or release notes.

--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -1,5 +1,5 @@
 ---
-title: How Good Research Works in Industry
+title: Research That Survives Contact
 date: '2026-03-22T04:00:00.000Z'
 section: blog
 blogGroup: essays
@@ -9,16 +9,18 @@ tags:
   - Research
   - Career
 summary: >-
-  How taste, problem choice, collaboration, and experiment cadence produce good
-  research.
+  How research taste, problem choice, collaboration, controlled experiments,
+  and throughput combine into a reliable research system.
 ---
-# How Good Research Works in Industry
+# Research That Survives Contact
 
-[Eugene Vinitsky's guide to good research](https://emerge-lab.github.io/papers/an-unsolicited-guide-to-good-research.pdf) stayed with me because it treats research as a craft rather than a sequence of heroic breakthroughs. Eugene leads the [EMERGE Lab](https://emerge-lab.github.io/), but much of his advice transfers to industry, where research is entangled with engineering, product, deadlines, and organizational constraints.
+Industry research rarely fails because nobody had an idea. It fails because the question was vague, the experiment could not isolate a cause, a collaborator waited on hidden context, or the answer arrived after the decision. An idea has to survive contact with engineering, product, deadlines, and an organization before it can matter.
+
+[Eugene Vinitsky's guide to good research](https://emerge-lab.github.io/papers/an-unsolicited-guide-to-good-research.pdf) stayed with me because it treats that survival as a craft rather than a heroic breakthrough. Eugene leads the [EMERGE Lab](https://emerge-lab.github.io/), but his advice transfers cleanly to industry.
 
 Those constraints change the work without changing its central questions. A researcher still needs to decide what matters, design experiments that produce knowledge, and collaborate without losing momentum. Good ideas help. Clear judgment and reliable execution determine whether those ideas survive contact with an organization.
 
-## Build research taste
+## Build taste
 
 Research taste is the ability to decide what deserves attention. The literature grows faster than anyone can read it, while consequential ideas remain much rarer than papers. A new researcher experiences that gap as overload. An experienced one builds a compressed map: foundational results, useful extensions, unresolved questions, and noise.
 
@@ -26,21 +28,21 @@ Following researchers and labs with consistently strong work is a practical way 
 
 Virality works against this process. Social feeds reward visible consensus and rapid reaction, which pushes people toward the same papers and the same opinions. Taste develops more slowly, through sustained exposure and enough independent judgment to notice depth before the crowd supplies a verdict.
 
-## Choose motivating problems
+## Choose live problems
 
 The best work contains an element of play. The problem keeps pulling you back when nobody is asking for an update, not because it is easy, but because some part of it remains intrinsically interesting. Research is too uncertain to sustain on discipline alone.
 
 Interest is not the same as comfort. Work that teaches you something usually sits just beyond your current ability: difficult enough to force a new model of the problem, but bounded enough that effort can still produce feedback. Too little tension becomes routine; too much becomes paralysis.
 
-## Keep collaborators unblocked
+## Do not block
 
 Serious research increasingly depends on the same coordination as serious engineering. The relevant skill is not simply being agreeable. It is keeping information and decisions moving across people who hold different pieces of the system.
 
-> Surface constraints early, give honest timing, and leave enough context for someone else to proceed. An explicit blocker can be routed or planned around; a hidden one silently stalls every dependent decision.
+My simplest rule is: do not block. Surface constraints early, give honest timing, and leave enough context for someone else to proceed. An explicit blocker can be routed or planned around; a hidden one quietly stalls several people at once.
 
 Apply the same rule to yourself. Ask for help when someone else likely has the missing context. Do not spend days privately rediscovering an answer the team already knows. When the uncertainty is genuinely yours, step away long enough to stop repeating the same failed approach. A walk or a night's sleep often changes the representation of the problem, which is more useful than another hour of force.
 
-## Run interpretable experiments
+## Make experiments legible
 
 ML is empirical, so an experiment should change one interpretable decision whenever possible. Ablations turn a promising run into evidence about what caused the result. Without them, a team can produce plenty of activity and very little knowledge.
 
@@ -48,8 +50,10 @@ Documentation is part of the experiment. Future you needs to know what changed, 
 
 Visibility only helps when the work is legible. A presentation should maximize what the audience understands, not how much detail the author can display. Proving that you did the work and helping someone reason about it are different goals.
 
-## Treat throughput as part of rigor
+## Throughput is rigor
 
 Compute changes the value of good judgment because it determines how quickly a question can meet evidence. Keep the GPUs busy, but make each run interpretable. Velocity without rigor produces noise; rigor without enough throughput leaves important decisions unresolved. A good research system makes the two reinforce each other.
 
-That is what I took from Eugene's guide. Research improves through practices that can be trained: build taste, expose blockers, run controlled experiments, record decisions, and explain the result clearly. None of those practices guarantees a breakthrough. Together they create a system in which a good idea can survive long enough to meet evidence, become legible to collaborators, and influence a real decision. In industry, that system matters more than the romance of the isolated insight.
+> **Deep insight:** In industry, time-to-evidence is part of rigor. A perfect result that arrives after the decision is not influence; it is an archive.
+
+That is what I took from Eugene's guide. None of these practices guarantees a breakthrough. Together they give a good idea enough structure to meet evidence, become legible to collaborators, and influence a real decision. In industry, that system matters more than the romance of the isolated insight.


### PR DESCRIPTION
## What changed
- scrub all 15 Blog posts paragraph by paragraph
- simplify technical prose while preserving technical detail and source grounding
- strengthen openings, headings, audio continuity, and earned insight callouts
- rename the perception survey to Autonomous-Vehicle Perception, circa 2026
- preserve existing slugs, legacy routes, and Blog groups

## Why
Make the Blog corpus clearer, denser, more musical, and easier to follow without introducing filler or generic AI prose.

## Validation
- npm run ci
- 63 Astro files: 0 diagnostics
- 36 tests passed
- 311 pages built
- 23 post routes and 246 paper reading paths verified