### PR TITLE
Start function interviews from blank files

### DIFF
--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -48,6 +48,22 @@ function removeTodoCommentBlocks(source: string) {
   return cleaned.join('\n');
 }
 
+function startsFromBlankFile(problem: CodePracticeProblem) {
+  return problem.editorStart === 'blank';
+}
+
+function getInitialEditorCode(problem: CodePracticeProblem) {
+  return startsFromBlankFile(problem) ? '' : removeTodoCommentBlocks(problem.starterCode);
+}
+
+function getReferenceEditorCode(problem: CodePracticeProblem, currentCode: string) {
+  if (startsFromBlankFile(problem)) {
+    return `# Reference solution\n${problem.solutionCode}`;
+  }
+
+  return augmentCodeWithSolution(problem, currentCode);
+}
+
 export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const isBrowserRunnable = (problem.environment ?? 'browser') === 'browser';
   const interviewDuration =
@@ -63,7 +79,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   const loadingRef = useRef(false);
   const isRunningRef = useRef(false);
   const runHandlerRef = useRef<() => void>(() => {});
-  const [code, setCode] = useState(() => removeTodoCommentBlocks(problem.starterCode));
+  const [code, setCode] = useState(() => getInitialEditorCode(problem));
   const [output, setOutput] = useState('');
   const [errorOutput, setErrorOutput] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>(() =>
@@ -109,7 +125,7 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   );
 
   useEffect(() => {
-    setCode(removeTodoCommentBlocks(problem.starterCode));
+    setCode(getInitialEditorCode(problem));
     setOutput('');
     setErrorOutput('');
     setHasRun(false);
@@ -247,14 +263,14 @@ export default function CodePracticeLab({ problem }: CodePracticeLabProps) {
   }
 
   function handleReset() {
-    setCode(removeTodoCommentBlocks(problem.starterCode));
+    setCode(getInitialEditorCode(problem));
     setOutput('');
     setErrorOutput('');
     setHasRun(false);
   }
 
   function handleLoadSolution() {
-    setCode((currentCode) => augmentCodeWithSolution(problem, currentCode));
+    setCode((currentCode) => getReferenceEditorCode(problem, currentCode));
     setOutput('');
     setErrorOutput('');
     setHasRun(false);

--- a/src/lib/code-practice.ts
+++ b/src/lib/code-practice.ts
@@ -53,6 +53,7 @@ export interface CodePracticeProblem {
   starterCode: string;
   track?: 'fundamentals' | 'architecture';
   environment?: 'browser' | 'local-pytorch';
+  editorStart?: 'blank' | 'scaffold';
   interview?: CodePracticeInterviewFormat;
   reasoning?: readonly CodePracticeReasoningPoint[];
   packages?: readonly string[];
@@ -4332,6 +4333,8 @@ export const codePracticeProblems: readonly CodePracticeProblem[] = ALL_CODE_PRA
     ...ATTENTION_PROBLEM_ENRICHMENTS[problem.id],
     track: problem.track ?? 'fundamentals',
     environment: problem.environment ?? 'browser',
+    editorStart:
+      problem.editorStart ?? (problem.signature.trimStart().startsWith('def ') ? 'blank' : 'scaffold'),
     order: PROGRESSIVE_ORDER[problem.id] ?? problem.order,
     difficulty: PROGRESSIVE_DIFFICULTY[problem.id] ?? problem.difficulty,
     walkthroughCode: problem.walkthroughCode ?? problem.solutionCode,

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -58,6 +58,7 @@ const testProblem: CodePracticeProblem = {
 print("starter")`,
   packages: ['torch', 'numpy'],
   tags: ['PyTorch', 'NumPy'],
+  editorStart: 'blank',
 };
 
 describe('CodePracticeLab', () => {
@@ -145,6 +146,8 @@ describe('CodePracticeLab', () => {
     expect(container.textContent).not.toContain('Use a row-wise max shift before the exponentials.');
     expect(container.textContent).not.toContain('return "solution"');
     expect(getEditor().textContent).not.toContain('TODO');
+    expect(getEditor().textContent).not.toContain('def softmax_cross_entropy');
+    expect(getEditor().textContent).not.toContain('print("starter")');
 
     const buttons = Array.from(container.querySelectorAll('button'));
     const solutionButton = buttons.find((button) => button.textContent === 'Solution');
@@ -157,14 +160,11 @@ describe('CodePracticeLab', () => {
       solutionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(getEditor().textContent).toContain('print("starter")');
-    expect(getEditor().textContent).toContain('# Original placeholder: raise NotImplementedError');
     expect(getEditor().textContent).toContain('# Reference solution');
+    expect(getEditor().textContent).toContain('def softmax_cross_entropy');
     expect(getEditor().textContent).toContain('return "solution"');
     expect(container.querySelector('.code-practice-lab--reference')).not.toBeNull();
-    expect(getEditor().textContent).not.toMatch(
-      /^\s+raise NotImplementedError\("Implement softmax_cross_entropy"\)$/m,
-    );
+    expect(getEditor().textContent).not.toContain('raise NotImplementedError');
     expect(container.querySelector('.cm-solution-line-toggle')).toBeNull();
     expect(container.querySelector('.code-practice-lab__solution-notes')).not.toBeNull();
     expect(container.textContent).toContain('Use a row-wise max shift before the exponentials.');
@@ -235,7 +235,7 @@ describe('CodePracticeLab', () => {
     expect(container.textContent).toContain('keyboard run');
   });
 
-  it('renders a CodeMirror editor with the starter code', async () => {
+  it('starts function-only exercises from an empty Python file', async () => {
     loadPyodideRuntime.mockResolvedValueOnce({
       runPythonAsync: vi.fn(),
     });
@@ -243,8 +243,31 @@ describe('CodePracticeLab', () => {
     await render();
 
     const editor = getEditor();
-    expect(editor.textContent).toContain('print("starter")');
+    expect(editor.textContent).not.toContain('def softmax_cross_entropy');
+    expect(editor.textContent).not.toContain('print("starter")');
     expect(container.textContent).toContain('Ctrl / Cmd + Enter');
+  });
+
+  it('resets a function-only exercise to an empty file', async () => {
+    loadPyodideRuntime.mockResolvedValueOnce({
+      runPythonAsync: vi.fn(),
+    });
+
+    await render();
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const solutionButton = buttons.find((button) => button.textContent === 'Solution');
+    const resetButton = buttons.find((button) => button.textContent === 'Reset');
+
+    await act(async () => {
+      solutionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(getEditor().textContent).toContain('def softmax_cross_entropy');
+
+    await act(async () => {
+      resetButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(getEditor().textContent).not.toContain('def softmax_cross_entropy');
+    expect(container.querySelector('.code-practice-lab--reference')).toBeNull();
   });
 
   it('keeps full nn.Module exercises editable without booting the browser shim', async () => {
@@ -254,6 +277,7 @@ describe('CodePracticeLab', () => {
       title: 'Build a configurable ResNet',
       environment: 'local-pytorch',
       track: 'architecture',
+      editorStart: 'scaffold',
       starterCode: `from torch import nn
 
 class ResNet(nn.Module):

--- a/tests/code-practice-primitives.test.ts
+++ b/tests/code-practice-primitives.test.ts
@@ -103,6 +103,21 @@ describe('code-practice primitive-first solutions', () => {
     }
   });
 
+  it('starts plain-function interviews blank while preserving class scaffolds', () => {
+    for (const problem of codePracticeProblems) {
+      const isPlainFunction = problem.signature.trimStart().startsWith('def ');
+      expect(problem.editorStart, problem.id).toBe(isPlainFunction ? 'blank' : 'scaffold');
+    }
+
+    expect(
+      codePracticeProblems.find((problem) => problem.id === 'incremental-kv-cache')?.editorStart,
+    ).toBe('scaffold');
+    expect(
+      codePracticeProblems.find((problem) => problem.id === 'simple-n-gram-language-model')
+        ?.editorStart,
+    ).toBe('scaffold');
+  });
+
   it('does not bypass a lesson with a matching PyTorch convenience helper', () => {
     const torchProblems = codePracticeProblems.filter(
       (problem) => problem.track === 'fundamentals' && problem.packages?.includes('torch'),


### PR DESCRIPTION
## Summary
- open plain-function interview exercises with an empty Python file
- keep class and dataclass scaffolds for stateful and architecture exercises
- make Solution load the complete reference implementation and Reset return function exercises to blank
- add regression coverage for both editor modes

## Validation
- `git diff --check`
- `npm run ci` (8 test files, 45 tests, 325 pages)
- browser QA: GQA opens blank, Solution loads full code, Reset clears it, and KV cache retains its dataclass scaffold