### PR TITLE
Restore authored stakes in Blog openings

### DIFF
--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -16,9 +16,11 @@ import { attentionMechanismsPlayground } from '../../lib/python-playground-examp
 
 # How Attention Stores and Retrieves Context
 
-Attention began as an escape hatch from a fixed-size memory. An encoder-decoder recurrent neural network had to compress a source sentence into a hidden state and ask that state to preserve everything the decoder might need. Attention let each decoding step reach back to the encoder states directly. The Transformer made a larger move in 2017: it removed recurrence from the main sequence path and used attention itself to route information between positions.
+Attention is a learned memory interface. Keys say what stored content can be matched, values carry the content itself, and a query retrieves the mixture needed at the current position. That separation is how attention stores and retrieves context.
 
-The core operation has survived. A query describes the current information need, keys determine which sources match it, and values carry the content returned by those sources. Most later variants do not replace that idea; they change where the keys and values come from, how much of them must be cached, which positions are eligible, or whether the past is stored token by token at all.
+The mechanism began as an escape hatch from a fixed-size memory. An encoder-decoder recurrent neural network had to compress a source sentence into one hidden state and ask that state to preserve everything the decoder might need. Attention let each decoding step reach back to the encoder states directly. The Transformer made the larger move in 2017: it removed recurrence from the main sequence path and used attention itself to route information between positions.
+
+What I find interesting is how much of the original idea survived. Most later variants do not replace query-key matching and value retrieval. They change where the keys and values come from, how much must be cached, which positions are eligible, or whether the past remains stored token by token at all.
 
 ## The encoder-decoder bottleneck
 

--- a/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
+++ b/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
@@ -12,7 +12,11 @@ summary: A technical history of how vision-language models moved from task-speci
 ---
 # Tracing the VLM Progression
 
-A model can name the mug, explain that mugs hold liquid, and still drive a gripper into the table beside it. The contradiction disappears once we stop treating “vision-language” as a single capability. Recognizing a mug, binding the word *mug* to pixels, estimating its pose, predicting contact, and controlling a wrist are different output contracts. Each tolerates a different amount of lost information.
+A vision-language model is not one capability. It is an interface that decides which parts of an image survive into a language-conditioned output. The VLM progression is therefore a progression in output contracts: recognition, alignment, generation, grounding, temporal reasoning, and finally action.
+
+That progression matters because a model can name a mug, explain that mugs hold liquid, and still drive a gripper into the table beside it. Recognizing the mug, binding the word *mug* to pixels, estimating its pose, predicting contact, and controlling a wrist are different jobs. Each tolerates a different amount of lost information.
+
+This is the history I care about. A new model can look like a clean capability jump while quietly inheriting an older compression boundary. Once location, time, or geometry disappears, a fluent language model cannot talk it back into existence.
 
 The usual timeline, CLIP to LLaVA to video to robotics, is useful but incomplete. It hides two important transitions. First, CLIP did not begin vision-language learning. Earlier systems already learned joint representations through region-level fusion. CLIP changed the scaling economics and the interface: natural language became an open vocabulary for visual recognition. Second, visual chat did not emerge directly from contrastive alignment. A generation of models learned how to connect pretrained visual encoders and language models before instruction tuning turned that machinery into an assistant.
 

--- a/src/content/posts/how-to-read-scaling-laws-for-language-models.md
+++ b/src/content/posts/how-to-read-scaling-laws-for-language-models.md
@@ -15,11 +15,17 @@ summary: Kaplan, Chinchilla, data constraints, inference economics, and why ever
 
 # How to Read Scaling Laws for Language Models
 
-This post is long overdue. I kept it in my backlog because I wanted to understand what Kaplan and Chinchilla mean now, not because either result is obscure.
+[Jie Tang's post about GLM-5.3](https://x.com/jietang/status/2089941544581403107) finally pulled this out of my backlog. Z.ai kept the GLM-5.2 base fixed, then spent another month scaling long-horizon environments and reinforcement-learning post-training. Tang's point was not that parameter scaling had ended. It was that scaling has several dials, and the dial with the largest return can change.
 
-Scaling laws appear in almost every model-release discussion. They justify larger models, fixed token-to-parameter ratios, and vague claims that progress is inevitable. None of those versions survives a close reading.
+That post begs for a refresher. If the base model stayed fixed, what exactly scaled? What did Kaplan and Chinchilla actually establish about where the next unit of compute should go? And which parts of their conclusions were empirical observations rather than permanent laws?
+
+Understanding those distinctions matters more now because a modern model budget no longer ends at pretraining. Parameters, data mixture, post-training environments, reinforcement-learning compute, serving cost, and test-time search can all be the binding constraint. Treating *scaling* as shorthand for *make the base model larger* hides the decision we now have to make.
+
+Scaling laws still appear in almost every model-release discussion. They justify larger models, fixed token-to-parameter ratios, and vague claims that progress is inevitable. None of those versions survives a close reading.
 
 A scaling law does not say that a model becomes intelligent if we make it larger. It makes a narrower claim. Inside a measured regime, a chosen error metric changes predictably as we spend more parameters, data, or compute.
+
+I still find that regularity remarkable. Neural-network training is messy, yet the expensive end of a training family can sometimes be forecast from much cheaper runs. In [Dario Amodei's discussion with Lex Fridman](https://lexfridman.com/dario-amodei-transcript/), he describes the confidence behind scaling as inductive: the pattern has repeated across domains even though its theoretical explanation remains incomplete.
 
 That regularity turns a large pretraining run from one heroic bet into a resource-allocation problem. A cheap sweep can tell us whether the next dollar should buy a larger model, more tokens, a different mixture, or a better evaluation.
 
@@ -126,7 +132,7 @@ The objective widens again after pretraining. A smaller model trained longer can
 
 Test-time search adds another coordinate. A smaller model with selective search can beat a larger single-pass model on some tasks. The measurement must include the search policy, verifier, latency, and failures.
 
-[Jie Tang's GLM-5.3 note](https://x.com/jietang/status/2089941544581403107) makes the same point from post-training. Z.ai kept the GLM-5.2 base fixed, then spent another month on long-horizon environments and reinforcement-learning post-training. [The release report](https://z.ai/blog/glm-5.3) attributes the gains to that stage. The controlled intervention is informative. It is not yet a post-training scaling law: one before-and-after release gives no response surface, held-out forecast, or compute-optimal valley.
+Tang's GLM-5.3 note makes the same point from post-training. Z.ai kept the GLM-5.2 base fixed, then spent another month on long-horizon environments and reinforcement-learning post-training. [The release report](https://z.ai/blog/glm-5.3) attributes the gains to that stage. The controlled intervention is informative. It is not yet a post-training scaling law: one before-and-after release gives no response surface, held-out forecast, or compute-optimal valley.
 
 The modern scaling problem is therefore not one curve. It is an allocation across pretraining data, model capacity, post-training environments, serving cost, and test-time effort. The right coordinate is the one that removes the current bottleneck under a measured constraint.
 

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -15,9 +15,14 @@ topics:
 summary: How modern autonomous-driving systems preserve sensor-specific evidence, establish metric geometry, fuse modalities, carry world state through time, and connect perception to planning, simulation, and validation.
 ---
 # Autonomous-Vehicle Perception, circa 2026
-A distant cyclist at dusk may appear as a few image pixels, two or three LiDAR returns, and a noisy radar detection with radial velocity. None of those measurements is the scene. Each is partial evidence with a different sampling pattern, uncertainty, and failure mode.
 
-The tempting definition of a unified sensor model is one that converts every sensor into one tensor as early as possible. That is usually the wrong objective. Early unification can erase the very signal that made a sensor useful: image texture, LiDAR height structure, radar Doppler, measurement age, or sensor-specific confidence. Once that information has been averaged away, a larger downstream model cannot reconstruct it.
+Autonomous-vehicle perception has one job: turn raw sensor measurements into a world state that the rest of the autonomy stack can use. Cameras, LiDAR, radar, calibration, fusion, and tracking are mechanisms, not the output. The output is a timely geometric account of what surrounds the vehicle, how it is moving, and how much the system should trust it—soon enough for prediction and planning to act.
+
+That job sounds clean until the evidence becomes thin. A distant cyclist at dusk may appear as a few image pixels, two or three LiDAR returns, and a noisy radar detection with radial velocity. None of those measurements is the cyclist. Each is partial evidence with a different sampling pattern, uncertainty, and failure mode.
+
+What still makes this problem interesting to me is that more unification can make the model worse. The tempting definition of a unified sensor model is one that converts every sensor into one tensor as early as possible. That is usually the wrong objective.
+
+Early unification can erase the very signal that made a sensor useful: image texture, LiDAR height structure, radar Doppler, measurement age, or sensor-specific confidence. Once that information has been averaged away, a larger downstream model cannot reconstruct it.
 
 The real architectural problem is deciding where each measurement becomes geometry, where different modalities are allowed to interact, what state survives through time, and which parts of that state are made explicit for prediction, planning, simulation, and validation. The progression is:
 

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -15,9 +15,11 @@ summary: A systems guide to how semantics, geometry, dynamics, and motor priors 
 
 _Updated August 21, 2026._
 
+Pre-training for robotics tries to give a policy useful priors before it has enough experience in one robot, task, or deployment. The promise is transfer: learn semantics, geometry, time, interaction, and action from several data sources, then reuse those priors when robot data is scarce.
+
 A robot can inherit the word “drawer” from the internet. It can learn what drawers look like, where handles usually are, and which instruction refers to which object. The internet does not tell it how a sticky drawer feels, how far a particular arm can reach, what force closes the gripper, or what to do after the object slips.
 
-That gap is the reason robotics pretraining is both promising and easy to misunderstand. Internet-scale data supplies broad semantics. Human video supplies temporal and interaction structure. Robot trajectories supply actions, contact, embodiment, and recovery. These sources are useful precisely because they are different. Treating them as interchangeable tokens inside one large model does not make the differences disappear.
+That gap is what makes robotics pretraining exciting to me, and what makes it easy to misunderstand. Internet-scale data supplies broad semantics. Human video supplies temporal and interaction structure. Robot trajectories supply actions, contact, embodiment, and recovery. These sources are useful precisely because they are different. Treating them as interchangeable tokens inside one large model does not make the differences disappear.
 
 The central design problem is therefore not simply **how to pretrain a large multimodal model**. It is:
 

--- a/src/content/posts/on-engineering-management.md
+++ b/src/content/posts/on-engineering-management.md
@@ -112,7 +112,7 @@ I think about each person’s work as a mixture of leverage, stretch, and stewar
 
 Everyone will do some stewardship work, but nobody should receive only stewardship while someone else gets all the ambiguous, visible, and exciting problems. Over time, access to ownership, learning, and meaningful work should be distributed intentionally.
 
-That being said, autonomy does not mean isolation. People should be able to make progress without constant approval, but they should also escalate early when blocked. A useful request for help includes the goal, what has been tried, what was observed, the current hypothesis, and the specific help needed. I want asking for help to be emotionally inexpensive but intellectually serious.
+Autonomy does not mean isolation. People should be able to make progress without constant approval, but they should also escalate early when blocked. A useful request for help includes the goal, what has been tried, what was observed, the current hypothesis, and the specific help needed. I want asking for help to be emotionally inexpensive but intellectually serious.
 
 The manager remains accountable but should become less central. The test of delegation is not whether work disappeared from my plate. It is whether judgment appeared somewhere else on the team.
 

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -15,11 +15,13 @@ summary: A systems guide to turning demonstrations, failures, interventions, cri
 
 # Post-Training for Robotics
 
+Post-training for robotics is the machinery that turns deployment evidence into a justified policy update. The name sounds like one stage after pretraining. In practice, it is a loop: adapt the policy, deploy it, find consequential failures, decide what those failures actually teach, update conservatively, and test whether the fix survives contact with the robot.
+
 A robot fails while closing a drawer.
 
 The rollout gives us an outcome: failure. It does not tell us whether the camera missed the handle, the model chose the wrong subtask, the trajectory approached at a bad angle, the gripper slipped, the controller lagged, or the success detector fired too early. Post-training begins in the gap between outcome and explanation.
 
-This is why “make the pretrained model behave better” is an inadequate description. A robot's action changes its next observation. One small error can create an unfamiliar state, an irreversible contact, or a recovery opportunity that no offline demonstration contains. The hard part is not taking another gradient step. It is deciding what the gradient is justified to say.
+This is why “make the pretrained model behave better” is an inadequate description. A robot's action changes its next observation. One small error can create an unfamiliar state, an irreversible contact, or a recovery opportunity that no offline demonstration contains. The part I find hardest is not taking another gradient step. It is deciding what the gradient is justified to say.
 
 The right object is therefore not an optimizer. It is a closed-loop policy improvement system:
 


### PR DESCRIPTION
## What changed
- reviewed all 18 Blog posts against the updated voice rules
- revised the seven openings that did not earn their title or preserve an authored motive
- defined Perception before the cyclist example
- restored Jie Tang as the Scaling Laws trigger and Dario Amodei on its empirical basis
- kept the other eleven posts unchanged because their openings already met the standard

## Validation
- corpus-wide prose regression audit
- git diff --check
- npm run ci
- desktop and 390px checks for all seven revised routes: correct headings, no broken images, no overflow, no console errors