### PR TITLE
Cover quoted paper-note sections in image gate

### DIFF
--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -100,7 +100,7 @@ describe('markdown authoring', () => {
     for (const filePath of postFiles) {
       const source = await readFile(filePath, 'utf8');
       if (
-        /^section: paper-shorts$/m.test(source) &&
+        /^section:\s*['"]?paper-shorts['"]?\s*$/m.test(source) &&
         !/PAPER RADAR DRAFT/.test(source) &&
         !/^## Summary\n\n> /m.test(source)
       ) {
@@ -122,7 +122,7 @@ describe('markdown authoring', () => {
     for (const filePath of postFiles) {
       const source = await readFile(filePath, 'utf8');
       if (
-        !/^section: paper-shorts$/m.test(source) ||
+        !/^section:\s*['"]?paper-shorts['"]?\s*$/m.test(source) ||
         /PAPER RADAR DRAFT/.test(source)
       ) {
         continue;


### PR DESCRIPTION
## Summary
- make the paper-note image and summary gates recognize quoted as well as unquoted section frontmatter
- confirm all 253 published paper notes are covered and contain 1–3 images

## Validation
- npx vitest run tests/content.test.ts
- git diff --check
- direct corpus audit: 253 published notes, zero image-count offenders
