### PR TITLE
Add attention inference interview exercises

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -4500,6 +4500,59 @@ html {
   border-top: 1px solid var(--code-border-color);
 }
 
+.code-practice-lab__reasoning {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.2rem;
+}
+
+.code-practice-lab__reasoning-heading h2 {
+  margin: 0.2rem 0 0;
+  color: inherit;
+  font-size: 1.05rem;
+  line-height: 1.25;
+}
+
+.code-practice-lab__reasoning-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.code-practice-lab__reasoning-card {
+  min-width: 0;
+  padding: 0.75rem;
+  border: 1px solid var(--code-border-color);
+  border-radius: 0.65rem;
+  background: rgba(118, 169, 255, 0.06);
+}
+
+.code-practice-lab__reasoning-card h3,
+.code-practice-lab__reasoning-card p {
+  margin: 0;
+}
+
+.code-practice-lab__reasoning-card h3 {
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.35;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.code-practice-lab__reasoning-card p {
+  margin-top: 0.45rem;
+  color: var(--text-secondary-color);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+:root[data-theme="dark"] .code-practice-lab__reasoning-card {
+  background: rgba(255, 228, 92, 0.04);
+}
+
 .code-practice-lab__runtime-note--local {
   margin: 0;
   padding: 0.75rem 1rem;
@@ -7117,6 +7170,10 @@ html {
   }
 
   .code-index__environment {
+    grid-template-columns: 1fr;
+  }
+
+  .code-practice-lab__reasoning-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -311,6 +311,26 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
           )}
         </section>
 
+        {problem.reasoning && problem.reasoning.length > 0 && (
+          <section
+            className="code-practice-lab__reasoning"
+            aria-labelledby={`${problem.id}-reasoning-title`}
+          >
+            <div className="code-practice-lab__reasoning-heading">
+              <p className="code-practice-lab__section-label">Reason through the system</p>
+              <h2 id={`${problem.id}-reasoning-title`}>Defend the tradeoffs</h2>
+            </div>
+            <div className="code-practice-lab__reasoning-grid">
+              {problem.reasoning.map((point) => (
+                <article key={point.axis} className="code-practice-lab__reasoning-card">
+                  <h3>{point.axis}</h3>
+                  <p>{point.detail}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
+
         {problem.visual && (
           <figure className="code-practice-lab__visual">
             <img src={problem.visual.src} alt={problem.visual.alt} loading="lazy" />

--- a/src/lib/code-practice-architectures.ts
+++ b/src/lib/code-practice-architectures.ts
@@ -3,7 +3,7 @@ import type { CodePracticeProblem } from './code-practice';
 export const ARCHITECTURE_CODE_PRACTICE_PROBLEMS = [
   {
     id: 'resnet-from-building-blocks',
-    order: 36,
+    order: 38,
     title: 'Build a configurable ResNet',
     difficulty: 'Hard',
     track: 'architecture',
@@ -220,7 +220,7 @@ if __name__ == "__main__":
   },
   {
     id: 'unet-encoder-decoder',
-    order: 37,
+    order: 39,
     title: 'Build a U-Net encoder-decoder',
     difficulty: 'Hard',
     track: 'architecture',
@@ -445,7 +445,7 @@ if __name__ == "__main__":
   },
   {
     id: 'centernet-style-detector',
-    order: 38,
+    order: 40,
     title: 'Build a CenterNet-style detector',
     difficulty: 'Hard',
     track: 'architecture',

--- a/src/lib/code-practice-attention.ts
+++ b/src/lib/code-practice-attention.ts
@@ -1,0 +1,531 @@
+import type { CodePracticeProblem } from './code-practice';
+
+const PYTORCH_AND_NUMPY_PACKAGES = ['torch', 'numpy'] as const;
+
+type AttentionProblemEnrichment = Pick<
+  CodePracticeProblem,
+  'reasoning' | 'interview'
+> &
+  Partial<Pick<CodePracticeProblem, 'title' | 'summary'>>;
+
+export const ATTENTION_PROBLEM_ENRICHMENTS: Readonly<
+  Record<string, AttentionProblemEnrichment>
+> = {
+  'stable-softmax-cross-entropy': {
+    reasoning: [
+      {
+        axis: 'Tensor reasoning',
+        detail:
+          'For logits `(N, C)`, the row maximum has shape `(N, 1)`. Keeping the class axis makes the subtraction broadcast across each row without mixing examples.',
+      },
+      {
+        axis: 'Inference efficiency',
+        detail:
+          'The reference exposes the reductions. Production kernels normally fuse the max, exponentiation, sum, and normalization to reduce memory traffic.',
+      },
+      {
+        axis: 'Memory / computation tradeoff',
+        detail:
+          'Materializing shifted logits and exponentials is clear but costs two `(N, C)` buffers. A fused kernel keeps fewer intermediates live.',
+      },
+    ],
+    interview: {
+      durationMinutes: 30,
+      evaluationCriteria: [
+        'States why subtracting one row maximum leaves softmax probabilities unchanged.',
+        'Tracks `(N, C)`, `(N, 1)`, and `(N,)` through every reduction and gather.',
+        'Tests a large-logit case that would overflow a naive implementation.',
+      ],
+      followUps: [
+        'How would you handle an all-masked row in attention softmax?',
+        'Why might a fused softmax kernel use less memory than this reference?',
+      ],
+    },
+  },
+  'causal-attention-mask': {
+    reasoning: [
+      {
+        axis: 'Tensor reasoning',
+        detail:
+          'Query positions form the row axis and key positions form the column axis. Comparing `(T, 1) >= (1, T)` creates the `(T, T)` visibility matrix.',
+      },
+      {
+        axis: 'Inference efficiency',
+        detail:
+          'During single-token append-only decoding, a kernel can avoid materializing a full mask because the query is already at the newest valid position.',
+      },
+      {
+        axis: 'Memory / computation tradeoff',
+        detail:
+          'A dense `(T, T)` mask is easy to inspect but grows quadratically. Production attention kernels usually encode causality in indexing rather than storing the matrix.',
+      },
+      {
+        axis: 'Cache update correctness',
+        detail:
+          'With a cache, compare absolute query positions against absolute key positions. A fresh local lower triangle is wrong when the query chunk starts after position zero.',
+      },
+    ],
+    interview: {
+      durationMinutes: 30,
+      evaluationCriteria: [
+        'Names the query-row and key-column axes before broadcasting them.',
+        'Combines causality with per-example padding without Python loops.',
+        'Explains how cached decoding changes the position indices.',
+      ],
+      followUps: [
+        'How would the mask change for a query chunk that begins at `start_pos > 0`?',
+        'When can a decoding kernel omit the explicit mask?',
+      ],
+    },
+  },
+  'rope-rotary-positional-embedding': {
+    reasoning: [
+      {
+        axis: 'Tensor reasoning',
+        detail:
+          'Even and odd channels each have shape `(B, T, H, D / 2)`. Sine and cosine tables use `(1, T, 1, D / 2)` so they broadcast over batches and heads.',
+      },
+      {
+        axis: 'Inference efficiency',
+        detail:
+          'Decode only needs the angles for the new absolute positions. Rebuilding a table for the whole prefix repeats work that the cache does not need.',
+      },
+      {
+        axis: 'Memory / computation tradeoff',
+        detail:
+          'Precomputed sine and cosine tables trade a small linear memory cost for fewer transcendental operations. Computing them on demand avoids a long-lived table.',
+      },
+      {
+        axis: 'Cache update correctness',
+        detail:
+          'Rotate each key exactly once at its absolute position before caching it. Re-rotating cached keys or restarting positions at zero silently corrupts attention scores.',
+      },
+    ],
+    interview: {
+      durationMinutes: 35,
+      evaluationCriteria: [
+        'Explains the adjacent-pair rotation and the even head-dimension requirement.',
+        'Tracks the broadcast shape of the angle table.',
+        'Connects the position offset to incremental KV-cache updates.',
+      ],
+      followUps: [
+        'How would you add `start_pos` for cached decoding?',
+        'Why are queries and keys rotated but values are not?',
+      ],
+    },
+  },
+  'scaled-dot-product-self-attention': {
+    title: 'Multi-head self-attention (MHA)',
+    summary:
+      'Implement MHA end to end: project Q/K/V, split heads, apply stable masked attention, merge heads, and project the result.',
+    reasoning: [
+      {
+        axis: 'Tensor reasoning',
+        detail:
+          'Splitting `(B, T, D_model)` gives Q/K/V shaped `(B, H, T, D_head)`. `Q @ Kᵀ` then produces scores `(B, H, T, T)` before values restore the last axis to `D_head`.',
+      },
+      {
+        axis: 'Inference efficiency',
+        detail:
+          'Prefill computes all token pairs. During decode, caching past K/V avoids re-projecting the prefix, so one new query attends over `T` cached keys instead of recomputing the whole prefix.',
+      },
+      {
+        axis: 'Memory / computation tradeoff',
+        detail:
+          'The score matrix is quadratic during prefill, while the decode cache grows linearly as `2 × B × H × T × D_head` elements for keys and values.',
+      },
+      {
+        axis: 'Cache update correctness',
+        detail:
+          'A cached implementation must append K/V along the sequence axis, preserve batch/head/head-dimension layout, and apply the same positional transform exactly once.',
+      },
+    ],
+    interview: {
+      durationMinutes: 45,
+      evaluationCriteria: [
+        'Writes every intermediate tensor shape before the matrix multiplications.',
+        'Applies masking before a stable softmax and handles blocked entries exactly.',
+        'Explains what changes between prefill and single-token decode.',
+      ],
+      followUps: [
+        'Where would you insert RoPE and a KV cache?',
+        'Which tensors dominate memory during prefill and during decode?',
+      ],
+    },
+  },
+};
+
+export const ATTENTION_CODE_PRACTICE_PROBLEMS = [
+  {
+    id: 'incremental-kv-cache',
+    order: 29,
+    title: 'Build an append-correct KV cache',
+    difficulty: 'Hard',
+    summary:
+      'Implement a stateful KV cache that validates tensor layout, appends along the sequence axis, and rejects stale or skipped positions.',
+    prompt: [
+      'You are implementing autoregressive decoding. Build a `KVCache` dataclass whose `update(key, value, start_pos)` method stores new key/value chunks shaped `(B, H_kv, T_new, D_head)`.',
+      'Treat `start_pos` as an explicit correctness contract. An update is valid only when it starts at the current cache length; stale writes and gaps must fail instead of silently changing token positions.',
+    ],
+    signature: `@dataclass(slots=True)
+class KVCache:
+    key: torch.Tensor | None = None
+    value: torch.Tensor | None = None
+    length: int = 0
+
+    def update(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        start_pos: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        ...`,
+    requirements: [
+      '`key` and `value` have the same positive shape `(B, H_kv, T_new, D_head)`.',
+      '`start_pos` must equal the current cache length; the first update must start at zero.',
+      'Later updates must preserve batch size, KV-head count, and head dimension.',
+      'Append only along sequence axis `2`, update `length`, and return the complete cached tensors.',
+      'Raise `ValueError` for malformed tensors, stale writes, or skipped positions.',
+    ],
+    examples: [
+      {
+        label: 'Two decode updates',
+        lines: [
+          'cache.update(k0, v0, start_pos=0)  # k0.shape == (1, 2, 2, 4)',
+          'keys, values = cache.update(k1, v1, start_pos=2)',
+        ],
+        result: 'keys.shape == values.shape == (1, 2, 3, 4) and cache.length == 3',
+      },
+      {
+        label: 'Rejected stale write',
+        lines: ['cache.length == 3', 'cache.update(k1, v1, start_pos=2)'],
+        result: 'ValueError: start_pos must equal the current cache length',
+      },
+    ],
+    hint: [
+      'The sequence axis is `2` in `(B, H_kv, T, D_head)`; the other three axes must stay stable across updates.',
+      'Check `start_pos == self.length` before mutating either tensor.',
+      'Clone the first chunk so outside mutation cannot rewrite cached history.',
+      'This browser reference uses `torch.cat` for clarity. Be ready to discuss why a production cache would preallocate storage.',
+    ],
+    reasoning: [
+      {
+        axis: 'Tensor reasoning',
+        detail:
+          'Only axis `2` grows. Batch size, KV-head count, and head dimension identify the cache layout and must match every later update.',
+      },
+      {
+        axis: 'Inference efficiency',
+        detail:
+          'The cache removes repeated K/V projection for the prefix. Each decode step projects only the new token chunk and reads the stored history.',
+      },
+      {
+        axis: 'Memory / computation tradeoff',
+        detail:
+          'The cache uses linear memory, `2 × B × H_kv × T × D_head` elements. This clear `cat` implementation reallocates; production systems preallocate or page storage to avoid quadratic copying.',
+      },
+      {
+        axis: 'Cache update correctness',
+        detail:
+          'Checking `start_pos == length` makes updates append-only. Perform every validation before assignment so a failed update cannot leave key and value state out of sync.',
+      },
+    ],
+    interview: {
+      durationMinutes: 40,
+      evaluationCriteria: [
+        'States the `(B, H_kv, T, D_head)` layout and identifies the append axis.',
+        'Validates the full update before mutating cache state.',
+        'Explains concatenation versus preallocation and quantifies cache growth.',
+      ],
+      followUps: [
+        'How would you redesign this with preallocated or paged storage?',
+        'Where should RoPE be applied relative to the cache write?',
+        'How would beam search change the cache API?',
+      ],
+    },
+    solutionNotes: [
+      'The cache is a small state machine. `length` is the next legal absolute position, so equality with `start_pos` rejects both overwrites and gaps.',
+      'All validation happens before mutation. That ordering matters because an exception after writing keys but before writing values would leave an unusable cache.',
+      'Concatenation keeps the interview implementation readable. A serving system would normally preallocate, use blocks, or use paged attention so repeated appends do not copy the full prefix.',
+    ],
+    solutionDiagram: `new K,V: (B, Hkv, Tnew, Dh)
+                 append on axis 2
+cache K,V: (B, Hkv, Tpast + Tnew, Dh)
+
+legal update: start_pos == cache.length
+new length:   start_pos + Tnew`,
+    starterCode: `from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(slots=True)
+class KVCache:
+    key: torch.Tensor | None = None
+    value: torch.Tensor | None = None
+    length: int = 0
+
+    def update(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        start_pos: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # TODO: validate the whole append, mutate both tensors, then advance length.
+        raise NotImplementedError("Implement update")
+
+
+cache = KVCache()
+k0 = torch.ones(1, 2, 2, 4, dtype=torch.float64)
+v0 = torch.zeros(1, 2, 2, 4, dtype=torch.float64)
+k1 = torch.ones(1, 2, 1, 4, dtype=torch.float64)
+v1 = torch.zeros(1, 2, 1, 4, dtype=torch.float64)
+cache.update(k0, v0, start_pos=0)
+keys, values = cache.update(k1, v1, start_pos=2)
+print(tuple(keys.shape), tuple(values.shape), cache.length)`,
+    solutionCode: `from dataclasses import dataclass
+import torch
+
+@dataclass(slots=True)
+class KVCache:
+    key: torch.Tensor | None = None
+    value: torch.Tensor | None = None
+    length: int = 0
+
+    def update(self, key, value, start_pos):
+        key = torch.as_tensor(key, dtype=torch.float64)
+        value = torch.as_tensor(value, dtype=torch.float64)
+        if key.ndim != 4 or any(size <= 0 for size in key.shape): raise ValueError("key must have positive shape (B, H_kv, T, D_head)")
+        if value.shape != key.shape: raise ValueError("value must match key shape")
+        if start_pos != self.length: raise ValueError("start_pos must equal the current cache length")
+        if self.key is not None:
+            cached_layout = (self.key.shape[0], self.key.shape[1], self.key.shape[3])
+            update_layout = (key.shape[0], key.shape[1], key.shape[3])
+            if cached_layout != update_layout: raise ValueError("cache layout changed")
+            next_key = torch.cat((self.key, key), dim=2)
+            next_value = torch.cat((self.value, value), dim=2)
+        else:
+            next_key, next_value = key.clone(), value.clone()
+        self.key, self.value = next_key, next_value
+        self.length = start_pos + key.shape[2]
+        return self.key, self.value`,
+    walkthroughCode: `from dataclasses import dataclass
+import torch
+
+@dataclass(slots=True)
+class KVCache:
+    key: torch.Tensor | None = None
+    value: torch.Tensor | None = None
+    length: int = 0
+
+    def update(self, key, value, start_pos):
+        # Normalize both chunks before checking any state transition.
+        key = torch.as_tensor(key, dtype=torch.float64)
+        value = torch.as_tensor(value, dtype=torch.float64)
+        if key.ndim != 4 or any(size <= 0 for size in key.shape):
+            raise ValueError("key must have positive shape (B, H_kv, T, D_head)")
+        if value.shape != key.shape:
+            raise ValueError("value must match key shape")
+        # Equality rejects both a stale overwrite and a skipped position.
+        if start_pos != self.length:
+            raise ValueError("start_pos must equal the current cache length")
+
+        if self.key is not None:
+            # Sequence length may grow; batch, KV heads, and head width may not.
+            cached_layout = (self.key.shape[0], self.key.shape[1], self.key.shape[3])
+            update_layout = (key.shape[0], key.shape[1], key.shape[3])
+            if cached_layout != update_layout:
+                raise ValueError("cache layout changed")
+            next_key = torch.cat((self.key, key), dim=2)
+            next_value = torch.cat((self.value, value), dim=2)
+        else:
+            # Own the first chunk instead of aliasing the caller's mutable tensor.
+            next_key, next_value = key.clone(), value.clone()
+
+        # Mutate only after every check and both next tensors have succeeded.
+        self.key, self.value = next_key, next_value
+        self.length = start_pos + key.shape[2]
+        return self.key, self.value`,
+    packages: PYTORCH_AND_NUMPY_PACKAGES,
+    tags: ['PyTorch', 'Transformers', 'Inference', 'KV Cache'],
+  },
+  {
+    id: 'grouped-query-and-multi-query-attention',
+    order: 30,
+    title: 'Implement GQA and MQA',
+    difficulty: 'Hard',
+    summary:
+      'Implement one grouped-query attention kernel whose KV-head count covers MHA, GQA, and MQA.',
+    prompt: [
+      'Implement `grouped_query_attention(query, key, value, mask=None)` for pre-split tensors. Queries have shape `(B, H_q, T_q, D_head)` while keys and values have shape `(B, H_kv, T_k, D_head)`.',
+      'Require `H_q` to be divisible by `H_kv`. Repeat each KV head across its query-head group, compute stable masked attention, and return `(B, H_q, T_q, D_head)`. Explain how `H_kv = H_q`, `1 < H_kv < H_q`, and `H_kv = 1` correspond to MHA, GQA, and MQA.',
+    ],
+    signature: `def grouped_query_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    ...`,
+    requirements: [
+      '`query` has shape `(B, H_q, T_q, D_head)`; `key` and `value` share `(B, H_kv, T_k, D_head)`.',
+      '`H_q % H_kv == 0`; each KV head serves `H_q / H_kv` adjacent query heads.',
+      '`mask`, if supplied, is broadcastable to `(B, H_q, T_q, T_k)` with `1` for visible positions.',
+      'Use scaled dot-product attention and a numerically stable masked softmax.',
+      'Return `(B, H_q, T_q, D_head)` and reject incompatible shapes.',
+    ],
+    examples: [
+      {
+        label: 'Grouped-query attention',
+        lines: ['query.shape = (2, 8, 1, 64)', 'key.shape = value.shape = (2, 2, 128, 64)'],
+        result: 'output.shape == (2, 8, 1, 64); each KV head serves four query heads',
+      },
+      {
+        label: 'Variant boundary',
+        lines: ['H_q = 8'],
+        result: 'H_kv = 8 is MHA; H_kv = 2 is GQA; H_kv = 1 is MQA',
+      },
+    ],
+    hint: [
+      'Insert a group axis: `(B, H_kv, 1, T_k, D_head)`, broadcast it to the group count, then merge KV-head and group axes.',
+      'After repetition, Q/K/V all expose `H_q` heads, so the score shape is `(B, H_q, T_q, T_k)`.',
+      'Set blocked logits to negative infinity before the stable softmax.',
+      'The explicit repetition is pedagogical. A production GQA kernel should map query heads to KV heads without materializing copies.',
+    ],
+    reasoning: [
+      {
+        axis: 'Tensor reasoning',
+        detail:
+          'Reshape the KV-head mapping as `H_kv × groups = H_q`. Repeating K/V changes the exposed head axis, not batch, sequence, or head width.',
+      },
+      {
+        axis: 'Inference efficiency',
+        detail:
+          'GQA and MQA reduce KV projection work, cache reads, and memory bandwidth. The attention score tensor still has `H_q` query heads.',
+      },
+      {
+        axis: 'Memory / computation tradeoff',
+        detail:
+          'Cache size falls by `H_kv / H_q` versus MHA. Explicitly repeating K/V can give that memory back, so optimized kernels use grouped indexing without materializing copies.',
+      },
+      {
+        axis: 'Cache update correctness',
+        detail:
+          'Store only the original `H_kv` heads. Repeating before the cache write wastes memory and can make the cache layout inconsistent with future updates.',
+      },
+    ],
+    interview: {
+      durationMinutes: 45,
+      evaluationCriteria: [
+        'Derives the KV repeat factor from `H_q / H_kv` and tracks every shape.',
+        'Uses stable masked softmax without hiding the core operations.',
+        'Quantifies the KV-cache reduction and identifies explicit repetition as a reference-only cost.',
+      ],
+      followUps: [
+        'How would a fused kernel avoid materializing repeated K/V heads?',
+        'What fraction of MHA cache memory does `H_q = 32, H_kv = 8` use?',
+        'Would GQA reduce the `(T_q, T_k)` score computation by the same factor?',
+      ],
+    },
+    solutionNotes: [
+      'MHA, GQA, and MQA differ only in the number of KV heads. The query-head count stays fixed, and `repeat = H_q / H_kv` maps each stored KV head to its query-head group.',
+      'The reference broadcasts then reshapes K/V so the matrix multiplications are easy to inspect. Optimized kernels keep the compact KV representation and perform the mapping inside the attention kernel.',
+      'The cache stores `(B, H_kv, T_k, D_head)`, not the repeated view. That is where GQA and MQA save decode memory and bandwidth.',
+    ],
+    solutionDiagram: `Q: (B, Hq,  Tq, Dh)
+K: (B, Hkv, Tk, Dh) ─ repeat groups=Hq/Hkv ┐
+V: (B, Hkv, Tk, Dh) ─ repeat groups=Hq/Hkv ┤
+                                                  ↓
+scores: (B, Hq, Tq, Tk) -> output: (B, Hq, Tq, Dh)
+
+Hkv = Hq: MHA   |   1 < Hkv < Hq: GQA   |   Hkv = 1: MQA`,
+    starterCode: `from __future__ import annotations
+
+import torch
+
+
+def grouped_query_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    # TODO: validate heads, expose each KV head to its query group, then attend stably.
+    raise NotImplementedError("Implement grouped_query_attention")
+
+
+query = torch.ones(1, 4, 1, 2, dtype=torch.float64)
+key = torch.ones(1, 2, 3, 2, dtype=torch.float64)
+value = torch.tensor(
+    [[[[1.0, 0.0], [2.0, 0.0], [3.0, 0.0]],
+      [[0.0, 1.0], [0.0, 2.0], [0.0, 3.0]]]],
+    dtype=torch.float64,
+)
+print(grouped_query_attention(query, key, value).shape)`,
+    solutionCode: `import torch
+
+def _repeat_kv(tensor, repeats):
+    batch, heads, length, dim = tensor.shape
+    expanded = torch.broadcast_to(
+        tensor[:, :, None, :, :], (batch, heads, repeats, length, dim)
+    )
+    return torch.reshape(expanded, (batch, heads * repeats, length, dim))
+
+def _stable_masked_softmax(scores):
+    valid = torch.isfinite(scores)
+    scores = torch.where(valid, scores, torch.zeros_like(scores))
+    scores = scores - torch.amax(scores, dim=-1, keepdim=True)
+    weights = torch.exp(scores) * torch.as_tensor(valid, dtype=scores.dtype)
+    return weights / torch.clamp(torch.sum(weights, dim=-1, keepdim=True), min=1e-8)
+
+def grouped_query_attention(query, key, value, mask=None):
+    if query.ndim != 4 or key.ndim != 4 or value.shape != key.shape: raise ValueError("expected Q and matching K/V tensors with rank four")
+    batch, query_heads, query_len, head_dim = query.shape
+    kv_batch, kv_heads, key_len, kv_dim = key.shape
+    if batch != kv_batch or head_dim != kv_dim or query_heads % kv_heads != 0: raise ValueError("incompatible batch, head, or feature dimensions")
+    repeats = query_heads // kv_heads
+    key, value = _repeat_kv(key, repeats), _repeat_kv(value, repeats)
+    scores = query @ key.transpose(-1, -2) / (head_dim ** 0.5)
+    if mask is not None:
+        mask = torch.broadcast_to(torch.as_tensor(mask), scores.shape)
+        scores = torch.where(mask != 0, scores, torch.full_like(scores, float("-inf")))
+    return _stable_masked_softmax(scores) @ value`,
+    walkthroughCode: `import torch
+
+def _repeat_kv(tensor, repeats):
+    batch, heads, length, dim = tensor.shape
+    # Insert a group axis, broadcast each stored head, then merge head and group.
+    expanded = torch.broadcast_to(
+        tensor[:, :, None, :, :], (batch, heads, repeats, length, dim)
+    )
+    return torch.reshape(expanded, (batch, heads * repeats, length, dim))
+
+def _stable_masked_softmax(scores):
+    valid = torch.isfinite(scores)
+    scores = torch.where(valid, scores, torch.zeros_like(scores))
+    scores = scores - torch.amax(scores, dim=-1, keepdim=True)
+    weights = torch.exp(scores) * torch.as_tensor(valid, dtype=scores.dtype)
+    return weights / torch.clamp(torch.sum(weights, dim=-1, keepdim=True), min=1e-8)
+
+def grouped_query_attention(query, key, value, mask=None):
+    if query.ndim != 4 or key.ndim != 4 or value.shape != key.shape:
+        raise ValueError("expected Q and matching K/V tensors with rank four")
+    batch, query_heads, query_len, head_dim = query.shape
+    kv_batch, kv_heads, key_len, kv_dim = key.shape
+    if batch != kv_batch or head_dim != kv_dim or query_heads % kv_heads != 0:
+        raise ValueError("incompatible batch, head, or feature dimensions")
+
+    # MHA repeats once, GQA repeats by its group size, and MQA repeats one KV head Hq times.
+    repeats = query_heads // kv_heads
+    key, value = _repeat_kv(key, repeats), _repeat_kv(value, repeats)
+    scores = query @ key.transpose(-1, -2) / (head_dim ** 0.5)
+    if mask is not None:
+        mask = torch.broadcast_to(torch.as_tensor(mask), scores.shape)
+        scores = torch.where(mask != 0, scores, torch.full_like(scores, float("-inf")))
+    return _stable_masked_softmax(scores) @ value`,
+    packages: PYTORCH_AND_NUMPY_PACKAGES,
+    tags: ['PyTorch', 'Transformers', 'GQA', 'MQA', 'Inference'],
+  },
+] as const satisfies readonly CodePracticeProblem[];

--- a/src/lib/code-practice.ts
+++ b/src/lib/code-practice.ts
@@ -1,4 +1,8 @@
 import { ARCHITECTURE_CODE_PRACTICE_PROBLEMS } from './code-practice-architectures';
+import {
+  ATTENTION_CODE_PRACTICE_PROBLEMS,
+  ATTENTION_PROBLEM_ENRICHMENTS,
+} from './code-practice-attention';
 
 export interface CodePracticeExample {
   label: string;
@@ -16,6 +20,17 @@ export interface CodePracticeInterviewFormat {
   durationMinutes: number;
   evaluationCriteria: readonly string[];
   followUps: readonly string[];
+}
+
+export type CodePracticeReasoningAxis =
+  | 'Inference efficiency'
+  | 'Tensor reasoning'
+  | 'Memory / computation tradeoff'
+  | 'Cache update correctness';
+
+export interface CodePracticeReasoningPoint {
+  axis: CodePracticeReasoningAxis;
+  detail: string;
 }
 
 export interface CodePracticeProblem {
@@ -39,6 +54,7 @@ export interface CodePracticeProblem {
   track?: 'fundamentals' | 'architecture';
   environment?: 'browser' | 'local-pytorch';
   interview?: CodePracticeInterviewFormat;
+  reasoning?: readonly CodePracticeReasoningPoint[];
   packages?: readonly string[];
   tags?: readonly string[];
 }
@@ -4253,13 +4269,15 @@ const PROGRESSIVE_ORDER: Readonly<Record<string, number>> = {
   'causal-attention-mask': 26,
   'rope-rotary-positional-embedding': 27,
   'scaled-dot-product-self-attention': 28,
-  'cross-attention': 29,
-  'simple-n-gram-language-model': 30,
-  'average-precision-from-matches': 31,
-  'greedy-detection-matching': 32,
-  'batched-best-iou-match': 33,
-  'manual-backprop-for-a-2-layer-mlp': 34,
-  'classic-mlp-forward-backward': 35,
+  'incremental-kv-cache': 29,
+  'grouped-query-and-multi-query-attention': 30,
+  'cross-attention': 31,
+  'simple-n-gram-language-model': 32,
+  'average-precision-from-matches': 33,
+  'greedy-detection-matching': 34,
+  'batched-best-iou-match': 35,
+  'manual-backprop-for-a-2-layer-mlp': 36,
+  'classic-mlp-forward-backward': 37,
 };
 
 const PROGRESSIVE_DIFFICULTY: Readonly<Record<string, CodePracticeProblem['difficulty']>> = {
@@ -4291,6 +4309,8 @@ const PROGRESSIVE_DIFFICULTY: Readonly<Record<string, CodePracticeProblem['diffi
   'causal-attention-mask': 'Medium',
   'rope-rotary-positional-embedding': 'Medium',
   'scaled-dot-product-self-attention': 'Hard',
+  'incremental-kv-cache': 'Hard',
+  'grouped-query-and-multi-query-attention': 'Hard',
   'cross-attention': 'Hard',
   'simple-n-gram-language-model': 'Hard',
   'average-precision-from-matches': 'Hard',
@@ -4302,17 +4322,19 @@ const PROGRESSIVE_DIFFICULTY: Readonly<Record<string, CodePracticeProblem['diffi
 
 const ALL_CODE_PRACTICE_PROBLEMS: readonly CodePracticeProblem[] = [
   ...RAW_CODE_PRACTICE_PROBLEMS,
+  ...ATTENTION_CODE_PRACTICE_PROBLEMS,
   ...ARCHITECTURE_CODE_PRACTICE_PROBLEMS,
 ];
 
 export const codePracticeProblems: readonly CodePracticeProblem[] = ALL_CODE_PRACTICE_PROBLEMS
   .map((problem) => ({
     ...problem,
+    ...ATTENTION_PROBLEM_ENRICHMENTS[problem.id],
     track: problem.track ?? 'fundamentals',
     environment: problem.environment ?? 'browser',
     order: PROGRESSIVE_ORDER[problem.id] ?? problem.order,
     difficulty: PROGRESSIVE_DIFFICULTY[problem.id] ?? problem.difficulty,
-    walkthroughCode: problem.solutionCode,
+    walkthroughCode: problem.walkthroughCode ?? problem.solutionCode,
     solutionCode: COMPACT_REFERENCE_SOLUTIONS[problem.id] ?? problem.solutionCode,
   }))
   .sort((left, right) => left.order - right.order);

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -32,6 +32,16 @@ const testProblem: CodePracticeProblem = {
   ],
   hint: ['Subtract the row max first.'],
   solutionNotes: ['Use a row-wise max shift before the exponentials.'],
+  reasoning: [
+    {
+      axis: 'Tensor reasoning',
+      detail: 'Keep the row maximum shaped (N, 1) so it broadcasts across classes.',
+    },
+    {
+      axis: 'Memory / computation tradeoff',
+      detail: 'A fused kernel avoids materializing every intermediate tensor.',
+    },
+  ],
   visual: {
     src: '/assets/images/code-tensor-ops-broadcasting.gif',
     alt: 'Tensor operation visual',
@@ -128,6 +138,10 @@ describe('CodePracticeLab', () => {
 
     expect(container.textContent).toContain('Problem 01');
     expect(container.textContent).toContain('Stable softmax cross-entropy');
+    expect(container.textContent).toContain('Reason through the system');
+    expect(container.textContent).toContain('Tensor reasoning');
+    expect(container.textContent).toContain('Keep the row maximum shaped (N, 1)');
+    expect(container.querySelectorAll('.code-practice-lab__reasoning-card')).toHaveLength(2);
     expect(container.textContent).not.toContain('Use a row-wise max shift before the exponentials.');
     expect(container.textContent).not.toContain('return "solution"');
     expect(getEditor().textContent).not.toContain('TODO');

--- a/tests/code-practice-primitives.test.ts
+++ b/tests/code-practice-primitives.test.ts
@@ -52,6 +52,19 @@ const REQUIRED_PRIMITIVES = [
     fragments: ['torch.amax(', 'torch.exp(', 'torch.sum('],
   },
   {
+    id: 'incremental-kv-cache',
+    fragments: ['@dataclass', 'start_pos != self.length', 'torch.cat((self.key, key), dim=2)'],
+  },
+  {
+    id: 'grouped-query-and-multi-query-attention',
+    fragments: [
+      'query_heads % kv_heads != 0',
+      'torch.broadcast_to(',
+      'query_heads // kv_heads',
+      'torch.amax(',
+    ],
+  },
+  {
     id: 'cross-attention',
     fragments: ['torch.amax(', 'torch.exp(', 'torch.sum('],
   },
@@ -132,6 +145,43 @@ describe('code-practice primitive-first solutions', () => {
   it('supports tensor transpose methods used by 2D and attention references', () => {
     expect(TORCH_COMPAT_SOURCE).toContain('def permute(self, *dims):');
     expect(TORCH_COMPAT_SOURCE).toContain('def transpose(self, dim0, dim1):');
+  });
+
+  it('covers the inference-attention interview sequence and its reasoning axes', () => {
+    const ids = [
+      'stable-softmax-cross-entropy',
+      'causal-attention-mask',
+      'rope-rotary-positional-embedding',
+      'scaled-dot-product-self-attention',
+      'incremental-kv-cache',
+      'grouped-query-and-multi-query-attention',
+    ];
+    const attentionProblems = ids.map((id) =>
+      codePracticeProblems.find((problem) => problem.id === id),
+    );
+
+    expect(attentionProblems.every(Boolean)).toBe(true);
+    expect(attentionProblems[3]?.title).toContain('MHA');
+    expect(attentionProblems[4]?.solutionCode).toContain('class KVCache:');
+    expect(attentionProblems[4]?.solutionCode).toContain('cached_layout != update_layout');
+    expect(attentionProblems[5]?.title).toContain('GQA');
+    expect(attentionProblems[5]?.title).toContain('MQA');
+
+    const axes = new Set(
+      attentionProblems.flatMap((problem) => problem?.reasoning?.map((point) => point.axis) ?? []),
+    );
+    expect(axes).toEqual(
+      new Set([
+        'Inference efficiency',
+        'Tensor reasoning',
+        'Memory / computation tradeoff',
+        'Cache update correctness',
+      ]),
+    );
+
+    for (const problem of attentionProblems.slice(1)) {
+      expect(problem?.interview?.followUps.length, problem?.id).toBeGreaterThan(0);
+    }
   });
 
   it('keeps architecture interviews typed, modular, and local-PyTorch only', () => {

--- a/tests/code-solution.test.ts
+++ b/tests/code-solution.test.ts
@@ -99,4 +99,16 @@ describe('augmentCodeWithSolution', () => {
     expect(annotatedCode).toContain('# Reference solution');
     expect(annotatedCode).toContain('return torch.mean(torch.log(normalizers)');
   });
+
+  it('preserves the full KV-cache layout invariant in the loaded solution', () => {
+    const problem = codePracticeProblems.find(
+      (candidate) => candidate.id === 'incremental-kv-cache',
+    );
+    const annotatedCode = augmentCodeWithSolution(problem!);
+
+    expect(annotatedCode).toContain(
+      'if cached_layout != update_layout: raise ValueError("cache layout changed")',
+    );
+    expect(annotatedCode).not.toContain('assert any(self.key.shape[axis] == key.shape[axis]');
+  });
 });


### PR DESCRIPTION
## Summary
- add browser-runnable KV-cache and GQA/MQA interview implementations
- deepen MHA, RoPE, causal masking, and stable softmax with explicit inference, tensor, memory/compute, and cache-correctness reasoning
- render responsive reasoning cards and keep the 40-problem progression contiguous

## Validation
- `git diff --check`
- `npm run ci` (8 test files, 43 tests; 325 static routes)
- browser runtime: KV cache `(1, 2, 3, 4)` / length `3`; GQA `(1, 4, 1, 2)`
- desktop and 390x844 responsive QA