### PR TITLE
Add four source-grounded autonomous driving paper notes

### DIFF
--- a/src/content/posts/caviar-a-causal-video-dataset-for-fine-grained-accident-reasoning-in-real-world-scenarios.md
+++ b/src/content/posts/caviar-a-causal-video-dataset-for-fine-grained-accident-reasoning-in-real-world-scenarios.md
@@ -1,0 +1,53 @@
+---
+title: 'CAViAR: A Causal Video Dataset for Fine-Grained Accident Reasoning in Real-World Scenarios'
+date: '2026-08-19T09:00:00.000Z'
+section: paper-shorts
+postSlug: caviar-a-causal-video-dataset-for-fine-grained-accident-reasoning-in-real-world-scenarios
+legacyPath: /paper shorts/2026/08/19/caviar-a-causal-video-dataset-for-fine-grained-accident-reasoning-in-real-world-scenarios.html
+tags:
+  - Autonomous Driving
+  - Vision-Language Models
+  - Safety Evaluation
+  - Datasets
+field: 'Autonomous Driving: VLMs & Evaluation'
+summary: '2026 – CAViAR tests whether driving VLMs can ground accident responsibility in visible actions'
+---
+
+## 2026 – CAViAR
+
+**arXiv:** [2608.19380](https://arxiv.org/abs/2608.19380)<br />
+**Code and annotations:** [NEC Labs CAViAR](https://github.com/nec-labs-ma/CAViAR)
+
+## Summary
+
+> CAViAR turns accident understanding into a responsibility-grounding benchmark rather than another captioning task. Its 2,249 real dashcam videos carry 20,108 question-answer pairs for scene context, accident type, apparent at-fault and affected agents, and apparent rule-violation category. Across six open VLM configurations, lighting recognition is nearly saturated, while accident classification remains close to the majority baseline and the best reported rule-violation score is only 0.82 out of 5. The benchmark isolates a useful failure, but its labels describe responsibility visible from one camera—not legal liability—and lack a formal inter-annotator agreement or human-performance baseline.
+
+## Core Insights
+
+### The dataset separates visible context from responsibility
+
+CAViAR adds a reviewed responsibility layer to 1,500 Car Crash Dataset clips and 749 Nexar clips. The fixed tasks ask what happened, which visible road user initiated the unsafe interaction, who was affected, and which of eleven jurisdiction-agnostic rule families best describes the visible behavior. Ambiguous or off-screen responsibility cases are excluded from responsibility evaluation instead of being forced into a single label. That decision makes the target narrower than legal fault, but also more defensible from dashcam evidence.
+
+The split is deliberately cross-corpus: CCD supplies training data and Nexar supplies the test set, with no shared videos, scenes, or devices. Three model families—Cosmos-Reason2, Qwen3-VL, and InternVL3—are evaluated at 2B and 8B scales before and after language-backbone LoRA fine-tuning. The vision encoder and projector remain frozen, so the experiment tests whether language-side adaptation can map existing visual evidence to the new task rather than whether better visual grounding can be learned end to end.
+
+| Diagnostic | Reported result | What it establishes |
+| --- | ---: | --- |
+| Lighting accuracy | 98.6% base / 98.7% fine-tuned, averaged across models | Some visible context is easy for the tested VLMs. |
+| Accident-type macro-F1 | 18.6% / 21.1% | Aggregate accuracy hides collapse toward common classes. |
+| Best apparent at-fault score | 2.27 / 5 | The best model often identifies a relevant agent without complete reasoning. |
+| Best rule-violation score | 0.82 / 5 | Mapping visible action to a rule category is the hardest reported task. |
+| Same-source CCD holdout | 31.12–39.60 BERTScore-F1 | Removing the CCD-to-Nexar shift does not remove the reasoning gap. |
+
+The comparison with existing site benchmarks is instructive. [DriveBench](/paper%20shorts/2025/01/01/are-vlms-ready-for-autonomous-driving-drivebench.html) tests whether driving answers remain grounded under visual corruption, while [NARRATE](/paper%20shorts/2026/08/14/narrate-a-multimodal-real-world-australian-driving-dataset-for-human-centred-explanations-in-automated-driving.html) records explanations from the drivers who performed ordinary maneuvers. CAViAR changes the evaluated object: a model must connect an observed accident sequence to agent roles and a rule-relevant behavior.
+
+### The benchmark still needs a human and annotation ceiling
+
+The annotation protocol uses two primary annotators and two reviewers, but the paper does not report independent inter-annotator agreement. GPT-4o judging correlates with two human raters on 45 samples, yet that small validation cannot establish an absolute scale for responsibility quality. A human baseline is also not reported. The expensive decision is therefore whether to use CAViAR as a diagnostic training and evaluation set, not whether its current scores measure deployable accident adjudication.
+
+## High-Level Takeaways
+
+- CAViAR extends driving-VLM evaluation from recognizing scene attributes to grounding apparent responsibility in visible agents, actions, and rule categories.
+- The cross-corpus split and same-source holdout suggest that domain shift contributes to the errors but does not fully explain the gap between context recognition and responsibility reasoning.
+- Frozen vision modules limit the fine-tuning conclusion: marginal 8B gains do not show that larger models cannot improve when visual grounding is adapted jointly.
+- The benchmark should not be used for legal or insurance decisions; its labels are single-view research annotations of apparent responsibility.
+- The central claim would weaken if an independently re-annotated test set, expert human baseline, and counterfactual agent-role evaluation showed that the present gap mostly reflects label ambiguity or metric failure.

--- a/src/content/posts/inference-time-attention-steering-for-vision-language-action-driving-models.md
+++ b/src/content/posts/inference-time-attention-steering-for-vision-language-action-driving-models.md
@@ -1,0 +1,61 @@
+---
+title: 'Inference-Time Attention Steering for Vision-Language-Action Driving Models'
+date: '2026-08-17T09:00:00.000Z'
+section: paper-shorts
+postSlug: inference-time-attention-steering-for-vision-language-action-driving-models
+legacyPath: /paper shorts/2026/08/17/inference-time-attention-steering-for-vision-language-action-driving-models.html
+tags:
+  - Autonomous Driving
+  - VLA
+  - Attention Steering
+field: 'Autonomous Driving: VLA & Planning'
+summary: '2026 – a bounded visual-token attention bias steers Alpamayo-R1 trajectories without retraining'
+---
+
+## 2026 – Inference-Time Attention Steering for Vision-Language-Action Driving Models
+
+**arXiv:** [2608.17095](https://arxiv.org/abs/2608.17095)
+
+## Summary
+
+> This paper shows that a bounded pre-softmax bias on detector-grounded visual tokens can move Alpamayo-R1's diffusion-decoded trajectory without changing its weights. On 50 synthetic lane-change scenes, the mean displacement grows monotonically with bias magnitude and reaches about 17 cm at the clamp; late-layer interventions are much stronger than early-layer ones. The result establishes a controllable trajectory response, not a safety policy or even actor-specific steering: the model often moves toward the attended actor, and the paper does not include matched background, shifted-box, or second-actor controls.
+
+## Core Insights
+
+### The intervention changes attention mass, not weights
+
+A YOLO11-nano detector selects a lead vehicle, maps its box onto Alpamayo-R1's $10 \times 18$ merged visual-token grid, and identifies the corresponding token indices. A forward pre-hook then adds a non-negative bias to those key positions before softmax:
+
+$$
+\tilde{z}_{q,j}=z_{q,j}+b_j,\qquad
+b_j=\begin{cases}
+\min(\lambda,\beta) & j\in\mathcal{T}_A\text{ and }j>k_{\text{sink}},\\
+0 & \text{otherwise.}
+\end{cases}
+$$
+
+The clamp $\beta=4$ bounds the perturbation, while a sink guard excludes the first four token positions. Token spans and mask shapes are checked on every run; an unexpected serving path fails open and leaves the model unchanged. This exposure audit is part of the method because a mask-based hook can affect only forward passes that materialize an additive attention mask.
+
+The evaluation uses Alpamayo-R1-10B with a 36-layer Qwen3-VL backbone, four front-camera context frames, and 64 predicted waypoints over 6.4 seconds. Baseline and steered diffusion samples share a seed. The paired zero-bias condition is therefore bit-identical, which is essential because cross-seed trajectory variation is about 30 times larger than the measured steering effect.
+
+| Intervention | Mean trajectory ADE | Mean maximum lateral shift | Scope |
+| --- | ---: | ---: | --- |
+| First 8 layers | 2.0 cm | 2.9 cm | Five-scene layer ablation |
+| Last 8 layers | 16.7 cm | 57.8 cm | Five-scene layer ablation |
+| Last 16 layers | 42.0 cm | 109.2 cm | Five-scene layer ablation |
+| All 36 layers | 67.6 cm | 205.5 cm | Five-scene layer ablation |
+| Last 8, bias sweep to $\lambda=4$ | about 17 cm | about 38 cm mean; about 140 cm maximum case | Fifty-scene dose response |
+
+### Unchanged reasoning text is a routing result
+
+The Chain-of-Causation text remains identical across the reported bias and temperature sweeps. The exposure audit shows why: the fused causal kernel used by the language path does not expose the additive mask, so the hook never reaches either language prefill or autoregressive decoding. Only the diffusion action decoder receives the intervention. The invariant text is therefore evidence of non-exposure, not evidence that language reasoning resists attention steering.
+
+This is a different control interface from [XCoT-VLA](/paper%20shorts/2026/08/11/xcot-vla-executable-chain-of-thought-for-vision-language-action-driving.html), which trains compact reasoning tokens to condition trajectory generation. Attention steering changes visual salience after training. Its attraction is operational—an external risk module can inject a bounded signal—but the paper does not yet map that signal to a desired behavior such as increasing clearance.
+
+## High-Level Takeaways
+
+- A late-layer additive attention bias is a real inference-time control knob for the tested diffusion trajectory decoder; the effect grows with both bias magnitude and the number of hooked layers.
+- The atomic intervention is a set of detector-grounded visual-token columns. Detector error, token mapping, layer exposure, and the diffusion seed are therefore part of the control contract.
+- Displacement is not driving quality. The reported tendency toward the actor can be helpful for following or harmful for collision avoidance, depending on the scene.
+- The result is limited to one quantized VLA, 50 selected synthetic lane-change scenarios, synthetic ego history, and open-loop predictions.
+- Actor specificity requires matched controls with the same token count on shifted boxes, background regions, mirrored locations, and other actors. If those controls move the trajectory equally, the mechanism is generic token perturbation rather than actor-aware steering.

--- a/src/content/posts/one-stage-object-detectors-in-autonomous-driving.md
+++ b/src/content/posts/one-stage-object-detectors-in-autonomous-driving.md
@@ -1,0 +1,51 @@
+---
+title: 'One-Stage Object Detectors in Autonomous Driving'
+date: '2026-08-19T09:00:00.000Z'
+section: paper-shorts
+postSlug: one-stage-object-detectors-in-autonomous-driving
+legacyPath: /paper shorts/2026/08/19/one-stage-object-detectors-in-autonomous-driving.html
+tags:
+  - Object Detection
+  - Autonomous Driving
+  - Survey
+field: 'Vision Foundations'
+summary: '2026 – a survey of one-stage detector design and the limits of cross-paper speed-accuracy comparisons'
+---
+
+## 2026 – One-Stage Object Detectors in Autonomous Driving
+
+**arXiv:** [2608.19014](https://arxiv.org/abs/2608.19014)
+
+## Summary
+
+> This survey organizes one-stage detectors by assignment, representation, feature fusion, loss design, and deployment trade-offs. Its useful conclusion is methodological: AP, frames per second, parameters, and input size must be read together and within one dataset-hardware protocol. The paper does not train a detector or run a matched autonomous-driving benchmark; its performance table combines values from Pascal VOC and COCO, different resolutions, hardware, and reporting conventions. It is therefore a map of design choices, not evidence that one listed family is safest or fastest for a driving stack.
+
+## Core Insights
+
+### One-stage detection now names several design families
+
+The original distinction was procedural: two-stage detectors generate proposals before classification and box refinement, while one-stage detectors predict dense classes and boxes directly. The survey shows how much diversity now sits inside the second category. SSD and RetinaNet use default boxes; early YOLO variants use grid-based anchors; FCOS predicts per-location boxes with centerness; CenterNet turns objects into keypoints; YOLOX combines an anchor-free head with dynamic assignment; and YOLOv10 removes non-maximum suppression through consistent one-to-many and one-to-one training assignments.
+
+Feature fusion and optimization often matter as much as the output parameterization. [EfficientDet](/paper%20shorts/2020/04/01/efficientdet-scalable-and-efficient-object-detection.html) couples BiFPN with compound scaling, RetinaNet introduces focal loss for foreground-background imbalance, GFL represents box coordinates as distributions, and VFNet aligns classification confidence with localization quality. These changes move the deployment frontier without making anchor-based versus anchor-free a sufficient selection rule.
+
+| Selection axis | What the survey records | Required deployment control |
+| --- | --- | --- |
+| Detection quality | AP or mAP from original papers | Same dataset, class set, IoU rule, resolution, and test-time augmentation |
+| Throughput | FPS or latency when reported | Same hardware, precision, batch size, pre/post-processing, and runtime |
+| Small-object behavior | Multi-scale features and reported weaknesses | Range-stratified pedestrian, cyclist, sign, and occlusion recall |
+| Efficiency | Parameters, FLOPs, and model scale | Measured memory, energy, and worst-case latency on target hardware |
+| Driving relevance | KITTI, Waymo, nuScenes, BDD100K, and Argoverse coverage | Per-class and adverse-condition results under the intended sensor contract |
+
+### The comparison table is not a leaderboard
+
+The survey explicitly marks its performance table as cross-paper reporting rather than a controlled benchmark. For example, it places YOLO and EfficientDet COCO numbers beside SSD and DSSD Pascal VOC numbers, with several missing FPS and parameter entries. Its qualitative radar chart is also a survey-derived five-point assessment, not a new measurement. The defensible use is to shortlist mechanisms and baselines before running a hardware- and dataset-matched evaluation.
+
+The survey's autonomous-driving discussion identifies the right failure categories—small and distant objects, occlusion, adverse weather, edge compute, and missing deployment-centric metrics—but it does not quantify them under one protocol. A detector choice for driving should therefore be driven by critical-class recall, calibration, degradation tests, and end-to-end latency, not a global AP/FPS pair copied from unrelated papers.
+
+## High-Level Takeaways
+
+- One-stage detection is no longer one architecture: anchor assignment, feature pyramid design, score-localization alignment, post-processing, and scaling policy are independent decisions.
+- The survey is most useful as a taxonomy and reading list. Its heterogeneous reported numbers cannot support a detector ranking for autonomous driving.
+- A production comparison should hold the input, dataset, hardware, precision, runtime, and post-processing fixed, then report range- and condition-stratified recall for safety-critical classes.
+- Anchor-free prediction removes anchor tuning but does not automatically improve latency, crowded-scene localization, or small-object recall.
+- The survey's deployment claims would become decision-grade only after a matched benchmark on driving data and target hardware, including tail latency, energy, calibration, weather, and occlusion slices.

--- a/src/content/posts/planning-oriented-end-to-end-autonomous-driving-architectures-evaluation-and-emerging-paradigms.md
+++ b/src/content/posts/planning-oriented-end-to-end-autonomous-driving-architectures-evaluation-and-emerging-paradigms.md
@@ -1,0 +1,59 @@
+---
+title: 'Planning-Oriented End-to-End Autonomous Driving: Architectures, Evaluation, and Emerging Paradigms'
+date: '2026-08-20T09:00:00.000Z'
+section: paper-shorts
+postSlug: planning-oriented-end-to-end-autonomous-driving-architectures-evaluation-and-emerging-paradigms
+legacyPath: /paper shorts/2026/08/20/planning-oriented-end-to-end-autonomous-driving-architectures-evaluation-and-emerging-paradigms.html
+tags:
+  - Autonomous Driving
+  - End-to-End Driving
+  - Planning
+  - Evaluation
+field: 'Autonomous Driving: VLA & Planning'
+summary: '2026 – a planning-oriented taxonomy that treats evaluation protocol as part of the method claim'
+---
+
+## 2026 – Planning-Oriented End-to-End Autonomous Driving
+
+**arXiv:** [2608.20111](https://arxiv.org/abs/2608.20111)
+
+## Summary
+
+> This survey argues that end-to-end driving should be classified by what supports the final plan, not by how much visible structure the network removes. It organizes methods along four axes—input representation, planning output, supervision, and evaluation—and follows the field from direct control imitation through structured BEV and vector planners to world models and vision-language-action systems. Its strongest decision rule is that an open-loop displacement score, a NAVSIM non-reactive score, and a Bench2Drive closed-loop score are different claims. The review maps those claims through June 2026; it does not provide a new cross-benchmark experiment or a universal model ranking.
+
+## Core Insights
+
+### End-to-end does not mean structure-free
+
+Planning-oriented systems remain end to end when their intermediate objects are learned or jointly optimized toward driving behavior. A model may carry BEV features, object or map queries, route encodings, world-model latents, language tokens, or explicit safety constraints. The architectural question is whether those objects preserve the geometry, uncertainty, semantics, and action interface the planner needs—not whether the diagram contains named modules.
+
+The survey's four-axis taxonomy prevents a backbone name from standing in for a driving formulation:
+
+| Axis | Representative choices | Decision exposed |
+| --- | --- | --- |
+| Input representation | Raw sensors, BEV, vectors, object queries, world-state latents, VLM tokens | Which evidence and structure reach the planner? |
+| Planning output | Controls, waypoints, trajectories, distributions, action tokens | Can the output express alternatives and accept safety checks? |
+| Supervision | Behavior cloning, privileged distillation, auxiliary tasks, RL, world-model prediction, language alignment | Which target teaches recovery, consequence, and route compliance? |
+| Evaluation | Open-loop replay, non-reactive real-log simulation, reactive closed loop, long-tail or preference scoring | Which behavior does the reported number actually test? |
+
+The progression is therefore not a clean replacement sequence. Direct behavior cloning minimizes interfaces but suffers from covariate shift. Privileged teachers add structure during training. BEV and vectorized planners expose geometry and multi-task supervision. World models evaluate possible consequences, but only if their imagined futures remain calibrated under action changes. VLA systems add semantic context, yet must bridge text-space reasoning to metric trajectories under a bounded latency budget.
+
+### Evaluation determines the scope of the architecture claim
+
+Open-loop evaluation scores a policy on states visited by the logged expert. It cannot test recovery after the policy causes a deviation, and it may penalize a safe alternative simply because it differs from the recorded path. NAVSIM-style non-reactive evaluation adds real sensor logs and planning-aware safety, progress, and comfort proxies at scale, but other agents do not react to the ego plan. Bench2Drive-style simulation tests interaction and recovery under the policy's induced state distribution, while inheriting CARLA's sim-to-real boundary. WOD-E2E adds rare scenarios and human preferences but remains open loop.
+
+The practical rule is to compare claims within protocols and triangulate across them. A low nuScenes L2 error does not imply a high closed-loop route score. A high NAVSIM score is stronger proxy evidence than displacement alone, but ranking inversions and saturated submetrics prevent it from replacing reactive evaluation. Small leaderboard differences are also uninterpretable without the benchmark version, controller, safety wrapper, sensor configuration, seeds, and metric implementation.
+
+The same standard applies to language and world models. [Inference-time attention steering](/paper%20shorts/2026/08/17/inference-time-attention-steering-for-vision-language-action-driving-models.html) can move a trajectory without establishing safer behavior, while [XCoT-VLA](/paper%20shorts/2026/08/11/xcot-vla-executable-chain-of-thought-for-vision-language-action-driving.html) trains a compact reasoning interface whose gains are still tied to its evaluation setting. Better explanations, plausible futures, and lower displacement error are useful diagnostics; none is a substitute for action-grounded and closed-loop evidence.
+
+### The review is a claim map, not a meta-analysis
+
+The authors use a structured narrative search across scholarly databases, benchmark repositories, leaderboards, code releases, and project pages, with work covered through June 2026. Inclusion criteria span influential driving formulations, planning outputs, benchmarks, world models, VLM/VLA mechanisms, and reproducibility or safety critiques. The resulting scope is broad, but public academic work is overrepresented, recent 2025–2026 methods lack independent reproduction, and metric versions make many numbers protocol-dependent. The paper correctly recommends comparing methods by claim and benchmark family instead of merging their scores.
+
+## High-Level Takeaways
+
+- A structured intermediate representation is compatible with end-to-end learning when the representation and policy are optimized around the final plan.
+- Output space, supervision, and evaluation can matter more than the encoder family: a trajectory distribution, a privileged teacher, or a reactive benchmark changes the scientific claim even when the visual backbone stays fixed.
+- Open-loop, non-reactive real-log, reactive closed-loop, and preference-aware evaluations test different failure surfaces and should never share one undifferentiated leaderboard.
+- World models need calibrated action-conditioned futures; VLA systems need evidence that language improves action quality rather than only explanation quality.
+- The survey's thesis would weaken if benchmark-aligned, compute-matched studies found that open-loop rankings reliably predict closed-loop safety and route completion across datasets, controllers, and distribution shifts.


### PR DESCRIPTION
## Summary
- replace four Paper Radar metadata drafts with source-grounded Arxiv Notes
- add decision-oriented evidence tables, limits, and research-line links
- assign the notes to Autonomous Driving: VLMs & Evaluation, Autonomous Driving: VLA & Planning, and Vision Foundations

## Validation
- git diff --check
- npm run ci
- desktop and mobile rendered-route QA for all four notes
- no browser console warnings or errors