### PR TITLE
Make Code practice interview-focused

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -4393,6 +4393,148 @@ html {
   }
 }
 
+/* Interview framing and the local-PyTorch architecture track. */
+.code-index__interview-loop {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.6fr) minmax(0, 1.4fr);
+  gap: 1.25rem;
+  padding: 1.25rem;
+  border: 1px solid var(--code-border-color);
+  border-radius: 22px;
+  background: var(--panel-bg);
+}
+
+.code-index__interview-loop h2,
+.code-index__track-heading h2 {
+  margin: 0;
+}
+
+.code-index__interview-loop ol {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem 1.25rem;
+  margin: 0;
+  padding-left: 1.3rem;
+  color: var(--text-secondary-color);
+}
+
+.code-index__interview-loop strong {
+  color: var(--text-color);
+}
+
+.code-index__track {
+  display: grid;
+  gap: 1rem;
+  scroll-margin-top: 6rem;
+}
+
+.code-index__track-heading {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.7fr) minmax(0, 1.3fr);
+  align-items: end;
+  gap: 1.25rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--code-border-color);
+}
+
+.code-index__track-heading > p {
+  max-width: 46rem;
+  margin: 0;
+  color: var(--text-secondary-color);
+}
+
+.code-index__card h3 {
+  margin: 0.7rem 0 0;
+  color: var(--text-color);
+  font-size: 1.45rem;
+  line-height: 1.2;
+}
+
+.code-index__card-badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.code-index__card-badges span {
+  padding: 0.22rem 0.45rem;
+  border: 1px solid var(--code-border-color);
+  border-radius: 999px;
+}
+
+.code-practice-lab__interview {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 1.2rem;
+  padding: 1rem;
+  border-left: 3px solid var(--accent-color);
+  border-radius: 0.25rem 0.75rem 0.75rem 0.25rem;
+  background: rgba(118, 169, 255, 0.08);
+}
+
+.code-practice-lab__interview-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.code-practice-lab__interview-heading p,
+.code-practice-lab__interview-heading strong,
+.code-practice-lab__follow-ups p {
+  margin: 0;
+}
+
+.code-practice-lab__interview-heading strong {
+  color: var(--text-color);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.code-practice-lab__follow-ups {
+  display: grid;
+  gap: 0.45rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--code-border-color);
+}
+
+.code-practice-lab__runtime-note--local {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--code-border-color);
+  background: rgba(118, 169, 255, 0.08);
+  color: var(--text-secondary-color);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+:root:not([data-theme="dark"]) .code-practice-lab__runtime-note--local {
+  background: rgba(53, 109, 255, 0.06);
+  color: #53627a;
+}
+
+.code-practice-lab__runtime-note--local code {
+  color: inherit;
+}
+
+:root[data-theme="dark"] .code-practice-lab__interview,
+:root[data-theme="dark"] .code-practice-lab__runtime-note--local {
+  background: rgba(255, 228, 92, 0.06);
+}
+
+@media (max-width: 760px) {
+  .code-index__interview-loop,
+  .code-index__track-heading {
+    grid-template-columns: 1fr;
+  }
+
+  .code-index__interview-loop ol {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 520px) {
   .home-stage {
     padding-top: 0;
@@ -7073,6 +7215,10 @@ html {
   box-shadow: none;
   color: #dff0ff;
   top: 5.25rem;
+}
+
+.code-practice-lab__workspace.code-practice-lab__workspace--local {
+  grid-template-rows: auto auto minmax(0, 1fr);
 }
 
 :root[data-theme="dark"] .code-practice-lab__workspace {

--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -49,6 +49,15 @@ function removeTodoCommentBlocks(source: string) {
 }
 
 export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
+  const isBrowserRunnable = (problem.environment ?? 'browser') === 'browser';
+  const interviewDuration =
+    problem.interview?.durationMinutes ??
+    ({ Easy: 20, Medium: 30, Hard: 45 } as const)[problem.difficulty];
+  const evaluationCriteria = problem.interview?.evaluationCriteria ?? [
+    'Clarify tensor shapes, return values, and failure cases before coding.',
+    'Keep the implementation small enough to explain while you write it.',
+    'Run the example and add one edge-case check before calling it done.',
+  ];
   const containerRef = useRef<HTMLElement | null>(null);
   const runtimeRef = useRef<PyodideRuntime | null>(null);
   const loadingRef = useRef(false);
@@ -57,8 +66,12 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const [code, setCode] = useState(() => removeTodoCommentBlocks(problem.starterCode));
   const [output, setOutput] = useState('');
   const [errorOutput, setErrorOutput] = useState('');
-  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
-  const [statusMessage, setStatusMessage] = useState('Loading Python...');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>(() =>
+    isBrowserRunnable ? 'idle' : 'ready',
+  );
+  const [statusMessage, setStatusMessage] = useState(() =>
+    isBrowserRunnable ? 'Loading Python...' : 'Local PyTorch',
+  );
   const [isRunning, setIsRunning] = useState(false);
   const [hasRun, setHasRun] = useState(false);
   const [editorTheme, setEditorTheme] = useState(() =>
@@ -88,8 +101,11 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
     [],
   );
   const editorExtensions = useMemo(
-    () => [...codeEditorExtensions, runShortcutExtension],
-    [runShortcutExtension],
+    () =>
+      isBrowserRunnable
+        ? [...codeEditorExtensions, runShortcutExtension]
+        : [...codeEditorExtensions],
+    [isBrowserRunnable, runShortcutExtension],
   );
 
   useEffect(() => {
@@ -101,6 +117,14 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
 
   useEffect(() => {
     let didCancel = false;
+
+    if (!isBrowserRunnable) {
+      setStatus('ready');
+      setStatusMessage('Local PyTorch');
+      return () => {
+        didCancel = true;
+      };
+    }
 
     async function bootstrapRuntime() {
       if (runtimeRef.current || loadingRef.current) {
@@ -170,7 +194,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
       didCancel = true;
       observer.disconnect();
     };
-  }, []);
+  }, [isBrowserRunnable]);
 
   useEffect(() => {
     setEditorTheme(
@@ -188,7 +212,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const hasExecutionResult = hasRun || Boolean(errorOutput);
 
   async function handleRun() {
-    if (isRunningRef.current) {
+    if (!isBrowserRunnable || isRunningRef.current) {
       return;
     }
 
@@ -239,7 +263,9 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   // The CodeMirror keymap is created once, so route it through a ref to the
   // current controlled editor state instead of rebuilding the editor on each keystroke.
   runHandlerRef.current = () => {
-    void handleRun();
+    if (isBrowserRunnable) {
+      void handleRun();
+    }
   };
 
   return (
@@ -256,11 +282,34 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
           <span className="code-practice-lab__difficulty">{problem.difficulty}</span>
         </header>
 
+        <p className="code-practice-lab__section-label">Interview prompt</p>
         <div className="code-practice-lab__copy">
           {problem.prompt.map((paragraph) => (
             <p key={paragraph}>{paragraph}</p>
           ))}
         </div>
+
+        <section className="code-practice-lab__interview" aria-label="Interview format">
+          <div className="code-practice-lab__interview-heading">
+            <p className="code-practice-lab__section-label">What good looks like</p>
+            <strong>{interviewDuration} min</strong>
+          </div>
+          <ul className="code-practice-lab__list">
+            {evaluationCriteria.map((criterion) => (
+              <li key={criterion}>{criterion}</li>
+            ))}
+          </ul>
+          {problem.interview && problem.interview.followUps.length > 0 && (
+            <div className="code-practice-lab__follow-ups">
+              <p className="code-practice-lab__section-label">Likely follow-ups</p>
+              <ul className="code-practice-lab__list">
+                {problem.interview.followUps.map((followUp) => (
+                  <li key={followUp}>{followUp}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
 
         {problem.visual && (
           <figure className="code-practice-lab__visual">
@@ -271,7 +320,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
 
         <div className="code-practice-lab__specs">
           <section className="code-practice-lab__spec-card">
-            <p className="code-practice-lab__section-label">Implement</p>
+            <p className="code-practice-lab__section-label">API contract</p>
             <pre>
               <code>{problem.signature}</code>
             </pre>
@@ -287,7 +336,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
           </section>
 
           <section className="code-practice-lab__spec-card">
-            <p className="code-practice-lab__section-label">Examples</p>
+            <p className="code-practice-lab__section-label">Acceptance checks</p>
             <div className="code-practice-lab__examples">
               {problem.examples.map((example) => (
                 <div key={example.label} className="code-practice-lab__example">
@@ -302,7 +351,9 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
         </div>
       </article>
 
-      <article className="code-practice-lab__workspace">
+      <article
+        className={`code-practice-lab__workspace${isBrowserRunnable ? '' : ' code-practice-lab__workspace--local'}`}
+      >
         <header className="code-practice-lab__workspace-header">
           <div className="code-practice-lab__workspace-identity">
             <p
@@ -320,17 +371,19 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
             >
               Solution
             </button>
-            <button
-              className="code-practice-lab__button code-practice-lab__button--primary"
-              type="button"
-              aria-label="Run code"
-              aria-keyshortcuts="Control+Enter Meta+Enter"
-              onClick={() => void handleRun()}
-              disabled={status !== 'ready' || isRunning}
-            >
-              <span>{isRunning ? 'Running...' : 'Run'}</span>
-              {!isRunning && <kbd>Ctrl / Cmd + Enter</kbd>}
-            </button>
+            {isBrowserRunnable && (
+              <button
+                className="code-practice-lab__button code-practice-lab__button--primary"
+                type="button"
+                aria-label="Run code"
+                aria-keyshortcuts="Control+Enter Meta+Enter"
+                onClick={() => void handleRun()}
+                disabled={status !== 'ready' || isRunning}
+              >
+                <span>{isRunning ? 'Running...' : 'Run'}</span>
+                {!isRunning && <kbd>Ctrl / Cmd + Enter</kbd>}
+              </button>
+            )}
             <button
               className="code-practice-lab__button code-practice-lab__button--secondary"
               type="button"
@@ -340,6 +393,13 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
             </button>
           </div>
         </header>
+
+        {!isBrowserRunnable && (
+          <p className="code-practice-lab__runtime-note code-practice-lab__runtime-note--local">
+            This exercise uses the full <code>torch.nn</code> API. Write here, then copy
+            <code> solution.py </code> into a local PyTorch environment to run the included smoke test.
+          </p>
+        )}
 
         <div className="code-practice-lab__editor-layout">
           <div className="code-practice-lab__editor-column">
@@ -381,7 +441,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
           )}
         </div>
 
-        {hasExecutionResult && (
+        {isBrowserRunnable && hasExecutionResult && (
           <div className="code-practice-lab__output" aria-live="polite">
             <div>
               <p>{errorOutput ? 'Errors' : 'Output'}</p>

--- a/src/lib/code-practice-architectures.ts
+++ b/src/lib/code-practice-architectures.ts
@@ -1,0 +1,678 @@
+import type { CodePracticeProblem } from './code-practice';
+
+export const ARCHITECTURE_CODE_PRACTICE_PROBLEMS = [
+  {
+    id: 'resnet-from-building-blocks',
+    order: 36,
+    title: 'Build a configurable ResNet',
+    difficulty: 'Hard',
+    track: 'architecture',
+    environment: 'local-pytorch',
+    summary:
+      'Implement a typed residual block and assemble a configurable ResNet with explicit downsampling rules.',
+    prompt: [
+      'You are given a classification service that needs a small ResNet family rather than one fixed network. Implement `BasicBlock` and `ResNet` around the supplied `ResNetConfig`.',
+      'In the interview, first state when the identity path must be projected. Then build the stages, preserve the batch dimension through global pooling, and finish with a shape smoke test.',
+    ],
+    signature: `@dataclass(frozen=True, slots=True)
+class ResNetConfig: ...
+
+class BasicBlock(nn.Module): ...
+
+class ResNet(nn.Module): ...`,
+    requirements: [
+      'Use `nn.Module` subclasses for the residual block and network.',
+      'Use the supplied frozen dataclass as the architecture contract.',
+      'Project the skip path when stride changes or channel counts differ.',
+      'Build one stage per `(channel, block_count)` pair in the config.',
+      'Return logits shaped `(B, num_classes)` for any valid image height and width.',
+      'Keep device and dtype behavior inherited from the input and module parameters.',
+    ],
+    examples: [
+      {
+        label: 'Acceptance check',
+        lines: [
+          'config = ResNetConfig(num_classes=10, blocks_per_stage=(2, 2, 2, 2))',
+          'images.shape = (2, 3, 224, 224)',
+        ],
+        result: 'model(images).shape == (2, 10)',
+      },
+    ],
+    hint: [
+      'A residual addition is valid only when the main and skip paths have the same shape.',
+      'The first block in each later stage performs spatial downsampling; the remaining blocks use stride one.',
+      'Track `self.in_channels` as `_make_stage` appends blocks.',
+      'Use adaptive average pooling so the classifier does not depend on a fixed image size.',
+    ],
+    interview: {
+      durationMinutes: 50,
+      evaluationCriteria: [
+        'Explains the identity-versus-projection decision before coding.',
+        'Separates configuration, reusable blocks, stage assembly, and the forward path.',
+        'Checks tensor shapes and names one production concern such as initialization or normalization.',
+      ],
+      followUps: [
+        'How would you generalize this to bottleneck blocks without rewriting `ResNet`?',
+        'What changes for small images such as CIFAR-10?',
+      ],
+    },
+    solutionNotes: [
+      'The projection is a shape adapter, not an optional flourish. A `1x1` convolution with the stage stride makes the skip path match both the spatial resolution and channel count of the residual path.',
+      'The config owns architecture choices while `_make_stage` owns repetition. That separation keeps the forward pass short and makes a second ResNet variant a data change instead of a copy-and-edit exercise.',
+    ],
+    solutionDiagram: `input
+  -> stem / 4
+  -> stage 1 / 4
+  -> stage 2 / 8
+  -> stage 3 / 16
+  -> stage 4 / 32
+  -> adaptive pool -> linear -> logits`,
+    starterCode: `from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+
+@dataclass(frozen=True, slots=True)
+class ResNetConfig:
+    in_channels: int = 3
+    num_classes: int = 1000
+    stage_channels: tuple[int, ...] = (64, 128, 256, 512)
+    blocks_per_stage: tuple[int, ...] = (2, 2, 2, 2)
+
+    def __post_init__(self) -> None:
+        if self.in_channels <= 0 or self.num_classes <= 0:
+            raise ValueError("in_channels and num_classes must be positive")
+        if len(self.stage_channels) != len(self.blocks_per_stage) or not self.stage_channels:
+            raise ValueError("stage_channels and blocks_per_stage must have equal non-zero length")
+        if any(value <= 0 for value in (*self.stage_channels, *self.blocks_per_stage)):
+            raise ValueError("stage widths and depths must be positive")
+
+
+class BasicBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1) -> None:
+        # TODO: build the residual branch and the conditional projection.
+        raise NotImplementedError("Implement __init__")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # TODO: combine the residual and skip paths, then apply the final activation.
+        raise NotImplementedError("Implement forward")
+
+
+class ResNet(nn.Module):
+    def __init__(self, config: ResNetConfig) -> None:
+        # TODO: create the stem, stages, adaptive pool, and classifier.
+        raise NotImplementedError("Implement __init__")
+
+    def _make_stage(self, out_channels: int, block_count: int, stride: int) -> nn.Sequential:
+        # TODO: downsample once, then append stride-one residual blocks.
+        raise NotImplementedError("Implement _make_stage")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # TODO: run the classification path and return (B, num_classes) logits.
+        raise NotImplementedError("Implement forward")
+
+
+def smoke_test() -> None:
+    device = torch.device("cpu")
+    model = ResNet(ResNetConfig(num_classes=10)).to(device=device, dtype=torch.float32)
+    images = torch.randn(2, 3, 224, 224, device=device, dtype=torch.float32)
+    with torch.inference_mode():
+        logits = model(images)
+    assert logits.shape == (2, 10)
+    print(tuple(logits.shape))
+
+
+if __name__ == "__main__":
+    smoke_test()`,
+    solutionCode: `from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+
+@dataclass(frozen=True, slots=True)
+class ResNetConfig:
+    in_channels: int = 3
+    num_classes: int = 1000
+    stage_channels: tuple[int, ...] = (64, 128, 256, 512)
+    blocks_per_stage: tuple[int, ...] = (2, 2, 2, 2)
+
+    def __post_init__(self) -> None:
+        if self.in_channels <= 0 or self.num_classes <= 0:
+            raise ValueError("in_channels and num_classes must be positive")
+        if len(self.stage_channels) != len(self.blocks_per_stage) or not self.stage_channels:
+            raise ValueError("stage_channels and blocks_per_stage must have equal non-zero length")
+        if any(value <= 0 for value in (*self.stage_channels, *self.blocks_per_stage)):
+            raise ValueError("stage widths and depths must be positive")
+
+
+class BasicBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1) -> None:
+        super().__init__()
+        self.residual = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, 3, stride=stride, padding=1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_channels, out_channels, 3, padding=1, bias=False),
+            nn.BatchNorm2d(out_channels),
+        )
+        self.projection = (
+            nn.Identity()
+            if stride == 1 and in_channels == out_channels
+            else nn.Sequential(
+                nn.Conv2d(in_channels, out_channels, 1, stride=stride, bias=False),
+                nn.BatchNorm2d(out_channels),
+            )
+        )
+        self.activation = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.activation(self.residual(x) + self.projection(x))
+
+
+class ResNet(nn.Module):
+    def __init__(self, config: ResNetConfig) -> None:
+        super().__init__()
+        self.in_channels = config.stage_channels[0]
+        self.stem = nn.Sequential(
+            nn.Conv2d(config.in_channels, self.in_channels, 7, stride=2, padding=3, bias=False),
+            nn.BatchNorm2d(self.in_channels),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(3, stride=2, padding=1),
+        )
+        stages = []
+        for index, (channels, blocks) in enumerate(zip(config.stage_channels, config.blocks_per_stage)):
+            stages.append(self._make_stage(channels, blocks, stride=1 if index == 0 else 2))
+        self.stages = nn.Sequential(*stages)
+        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.classifier = nn.Linear(config.stage_channels[-1], config.num_classes)
+
+    def _make_stage(self, out_channels: int, block_count: int, stride: int) -> nn.Sequential:
+        blocks = [BasicBlock(self.in_channels, out_channels, stride)]
+        self.in_channels = out_channels
+        blocks.extend(BasicBlock(out_channels, out_channels) for _ in range(block_count - 1))
+        return nn.Sequential(*blocks)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        features = self.stages(self.stem(x))
+        return self.classifier(torch.flatten(self.pool(features), 1))
+
+
+def smoke_test() -> None:
+    device = torch.device("cpu")
+    model = ResNet(ResNetConfig(num_classes=10)).to(device=device, dtype=torch.float32)
+    images = torch.randn(2, 3, 224, 224, device=device, dtype=torch.float32)
+    with torch.inference_mode():
+        logits = model(images)
+    assert logits.shape == (2, 10)
+    print(tuple(logits.shape))
+
+
+if __name__ == "__main__":
+    smoke_test()`,
+    packages: ['torch'],
+    tags: ['PyTorch', 'Architecture', 'ResNet', 'Clean Code'],
+  },
+  {
+    id: 'unet-encoder-decoder',
+    order: 37,
+    title: 'Build a U-Net encoder-decoder',
+    difficulty: 'Hard',
+    track: 'architecture',
+    environment: 'local-pytorch',
+    summary:
+      'Implement a configurable U-Net with reusable blocks, skip connections, and robust odd-size handling.',
+    prompt: [
+      'A segmentation pipeline must preserve fine spatial detail while using deeper context. Implement `DoubleConv`, `UpBlock`, and `UNet` using the supplied `UNetConfig`.',
+      'Treat input-size behavior as part of the API. Your decoder must align each upsampled tensor to its skip tensor before concatenation, including when pooling rounded an odd spatial dimension down.',
+    ],
+    signature: `@dataclass(frozen=True, slots=True)
+class UNetConfig: ...
+
+class DoubleConv(nn.Module): ...
+class UpBlock(nn.Module): ...
+class UNet(nn.Module): ...`,
+    requirements: [
+      'Use one reusable double-convolution block throughout the encoder and decoder.',
+      'Store encoder and decoder blocks in `nn.ModuleList` containers.',
+      'Use max pooling to downsample and transposed convolution to upsample.',
+      'Resize an upsampled feature map to the exact skip size before concatenation when necessary.',
+      'Return logits shaped `(B, out_channels, H, W)` for even and odd input sizes.',
+    ],
+    examples: [
+      {
+        label: 'Odd-size acceptance check',
+        lines: [
+          'config = UNetConfig(in_channels=3, out_channels=4, channels=(32, 64, 128))',
+          'images.shape = (2, 3, 127, 131)',
+        ],
+        result: 'model(images).shape == (2, 4, 127, 131)',
+      },
+    ],
+    hint: [
+      'Save the output of each encoder block before pooling it.',
+      'The bottleneck has twice as many channels as the deepest encoder block.',
+      'Build the decoder by iterating over encoder channels in reverse.',
+      'After upsampling, compare `x.shape[-2:]` with `skip.shape[-2:]` before concatenating on the channel axis.',
+    ],
+    interview: {
+      durationMinutes: 50,
+      evaluationCriteria: [
+        'Explains what information the skip connections restore.',
+        'Keeps channel bookkeeping inside reusable blocks instead of the forward method.',
+        'Tests an odd spatial size and states the output-logit contract.',
+      ],
+      followUps: [
+        'When would bilinear upsampling be preferable to transposed convolution?',
+        'How would you adapt the output and loss for multi-label segmentation?',
+      ],
+    },
+    solutionNotes: [
+      'The encoder stores high-resolution features before each pool. The decoder upsamples its current representation, aligns it to the matching skip tensor, concatenates along channels, and uses `DoubleConv` to fuse the two sources.',
+      'Odd sizes expose a common hidden assumption: repeated division by two is not exactly reversible. Aligning to `skip.shape[-2:]` makes the spatial contract explicit and avoids hard-coded crop arithmetic.',
+    ],
+    solutionDiagram: `input -> enc 32 -> pool -> enc 64 -> pool -> enc 128 -> bottleneck 256
+            |                    |                     |
+            +--------------------+---------------------+
+                                 decoder + skips -> logits at input size`,
+    starterCode: `from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+@dataclass(frozen=True, slots=True)
+class UNetConfig:
+    in_channels: int = 3
+    out_channels: int = 1
+    channels: tuple[int, ...] = (64, 128, 256, 512)
+
+    def __post_init__(self) -> None:
+        if self.in_channels <= 0 or self.out_channels <= 0:
+            raise ValueError("input and output channels must be positive")
+        if len(self.channels) < 2 or any(channel <= 0 for channel in self.channels):
+            raise ValueError("channels must contain at least two positive widths")
+
+
+class DoubleConv(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        # TODO: create two Conv-BatchNorm-ReLU layers.
+        raise NotImplementedError("Implement __init__")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # TODO: apply the double-convolution block.
+        raise NotImplementedError("Implement forward")
+
+
+class UpBlock(nn.Module):
+    def __init__(self, in_channels: int, skip_channels: int, out_channels: int) -> None:
+        # TODO: create the upsampler and the skip-fusion block.
+        raise NotImplementedError("Implement __init__")
+
+    def forward(self, x: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
+        # TODO: upsample, align, concatenate, and fuse.
+        raise NotImplementedError("Implement forward")
+
+
+class UNet(nn.Module):
+    def __init__(self, config: UNetConfig) -> None:
+        # TODO: assemble encoder blocks, bottleneck, decoder blocks, and output head.
+        raise NotImplementedError("Implement __init__")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # TODO: save skips, run the bottleneck, and decode in reverse order.
+        raise NotImplementedError("Implement forward")
+
+
+def smoke_test() -> None:
+    device = torch.device("cpu")
+    config = UNetConfig(out_channels=4, channels=(32, 64, 128))
+    model = UNet(config).to(device=device, dtype=torch.float32)
+    images = torch.randn(2, 3, 127, 131, device=device, dtype=torch.float32)
+    with torch.inference_mode():
+        logits = model(images)
+    assert logits.shape == (2, 4, 127, 131)
+    print(tuple(logits.shape))
+
+
+if __name__ == "__main__":
+    smoke_test()`,
+    solutionCode: `from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+@dataclass(frozen=True, slots=True)
+class UNetConfig:
+    in_channels: int = 3
+    out_channels: int = 1
+    channels: tuple[int, ...] = (64, 128, 256, 512)
+
+    def __post_init__(self) -> None:
+        if self.in_channels <= 0 or self.out_channels <= 0:
+            raise ValueError("input and output channels must be positive")
+        if len(self.channels) < 2 or any(channel <= 0 for channel in self.channels):
+            raise ValueError("channels must contain at least two positive widths")
+
+
+class DoubleConv(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, 3, padding=1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_channels, out_channels, 3, padding=1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+class UpBlock(nn.Module):
+    def __init__(self, in_channels: int, skip_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.upsample = nn.ConvTranspose2d(in_channels, out_channels, 2, stride=2)
+        self.fuse = DoubleConv(out_channels + skip_channels, out_channels)
+
+    def forward(self, x: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
+        x = self.upsample(x)
+        if x.shape[-2:] != skip.shape[-2:]:
+            x = F.interpolate(x, size=skip.shape[-2:], mode="bilinear", align_corners=False)
+        return self.fuse(torch.cat((skip, x), dim=1))
+
+
+class UNet(nn.Module):
+    def __init__(self, config: UNetConfig) -> None:
+        super().__init__()
+        encoder_channels = (config.in_channels, *config.channels[:-1])
+        self.encoder = nn.ModuleList(
+            DoubleConv(in_channels, out_channels)
+            for in_channels, out_channels in zip(encoder_channels, config.channels)
+        )
+        self.pool = nn.MaxPool2d(2)
+        bottleneck_channels = config.channels[-1] * 2
+        self.bottleneck = DoubleConv(config.channels[-1], bottleneck_channels)
+        decoder = []
+        current_channels = bottleneck_channels
+        for skip_channels in reversed(config.channels):
+            decoder.append(UpBlock(current_channels, skip_channels, skip_channels))
+            current_channels = skip_channels
+        self.decoder = nn.ModuleList(decoder)
+        self.output_head = nn.Conv2d(config.channels[0], config.out_channels, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        skips = []
+        for block in self.encoder:
+            x = block(x)
+            skips.append(x)
+            x = self.pool(x)
+        x = self.bottleneck(x)
+        for block, skip in zip(self.decoder, reversed(skips)):
+            x = block(x, skip)
+        return self.output_head(x)
+
+
+def smoke_test() -> None:
+    device = torch.device("cpu")
+    config = UNetConfig(out_channels=4, channels=(32, 64, 128))
+    model = UNet(config).to(device=device, dtype=torch.float32)
+    images = torch.randn(2, 3, 127, 131, device=device, dtype=torch.float32)
+    with torch.inference_mode():
+        logits = model(images)
+    assert logits.shape == (2, 4, 127, 131)
+    print(tuple(logits.shape))
+
+
+if __name__ == "__main__":
+    smoke_test()`,
+    packages: ['torch'],
+    tags: ['PyTorch', 'Architecture', 'U-Net', 'Segmentation', 'Clean Code'],
+  },
+  {
+    id: 'centernet-style-detector',
+    order: 38,
+    title: 'Build a CenterNet-style detector',
+    difficulty: 'Hard',
+    track: 'architecture',
+    environment: 'local-pytorch',
+    summary:
+      'Implement a compact keypoint detector with typed outputs and separate heatmap, size, and offset heads.',
+    prompt: [
+      'Design the prediction side of a CenterNet-style detector. The model should turn an image into a stride-four feature map, then predict class-center heatmap logits, box size, and sub-pixel center offset at every location.',
+      'Keep decoding and losses out of scope. In the interview, make the output contract explicit and explain why the heatmap head uses a negative prior bias.',
+    ],
+    signature: `@dataclass(frozen=True, slots=True)
+class CenterNetConfig: ...
+
+@dataclass(slots=True)
+class CenterNetOutput: ...
+
+class CenterNetDetector(nn.Module): ...`,
+    requirements: [
+      'Use a frozen config dataclass and a typed output dataclass.',
+      'Downsample the input by exactly four before the prediction heads.',
+      'Use separate heads for class heatmap logits, width/height, and center offset.',
+      'Initialize the final heatmap bias to `-2.19` so initial foreground probabilities are low.',
+      'Assume the input height and width are divisible by four.',
+      'Return heatmap logits shaped `(B, K, H/4, W/4)` and two regression maps shaped `(B, 2, H/4, W/4)`.',
+      'Do not apply sigmoid or decode boxes inside `forward`.',
+    ],
+    examples: [
+      {
+        label: 'Acceptance check',
+        lines: [
+          'config = CenterNetConfig(num_classes=6)',
+          'images.shape = (2, 3, 128, 160)',
+        ],
+        result: 'heatmap=(2, 6, 32, 40); size=(2, 2, 32, 40); offset=(2, 2, 32, 40)',
+      },
+    ],
+    hint: [
+      'Two stride-two convolutional blocks produce the required stride-four feature grid.',
+      'A small `PredictionHead` class keeps the three task heads structurally consistent.',
+      'Initialize only the last convolution in the heatmap head with the negative bias.',
+      'Returning logits keeps the model compatible with a numerically stable focal-style loss.',
+    ],
+    interview: {
+      durationMinutes: 45,
+      evaluationCriteria: [
+        'Defines the dense output shapes before implementing the modules.',
+        'Separates shared feature extraction from task-specific prediction heads.',
+        'Explains the heatmap prior and keeps post-processing outside `forward`.',
+      ],
+      followUps: [
+        'How would you decode these maps into image-space boxes?',
+        'Where would deformable convolutions or a feature pyramid fit?',
+      ],
+    },
+    solutionNotes: [
+      'The detector shares one stride-four feature map, then branches into three small heads. The heatmap answers which class center occupies each cell; the regression maps answer how large the box is and how far the continuous center lies from the integer cell.',
+      'Returning raw heatmap logits keeps loss computation stable and leaves thresholding, local-maximum suppression, top-k selection, and coordinate decoding outside the model boundary.',
+    ],
+    solutionDiagram: `image (B, 3, H, W)
+  -> stride-4 backbone (B, C, H/4, W/4)
+     |-> heatmap logits (B, K, H/4, W/4)
+     |-> box size       (B, 2, H/4, W/4)
+     +-> center offset  (B, 2, H/4, W/4)`,
+    starterCode: `from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+
+@dataclass(frozen=True, slots=True)
+class CenterNetConfig:
+    in_channels: int = 3
+    num_classes: int = 80
+    feature_channels: int = 128
+    head_channels: int = 64
+
+    def __post_init__(self) -> None:
+        if min(self.in_channels, self.num_classes, self.feature_channels, self.head_channels) <= 0:
+            raise ValueError("all channel counts and num_classes must be positive")
+        if self.feature_channels < 2:
+            raise ValueError("feature_channels must be at least two")
+
+
+@dataclass(slots=True)
+class CenterNetOutput:
+    heatmap_logits: torch.Tensor
+    size: torch.Tensor
+    offset: torch.Tensor
+
+
+class ConvNormAct(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1) -> None:
+        # TODO: build one stride-aware feature block.
+        raise NotImplementedError("Implement __init__")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # TODO: apply the feature block.
+        raise NotImplementedError("Implement forward")
+
+
+class PredictionHead(nn.Module):
+    def __init__(self, in_channels: int, hidden_channels: int, out_channels: int) -> None:
+        # TODO: build a small task-specific head.
+        raise NotImplementedError("Implement __init__")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # TODO: return the dense prediction map.
+        raise NotImplementedError("Implement forward")
+
+
+class CenterNetDetector(nn.Module):
+    def __init__(self, config: CenterNetConfig) -> None:
+        # TODO: assemble the stride-four backbone and three prediction heads.
+        raise NotImplementedError("Implement __init__")
+
+    def forward(self, x: torch.Tensor) -> CenterNetOutput:
+        # TODO: return typed heatmap, size, and offset maps.
+        raise NotImplementedError("Implement forward")
+
+
+def smoke_test() -> None:
+    device = torch.device("cpu")
+    model = CenterNetDetector(CenterNetConfig(num_classes=6)).to(device=device, dtype=torch.float32)
+    images = torch.randn(2, 3, 128, 160, device=device, dtype=torch.float32)
+    with torch.inference_mode():
+        output = model(images)
+    assert output.heatmap_logits.shape == (2, 6, 32, 40)
+    assert output.size.shape == output.offset.shape == (2, 2, 32, 40)
+    print(tuple(output.heatmap_logits.shape), tuple(output.size.shape), tuple(output.offset.shape))
+
+
+if __name__ == "__main__":
+    smoke_test()`,
+    solutionCode: `from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+
+@dataclass(frozen=True, slots=True)
+class CenterNetConfig:
+    in_channels: int = 3
+    num_classes: int = 80
+    feature_channels: int = 128
+    head_channels: int = 64
+
+    def __post_init__(self) -> None:
+        if min(self.in_channels, self.num_classes, self.feature_channels, self.head_channels) <= 0:
+            raise ValueError("all channel counts and num_classes must be positive")
+        if self.feature_channels < 2:
+            raise ValueError("feature_channels must be at least two")
+
+
+@dataclass(slots=True)
+class CenterNetOutput:
+    heatmap_logits: torch.Tensor
+    size: torch.Tensor
+    offset: torch.Tensor
+
+
+class ConvNormAct(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1) -> None:
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, 3, stride=stride, padding=1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+class PredictionHead(nn.Module):
+    def __init__(self, in_channels: int, hidden_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Conv2d(in_channels, hidden_channels, 3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(hidden_channels, out_channels, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+class CenterNetDetector(nn.Module):
+    def __init__(self, config: CenterNetConfig) -> None:
+        super().__init__()
+        mid_channels = config.feature_channels // 2
+        self.backbone = nn.Sequential(
+            ConvNormAct(config.in_channels, mid_channels, stride=2),
+            ConvNormAct(mid_channels, config.feature_channels, stride=2),
+            ConvNormAct(config.feature_channels, config.feature_channels),
+        )
+        self.heatmap_head = PredictionHead(config.feature_channels, config.head_channels, config.num_classes)
+        self.size_head = PredictionHead(config.feature_channels, config.head_channels, 2)
+        self.offset_head = PredictionHead(config.feature_channels, config.head_channels, 2)
+        nn.init.constant_(self.heatmap_head.layers[-1].bias, -2.19)
+
+    def forward(self, x: torch.Tensor) -> CenterNetOutput:
+        features = self.backbone(x)
+        return CenterNetOutput(
+            heatmap_logits=self.heatmap_head(features),
+            size=self.size_head(features),
+            offset=self.offset_head(features),
+        )
+
+
+def smoke_test() -> None:
+    device = torch.device("cpu")
+    model = CenterNetDetector(CenterNetConfig(num_classes=6)).to(device=device, dtype=torch.float32)
+    images = torch.randn(2, 3, 128, 160, device=device, dtype=torch.float32)
+    with torch.inference_mode():
+        output = model(images)
+    assert output.heatmap_logits.shape == (2, 6, 32, 40)
+    assert output.size.shape == output.offset.shape == (2, 2, 32, 40)
+    print(tuple(output.heatmap_logits.shape), tuple(output.size.shape), tuple(output.offset.shape))
+
+
+if __name__ == "__main__":
+    smoke_test()`,
+    packages: ['torch'],
+    tags: ['PyTorch', 'Architecture', 'CenterNet', 'Detection', 'Clean Code'],
+  },
+] as const satisfies readonly CodePracticeProblem[];

--- a/src/lib/code-practice.ts
+++ b/src/lib/code-practice.ts
@@ -1,3 +1,5 @@
+import { ARCHITECTURE_CODE_PRACTICE_PROBLEMS } from './code-practice-architectures';
+
 export interface CodePracticeExample {
   label: string;
   lines: readonly string[];
@@ -8,6 +10,12 @@ export interface CodePracticeVisual {
   src: string;
   alt: string;
   caption: string;
+}
+
+export interface CodePracticeInterviewFormat {
+  durationMinutes: number;
+  evaluationCriteria: readonly string[];
+  followUps: readonly string[];
 }
 
 export interface CodePracticeProblem {
@@ -28,12 +36,15 @@ export interface CodePracticeProblem {
   visual?: CodePracticeVisual;
   solutionDiagram?: string;
   starterCode: string;
+  track?: 'fundamentals' | 'architecture';
+  environment?: 'browser' | 'local-pytorch';
+  interview?: CodePracticeInterviewFormat;
   packages?: readonly string[];
   tags?: readonly string[];
 }
 
 export const CODE_PRACTICE_SECTION_SUMMARY =
-  'Interview-style PyTorch and NumPy exercises with runnable starter code, editor-inserted hints, and reference solutions.';
+  'Practice the way you would code in an ML interview: clarify the contract, design a small API, implement it cleanly, test shapes, and defend the tradeoffs.';
 
 const PYTORCH_AND_NUMPY_PACKAGES = ['torch', 'numpy'] as const;
 
@@ -4289,9 +4300,16 @@ const PROGRESSIVE_DIFFICULTY: Readonly<Record<string, CodePracticeProblem['diffi
   'classic-mlp-forward-backward': 'Hard',
 };
 
-export const codePracticeProblems: readonly CodePracticeProblem[] = [...RAW_CODE_PRACTICE_PROBLEMS]
+const ALL_CODE_PRACTICE_PROBLEMS: readonly CodePracticeProblem[] = [
+  ...RAW_CODE_PRACTICE_PROBLEMS,
+  ...ARCHITECTURE_CODE_PRACTICE_PROBLEMS,
+];
+
+export const codePracticeProblems: readonly CodePracticeProblem[] = ALL_CODE_PRACTICE_PROBLEMS
   .map((problem) => ({
     ...problem,
+    track: problem.track ?? 'fundamentals',
+    environment: problem.environment ?? 'browser',
     order: PROGRESSIVE_ORDER[problem.id] ?? problem.order,
     difficulty: PROGRESSIVE_DIFFICULTY[problem.id] ?? problem.difficulty,
     walkthroughCode: problem.solutionCode,

--- a/src/pages/code.astro
+++ b/src/pages/code.astro
@@ -7,18 +7,38 @@ import {
 } from '../lib/code-practice';
 
 const problemCountLabel = String(codePracticeProblems.length).padStart(2, '0');
+const fundamentals = codePracticeProblems.filter((problem) => problem.track !== 'architecture');
+const architectures = codePracticeProblems.filter((problem) => problem.track === 'architecture');
+const practiceTracks = [
+  {
+    id: 'fundamentals',
+    eyebrow: 'Track 01',
+    title: 'ML coding fundamentals',
+    summary:
+      'Short interview problems for tensor operations, losses, geometry, attention, matching, and manual backprop. These run in the browser.',
+    problems: fundamentals,
+  },
+  {
+    id: 'architectures',
+    eyebrow: 'Track 02',
+    title: 'Architecture builds',
+    summary:
+      'Longer local-PyTorch exercises for designing clean module boundaries, tracking shapes, and testing a complete model.',
+    problems: architectures,
+  },
+];
 ---
 
 <PostLayout
   title="Code"
-  description="Coding interview practice problems with runnable Python workspaces."
+  description="ML coding interview practice with runnable fundamentals and clean PyTorch architecture builds."
   showSectionsNav={false}
 >
   <section class="code-index">
     <div class="code-index__header">
       <div>
         <p class="code-index__eyebrow">Code</p>
-        <h1>Interview practice</h1>
+        <h1>ML coding interviews</h1>
         <p>{CODE_PRACTICE_SECTION_SUMMARY}</p>
       </div>
 
@@ -28,37 +48,65 @@ const problemCountLabel = String(codePracticeProblems.length).padStart(2, '0');
       </div>
     </div>
 
+    <section class="code-index__interview-loop" aria-labelledby="code-interview-loop-title">
+      <div>
+        <p class="code-index__eyebrow">Interview loop</p>
+        <h2 id="code-interview-loop-title">Practice the whole answer</h2>
+      </div>
+      <ol>
+        <li><strong>Clarify.</strong> State shapes, return values, and failure cases.</li>
+        <li><strong>Design.</strong> Sketch the smallest useful API and its data flow.</li>
+        <li><strong>Implement.</strong> Write typed, readable code and narrate key choices.</li>
+        <li><strong>Test.</strong> Check the happy path, one edge case, and the main tradeoff.</li>
+      </ol>
+    </section>
+
     <section class="code-index__environment" aria-labelledby="code-environment-title">
       <div>
-        <p class="code-index__eyebrow">Browser workspace</p>
-        <h2 id="code-environment-title">Run each problem locally</h2>
+        <p class="code-index__eyebrow">Two workspaces</p>
+        <h2 id="code-environment-title">Use the right runtime</h2>
         <p>
-          Every problem opens a local Python editor powered by Pyodide. NumPy loads on demand;
-          <code>torch</code> is a lightweight, NumPy-backed compatibility layer for the tensor
-          operations used in these exercises—not the full PyTorch runtime.
+          Fundamentals run in a browser Python editor. Architecture builds use real
+          <code>torch.nn</code> code and include a local smoke test because the browser compatibility
+          layer is not a full PyTorch runtime.
         </p>
       </div>
       <ul>
-        <li><kbd>Ctrl / Cmd + Enter</kbd> runs the current editor contents.</li>
+        <li><kbd>Ctrl / Cmd + Enter</kbd> runs browser exercises.</li>
         <li>Hints insert comments into the editor, and Solution loads the reference code.</li>
-        <li>No autograd, CUDA, or <code>nn.Module</code>.</li>
+        <li>Architecture exercises use dataclasses, classes, <code>nn.Module</code>, and typed outputs.</li>
       </ul>
     </section>
 
-    <ul class="code-index__list">
-      {codePracticeProblems.map((problem) => (
-        <li>
-          <a class="code-index__card" href={getCodePracticeProblemPath(problem)}>
-            <div class="code-index__card-header">
-              <p>{`Problem ${String(problem.order).padStart(2, '0')}`}</p>
-              <span>{problem.difficulty}</span>
-            </div>
-            <h2>{problem.title}</h2>
-            <p>{problem.summary}</p>
-            <strong>Open problem</strong>
-          </a>
-        </li>
-      ))}
-    </ul>
+    {practiceTracks.map((track) => (
+      <section class="code-index__track" aria-labelledby={`code-track-${track.id}`}>
+        <div class="code-index__track-heading">
+          <div>
+            <p class="code-index__eyebrow">{track.eyebrow}</p>
+            <h2 id={`code-track-${track.id}`}>{track.title}</h2>
+          </div>
+          <p>{track.summary}</p>
+        </div>
+
+        <ul class="code-index__list">
+          {track.problems.map((problem) => (
+            <li>
+              <a class="code-index__card" href={getCodePracticeProblemPath(problem)}>
+                <div class="code-index__card-header">
+                  <p>{`Problem ${String(problem.order).padStart(2, '0')}`}</p>
+                  <div class="code-index__card-badges">
+                    <span>{problem.environment === 'local-pytorch' ? 'Local PyTorch' : 'Browser'}</span>
+                    <span>{problem.difficulty}</span>
+                  </div>
+                </div>
+                <h3>{problem.title}</h3>
+                <p>{problem.summary}</p>
+                <strong>Open problem</strong>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
   </section>
 </PostLayout>

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -233,6 +233,32 @@ describe('CodePracticeLab', () => {
     expect(container.textContent).toContain('Ctrl / Cmd + Enter');
   });
 
+  it('keeps full nn.Module exercises editable without booting the browser shim', async () => {
+    await render({
+      ...testProblem,
+      id: 'resnet-from-building-blocks',
+      title: 'Build a configurable ResNet',
+      environment: 'local-pytorch',
+      track: 'architecture',
+      starterCode: `from torch import nn
+
+class ResNet(nn.Module):
+    def forward(self, x):
+        raise NotImplementedError("Implement forward")`,
+      solutionCode: `from torch import nn
+
+class ResNet(nn.Module):
+    def forward(self, x):
+        return x`,
+    });
+
+    expect(loadPyodideRuntime).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('Local PyTorch');
+    expect(container.textContent).toContain('full torch.nn API');
+    expect(container.querySelector('button[aria-label="Run code"]')).toBeNull();
+    expect(getEditor().textContent).toContain('class ResNet(nn.Module):');
+  });
+
   it('keeps the default workspace focused until a reference solution is loaded', async () => {
     loadPyodideRuntime.mockResolvedValueOnce({
       runPythonAsync: vi.fn(),

--- a/tests/code-practice-primitives.test.ts
+++ b/tests/code-practice-primitives.test.ts
@@ -79,7 +79,9 @@ describe('code-practice primitive-first solutions', () => {
   });
 
   it('keeps learner-facing reference implementations concise', () => {
-    for (const problem of codePracticeProblems) {
+    const fundamentals = codePracticeProblems.filter((problem) => problem.track === 'fundamentals');
+
+    for (const problem of fundamentals) {
       expect(problem.solutionCode.split('\n').length, problem.id).toBeLessThanOrEqual(45);
       expect(
         problem.solutionCode.split('\n').filter((line) => line.trimStart().startsWith('#')),
@@ -89,7 +91,9 @@ describe('code-practice primitive-first solutions', () => {
   });
 
   it('does not bypass a lesson with a matching PyTorch convenience helper', () => {
-    const torchProblems = codePracticeProblems.filter((problem) => problem.packages?.includes('torch'));
+    const torchProblems = codePracticeProblems.filter(
+      (problem) => problem.track === 'fundamentals' && problem.packages?.includes('torch'),
+    );
 
     for (const problem of torchProblems) {
       for (const call of BANNED_CONVENIENCE_CALLS) {
@@ -128,5 +132,31 @@ describe('code-practice primitive-first solutions', () => {
   it('supports tensor transpose methods used by 2D and attention references', () => {
     expect(TORCH_COMPAT_SOURCE).toContain('def permute(self, *dims):');
     expect(TORCH_COMPAT_SOURCE).toContain('def transpose(self, dim0, dim1):');
+  });
+
+  it('keeps architecture interviews typed, modular, and local-PyTorch only', () => {
+    const architectures = codePracticeProblems.filter((problem) => problem.track === 'architecture');
+
+    expect(architectures.map((problem) => problem.id)).toEqual([
+      'resnet-from-building-blocks',
+      'unet-encoder-decoder',
+      'centernet-style-detector',
+    ]);
+
+    for (const problem of architectures) {
+      expect(problem.environment, problem.id).toBe('local-pytorch');
+      expect(problem.interview?.durationMinutes, problem.id).toBeGreaterThanOrEqual(45);
+      expect(problem.solutionCode, problem.id).toContain('@dataclass');
+      expect(problem.solutionCode, problem.id).toContain('nn.Module');
+      expect(problem.solutionCode, problem.id).toContain('def smoke_test()');
+      expect(problem.solutionCode, problem.id).toContain('with torch.inference_mode():');
+    }
+
+    expect(architectures[0].solutionCode).toContain('nn.AdaptiveAvgPool2d(1)');
+    expect(architectures[1].solutionCode).toContain('F.interpolate(');
+    expect(architectures[1].solutionCode).toContain('nn.ModuleList(');
+    expect(architectures[2].solutionCode).toContain('class CenterNetOutput:');
+    expect(architectures[2].solutionCode).toContain('nn.init.constant_');
+    expect(architectures[2].solutionCode).toContain('-2.19');
   });
 });


### PR DESCRIPTION
## What changed
- frame every exercise around an interview prompt, rubric, acceptance checks, and time box
- split the index into browser-runnable fundamentals and local PyTorch architecture builds
- add configurable ResNet, U-Net, and CenterNet-style detector exercises with dataclasses, nn.Module boundaries, typed outputs, and smoke tests
- keep local-only architecture work out of the lightweight browser torch shim

## Validation
- npm run ci
- real PyTorch smoke tests for all three architectures
- desktop and 390px mobile layout checks for the index and ResNet workspace