### PR TITLE
Add answer scoring to trivia decks

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2424,7 +2424,8 @@ h3,
 }
 
 .trivia-deck button,
-.trivia-deck select {
+.trivia-deck select,
+.trivia-deck textarea {
   min-height: 2.75rem;
   border: 1px solid var(--button-border);
   border-radius: 7px;
@@ -2440,12 +2441,14 @@ h3,
 
 .trivia-deck button:hover,
 .trivia-deck button:focus-visible,
-.trivia-deck select:focus-visible {
+.trivia-deck select:focus-visible,
+.trivia-deck textarea:focus-visible {
   border-color: var(--link-color);
 }
 
 .trivia-deck button:focus-visible,
-.trivia-deck select:focus-visible {
+.trivia-deck select:focus-visible,
+.trivia-deck textarea:focus-visible {
   outline: 2px solid var(--link-color);
   outline-offset: 2px;
 }
@@ -2539,22 +2542,67 @@ h3,
   font-size: 0.86em;
 }
 
+.trivia-card__response {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: 1.5rem;
+}
+
+.trivia-card__response label,
+.trivia-card__comparison h3 {
+  margin: 0;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.trivia-card__response textarea {
+  width: 100%;
+  min-height: 7rem;
+  padding: 0.75rem;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: var(--font-reading);
+  line-height: 1.5;
+}
+
 .trivia-card__reveal {
   align-self: flex-start;
-  margin-top: 1.5rem;
+  margin-top: 0.45rem;
   color: var(--link-color) !important;
 }
 
-.trivia-card__answer {
+.trivia-card__comparison {
+  display: grid;
+  gap: 1.2rem;
   margin-top: 1.5rem;
   padding-top: 1.2rem;
   border-top: 1px solid var(--button-border);
 }
 
-.trivia-card__answer p {
+.trivia-card__comparison section {
+  min-width: 0;
+}
+
+.trivia-card__comparison h3 {
+  margin-bottom: 0.45rem;
+  text-shadow: none;
+}
+
+.trivia-card__comparison p {
   margin: 0;
   font-size: 1.02rem;
   line-height: 1.65;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.trivia-card__comparison .trivia-card__empty-answer {
+  color: var(--text-secondary-color);
+  font-style: italic;
 }
 
 .trivia-card__answer pre {
@@ -3819,6 +3867,10 @@ body.home-page small {
   .trivia-card {
     min-height: 23rem;
     padding: 1.15rem;
+  }
+
+  .trivia-card__response textarea {
+    min-height: 8rem;
   }
 
   .trivia-deck__navigation > button,

--- a/src/components/TriviaDeck.tsx
+++ b/src/components/TriviaDeck.tsx
@@ -7,7 +7,10 @@ interface TriviaDeckProps {
 }
 
 interface SavedProgress {
-  knownCardIds: string[];
+  answers?: Record<string, string>;
+  attemptedCardIds?: string[];
+  correctCardIds?: string[];
+  knownCardIds?: string[];
 }
 
 function inlineCode(text: string): ReactNode[] {
@@ -42,7 +45,9 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
   const [orderedIds, setOrderedIds] = useState(() => deck.cards.map((card) => card.id));
   const [position, setPosition] = useState(0);
   const [revealed, setRevealed] = useState(false);
-  const [knownCardIds, setKnownCardIds] = useState<Set<string>>(() => new Set());
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [attemptedCardIds, setAttemptedCardIds] = useState<Set<string>>(() => new Set());
+  const [correctCardIds, setCorrectCardIds] = useState<Set<string>>(() => new Set());
 
   useEffect(() => {
     try {
@@ -50,7 +55,24 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
       if (!saved) return;
       const parsed = JSON.parse(saved) as SavedProgress;
       const validIds = new Set(deck.cards.map((card) => card.id));
-      setKnownCardIds(new Set(parsed.knownCardIds.filter((id) => validIds.has(id))));
+      const legacyKnownIds = Array.isArray(parsed.knownCardIds) ? parsed.knownCardIds : [];
+      const savedCorrectIds = Array.isArray(parsed.correctCardIds)
+        ? parsed.correctCardIds
+        : legacyKnownIds;
+      const savedAttemptedIds = Array.isArray(parsed.attemptedCardIds)
+        ? parsed.attemptedCardIds
+        : savedCorrectIds;
+      const savedAnswers = parsed.answers && typeof parsed.answers === 'object'
+        ? Object.fromEntries(
+          Object.entries(parsed.answers).filter(
+            ([id, answer]) => validIds.has(id) && typeof answer === 'string',
+          ),
+        )
+        : {};
+
+      setAnswers(savedAnswers);
+      setAttemptedCardIds(new Set(savedAttemptedIds.filter((id) => validIds.has(id))));
+      setCorrectCardIds(new Set(savedCorrectIds.filter((id) => validIds.has(id))));
     } catch {
       // A corrupt or unavailable local store should never block the study deck.
     }
@@ -69,14 +91,22 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
   );
   const currentPosition = clampPosition(position, visibleCards.length);
   const card = visibleCards[currentPosition];
-  const knownVisibleCount = visibleCards.filter((item) => knownCardIds.has(item.id)).length;
+  const attemptedVisibleCount = visibleCards.filter((item) => attemptedCardIds.has(item.id)).length;
+  const correctVisibleCount = visibleCards.filter((item) => correctCardIds.has(item.id)).length;
 
-  function persist(nextKnown: Set<string>) {
-    setKnownCardIds(nextKnown);
+  function persist(
+    nextAnswers: Record<string, string>,
+    nextAttempted: Set<string>,
+    nextCorrect: Set<string>,
+  ) {
     try {
       window.localStorage.setItem(
         storageKey,
-        JSON.stringify({ knownCardIds: Array.from(nextKnown) } satisfies SavedProgress),
+        JSON.stringify({
+          answers: nextAnswers,
+          attemptedCardIds: Array.from(nextAttempted),
+          correctCardIds: Array.from(nextCorrect),
+        } satisfies SavedProgress),
       );
     } catch {
       // Progress persistence is optional in private or storage-restricted browsing modes.
@@ -94,12 +124,22 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
     setRevealed(false);
   }
 
-  function markKnown(isKnown: boolean) {
+  function updateAnswer(answer: string) {
     if (!card) return;
-    const nextKnown = new Set(knownCardIds);
-    if (isKnown) nextKnown.add(card.id);
-    else nextKnown.delete(card.id);
-    persist(nextKnown);
+    const nextAnswers = { ...answers, [card.id]: answer };
+    setAnswers(nextAnswers);
+    persist(nextAnswers, attemptedCardIds, correctCardIds);
+  }
+
+  function markAnswer(isCorrect: boolean) {
+    if (!card) return;
+    const nextAttempted = new Set(attemptedCardIds).add(card.id);
+    const nextCorrect = new Set(correctCardIds);
+    if (isCorrect) nextCorrect.add(card.id);
+    else nextCorrect.delete(card.id);
+    setAttemptedCardIds(nextAttempted);
+    setCorrectCardIds(nextCorrect);
+    persist(answers, nextAttempted, nextCorrect);
     move(1);
   }
 
@@ -130,7 +170,14 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
   }
 
   function resetProgress() {
-    persist(new Set());
+    setAnswers({});
+    setAttemptedCardIds(new Set());
+    setCorrectCardIds(new Set());
+    try {
+      window.localStorage.removeItem(storageKey);
+    } catch {
+      // Progress persistence is optional in private or storage-restricted browsing modes.
+    }
     setPosition(0);
     setRevealed(false);
   }
@@ -139,7 +186,8 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
 
   const progressPercent = visibleCards.length === 0
     ? 0
-    : Math.round((knownVisibleCount / visibleCards.length) * 100);
+    : Math.round((correctVisibleCount / visibleCards.length) * 100);
+  const currentAnswer = answers[card.id] ?? '';
 
   return (
     <section
@@ -162,15 +210,15 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
 
       <div className="trivia-deck__status">
         <span>Card {currentPosition + 1} of {visibleCards.length}</span>
-        <span>{knownVisibleCount} got it</span>
+        <span>{correctVisibleCount}/{attemptedVisibleCount} right</span>
       </div>
       <div
         className="trivia-deck__progress"
         role="progressbar"
-        aria-label="Cards marked got it"
+        aria-label="Cards answered correctly"
         aria-valuemin={0}
         aria-valuemax={visibleCards.length}
-        aria-valuenow={knownVisibleCount}
+        aria-valuenow={correctVisibleCount}
       >
         <span style={{ width: `${progressPercent}%` }} />
       </div>
@@ -182,19 +230,38 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
         </p>
 
         {!revealed ? (
-          <button
-            type="button"
-            className="trivia-card__reveal"
-            onClick={() => setRevealed(true)}
-            aria-expanded="false"
-          >
-            Show answer
-          </button>
+          <div className="trivia-card__response">
+            <label htmlFor={`${deck.id}-${card.id}-answer`}>Your answer</label>
+            <textarea
+              id={`${deck.id}-${card.id}-answer`}
+              value={currentAnswer}
+              onChange={(event) => updateAnswer(event.target.value)}
+              placeholder="Write or outline your answer here…"
+              rows={4}
+            />
+            <button
+              type="button"
+              className="trivia-card__reveal"
+              onClick={() => setRevealed(true)}
+              aria-expanded="false"
+            >
+              Show answer
+            </button>
+          </div>
         ) : (
-          <div className="trivia-card__answer">
-            <p>{inlineCode(card.answer)}</p>
-            {card.code && <pre><code>{card.code}</code></pre>}
-            {card.detail && <p className="trivia-card__detail">{inlineCode(card.detail)}</p>}
+          <div className="trivia-card__comparison">
+            <section aria-label="Your answer">
+              <h3>Your answer</h3>
+              <p className={currentAnswer.trim() ? '' : 'trivia-card__empty-answer'}>
+                {currentAnswer.trim() || 'No answer entered.'}
+              </p>
+            </section>
+            <section className="trivia-card__answer" aria-label="Reference answer">
+              <h3>Reference answer</h3>
+              <p>{inlineCode(card.answer)}</p>
+              {card.code && <pre><code>{card.code}</code></pre>}
+              {card.detail && <p className="trivia-card__detail">{inlineCode(card.detail)}</p>}
+            </section>
           </div>
         )}
       </article>
@@ -205,9 +272,9 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
         </button>
         {revealed ? (
           <div className="trivia-deck__rating" aria-label="Rate this answer">
-            <button type="button" onClick={() => markKnown(false)}>Again</button>
-            <button type="button" className="trivia-deck__primary" onClick={() => markKnown(true)}>
-              Got it
+            <button type="button" onClick={() => markAnswer(false)}>Not quite</button>
+            <button type="button" className="trivia-deck__primary" onClick={() => markAnswer(true)}>
+              Got it right
             </button>
           </div>
         ) : (

--- a/src/content/posts/python-interview-trivia.mdx
+++ b/src/content/posts/python-interview-trivia.mdx
@@ -19,7 +19,7 @@ This deck turns high-level Python interview questions into short retrieval promp
 
 ## How to use the deck
 
-Choose one topic for a focused pass or keep all topics mixed. Mark a card **Got it** only when you can explain the answer without relying on the wording shown here. **Again** removes that card from the completed count. Progress is stored only in this browser.
+Choose one topic for a focused pass or keep all topics mixed. Type or outline your answer, reveal the reference answer, then mark the attempt **Not quite** or **Got it right**. The score reports correct answers over attempted answers, and the topic filter scopes that score to the visible cards. Typed answers and progress are stored only in this browser.
 
 The original preparation conversation supplied the Python question bank. The answers were tightened against the language and library documentation, with special care around identity, hashability, generators, the GIL, and runtime typing.
 

--- a/src/content/posts/pytorch-interview-trivia.mdx
+++ b/src/content/posts/pytorch-interview-trivia.mdx
@@ -21,7 +21,7 @@ This deck tests the contracts that sit underneath everyday PyTorch code: which o
 
 Start with **Tensors**, **Autograd**, and **Training**. Add data loading and distributed topics once the single-device path is automatic. For each answer, name the tensor shape, device, dtype, or state boundary when it matters; those details distinguish a usable engineering answer from a memorized slogan.
 
-Mark **Got it** only after answering before the reveal. Topic filters and progress stay on this device, which makes the deck suitable for short mobile sessions.
+Type or outline your response before the reveal, compare it with the reference answer, then mark the attempt **Not quite** or **Got it right**. The score reports correct answers over attempted answers for the selected topic. Typed answers and progress stay on this device, which makes the deck suitable for short mobile sessions.
 
 ## Sources and deeper notes
 

--- a/tests/trivia-deck.test.tsx
+++ b/tests/trivia-deck.test.tsx
@@ -47,27 +47,67 @@ describe('TriviaDeck', () => {
     act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
   }
 
+  function enterAnswer(answer: string) {
+    const textarea = container.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    act(() => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        'value',
+      )?.set;
+      valueSetter?.call(textarea, answer);
+      textarea?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
   it('hides the answer until reveal and renders inline code accessibly', async () => {
     await renderDeck();
 
     expect(container.textContent).toContain('Question one?');
     expect(container.textContent).not.toContain('Answer one.');
     expect(container.querySelector('[role="heading"] code')?.textContent).toBe('one');
+    expect(container.querySelector('textarea')).not.toBeNull();
+
+    enterAnswer('My candidate answer.');
 
     click('Show answer');
 
     expect(container.textContent).toContain('Answer one.');
+    expect(container.textContent).toContain('My candidate answer.');
     expect(container.querySelector('.trivia-card__answer code')?.textContent).toBe('one');
   });
 
-  it('marks a card complete, persists progress, and advances', async () => {
+  it('marks a card correct, persists the answer and score, and advances', async () => {
     await renderDeck();
+    enterAnswer('My answer.');
     click('Show answer');
-    click('Got it');
+    click('Got it right');
 
     expect(container.textContent).toContain('Question two?');
-    expect(container.textContent).toContain('1 got it');
-    expect(window.localStorage.getItem('trivia-progress:test-deck')).toContain('one');
+    expect(container.textContent).toContain('1/1 right');
+    const saved = window.localStorage.getItem('trivia-progress:test-deck');
+    expect(saved).toContain('My answer.');
+    expect(saved).toContain('"attemptedCardIds":["one"]');
+    expect(saved).toContain('"correctCardIds":["one"]');
+  });
+
+  it('counts an incorrect self-grade as attempted but not correct', async () => {
+    await renderDeck();
+    click('Show answer');
+    click('Not quite');
+
+    expect(container.textContent).toContain('0/1 right');
+  });
+
+  it('migrates the previous got-it progress into the new score', async () => {
+    window.localStorage.setItem(
+      'trivia-progress:test-deck',
+      JSON.stringify({ knownCardIds: ['one'] }),
+    );
+
+    await renderDeck();
+
+    expect(container.textContent).toContain('1/1 right');
   });
 
   it('filters by topic and resets the visible position', async () => {
@@ -83,6 +123,21 @@ describe('TriviaDeck', () => {
 
     expect(container.textContent).toContain('Card 1 of 1');
     expect(container.textContent).toContain('Question one?');
+  });
+
+  it('scopes the score to the selected topic', async () => {
+    await renderDeck();
+    click('Show answer');
+    click('Got it right');
+
+    const select = container.querySelector('select');
+    await act(async () => {
+      if (!select) return;
+      select.value = 'Runtime';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('0/0 right');
   });
 });
 


### PR DESCRIPTION
## What changed
- add a saved answer box to every Python and PyTorch trivia card
- compare the typed response with the reference answer before self-grading
- track correct answers over attempted answers, scoped to the selected topic
- migrate existing Got it progress into the new score

## Testing
- git diff --check
- npm run ci
- mobile interaction QA at 390 x 844 on both trivia routes