### PR TITLE
Add automatic grading to trivia decks

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2605,6 +2605,33 @@ h3,
   font-style: italic;
 }
 
+.trivia-card__comparison .trivia-card__grade {
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--button-border);
+  border-left-width: 4px;
+  border-radius: 7px;
+  background: var(--panel-bg);
+}
+
+.trivia-card__comparison .trivia-card__grade[data-status="correct"] {
+  border-left-color: #2f9e63;
+}
+
+.trivia-card__comparison .trivia-card__grade[data-status="close"] {
+  border-left-color: #d08a16;
+}
+
+.trivia-card__comparison .trivia-card__grade[data-status="needs-work"] {
+  border-left-color: #c94b52;
+}
+
+.trivia-card__comparison .trivia-card__grade-detail {
+  margin-top: 0.55rem;
+  color: var(--text-secondary-color);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
 .trivia-card__answer pre {
   width: 100%;
   max-width: 100%;

--- a/src/components/TriviaDeck.tsx
+++ b/src/components/TriviaDeck.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { KeyboardEvent, ReactNode } from 'react';
 import type { TriviaCard, TriviaDeckData } from '../lib/trivia-decks';
+import { gradeTriviaAnswer, type TriviaGrade } from '../lib/trivia-grader';
 
 interface TriviaDeckProps {
   deck: TriviaDeckData;
@@ -45,6 +46,7 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
   const [orderedIds, setOrderedIds] = useState(() => deck.cards.map((card) => card.id));
   const [position, setPosition] = useState(0);
   const [revealed, setRevealed] = useState(false);
+  const [grade, setGrade] = useState<TriviaGrade | null>(null);
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [attemptedCardIds, setAttemptedCardIds] = useState<Set<string>>(() => new Set());
   const [correctCardIds, setCorrectCardIds] = useState<Set<string>>(() => new Set());
@@ -122,6 +124,7 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
       return next;
     });
     setRevealed(false);
+    setGrade(null);
   }
 
   function updateAnswer(answer: string) {
@@ -131,23 +134,25 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
     persist(nextAnswers, attemptedCardIds, correctCardIds);
   }
 
-  function markAnswer(isCorrect: boolean) {
+  function gradeAnswer() {
     if (!card) return;
+    const nextGrade = gradeTriviaAnswer(card, answers[card.id] ?? '');
     const nextAttempted = new Set(attemptedCardIds).add(card.id);
     const nextCorrect = new Set(correctCardIds);
-    if (isCorrect) nextCorrect.add(card.id);
+    if (nextGrade.status === 'correct') nextCorrect.add(card.id);
     else nextCorrect.delete(card.id);
+    setGrade(nextGrade);
+    setRevealed(true);
     setAttemptedCardIds(nextAttempted);
     setCorrectCardIds(nextCorrect);
     persist(answers, nextAttempted, nextCorrect);
-    move(1);
   }
 
   function handleDeckKeyDown(event: KeyboardEvent<HTMLElement>) {
     if (event.target !== event.currentTarget) return;
     if (event.key === ' ' || event.key === 'Enter') {
       event.preventDefault();
-      setRevealed(true);
+      gradeAnswer();
     } else if (event.key === 'ArrowLeft') {
       event.preventDefault();
       move(-1);
@@ -161,12 +166,14 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
     setTopic(nextTopic);
     setPosition(0);
     setRevealed(false);
+    setGrade(null);
   }
 
   function shuffleCards() {
     setOrderedIds((ids) => shuffled(ids));
     setPosition(0);
     setRevealed(false);
+    setGrade(null);
   }
 
   function resetProgress() {
@@ -180,6 +187,7 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
     }
     setPosition(0);
     setRevealed(false);
+    setGrade(null);
   }
 
   if (!card) return null;
@@ -242,14 +250,34 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
             <button
               type="button"
               className="trivia-card__reveal"
-              onClick={() => setRevealed(true)}
+              onClick={gradeAnswer}
               aria-expanded="false"
             >
-              Show answer
+              Grade answer
             </button>
           </div>
         ) : (
           <div className="trivia-card__comparison">
+            {grade && (
+              <section
+                className="trivia-card__grade"
+                data-status={grade.status}
+                aria-label="Automatic grade"
+              >
+                <h3>{grade.label}</h3>
+                <p>{grade.explanation}</p>
+                {grade.matchedConcepts.length > 0 && (
+                  <p className="trivia-card__grade-detail">
+                    <strong>Matched:</strong> {grade.matchedConcepts.join(' · ')}
+                  </p>
+                )}
+                {grade.missingConcepts.length > 0 && (
+                  <p className="trivia-card__grade-detail">
+                    <strong>Review:</strong> {grade.missingConcepts.join(' · ')}
+                  </p>
+                )}
+              </section>
+            )}
             <section aria-label="Your answer">
               <h3>Your answer</h3>
               <p className={currentAnswer.trim() ? '' : 'trivia-card__empty-answer'}>
@@ -271,10 +299,9 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
           Previous
         </button>
         {revealed ? (
-          <div className="trivia-deck__rating" aria-label="Rate this answer">
-            <button type="button" onClick={() => markAnswer(false)}>Not quite</button>
-            <button type="button" className="trivia-deck__primary" onClick={() => markAnswer(true)}>
-              Got it right
+          <div className="trivia-deck__rating">
+            <button type="button" className="trivia-deck__primary" onClick={() => move(1)}>
+              Next card
             </button>
           </div>
         ) : (
@@ -285,7 +312,7 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
       </div>
 
       <div className="trivia-deck__footer">
-        <span>Space reveals · arrows move</span>
+        <span>Space grades · arrows move</span>
         <button type="button" onClick={resetProgress}>Reset progress</button>
       </div>
     </section>

--- a/src/content/posts/python-interview-trivia.mdx
+++ b/src/content/posts/python-interview-trivia.mdx
@@ -19,7 +19,9 @@ This deck turns high-level Python interview questions into short retrieval promp
 
 ## How to use the deck
 
-Choose one topic for a focused pass or keep all topics mixed. Type or outline your answer, reveal the reference answer, then mark the attempt **Not quite** or **Got it right**. The score reports correct answers over attempted answers, and the topic filter scopes that score to the visible cards. Typed answers and progress are stored only in this browser.
+Choose one topic for a focused pass or keep all topics mixed. Type or outline your response, then select **Grade answer**. The deck reports **Correct**, **Close**, or **Needs work**, identifies concepts to review, and updates the correct-over-attempted score automatically. The topic filter scopes the score to the visible cards.
+
+Grading runs on this device and looks for the core ideas in the reference answer rather than exact wording. It is deliberately conservative: an unfamiliar but valid paraphrase may receive **Close**, but a one-word overlap will not pass. Typed answers and progress are stored only in this browser.
 
 The original preparation conversation supplied the Python question bank. The answers were tightened against the language and library documentation, with special care around identity, hashability, generators, the GIL, and runtime typing.
 

--- a/src/content/posts/pytorch-interview-trivia.mdx
+++ b/src/content/posts/pytorch-interview-trivia.mdx
@@ -21,7 +21,9 @@ This deck tests the contracts that sit underneath everyday PyTorch code: which o
 
 Start with **Tensors**, **Autograd**, and **Training**. Add data loading and distributed topics once the single-device path is automatic. For each answer, name the tensor shape, device, dtype, or state boundary when it matters; those details distinguish a usable engineering answer from a memorized slogan.
 
-Type or outline your response before the reveal, compare it with the reference answer, then mark the attempt **Not quite** or **Got it right**. The score reports correct answers over attempted answers for the selected topic. Typed answers and progress stay on this device, which makes the deck suitable for short mobile sessions.
+Type or outline your response, then select **Grade answer**. The deck reports **Correct**, **Close**, or **Needs work**, identifies concepts to review, and updates the correct-over-attempted score automatically for the selected topic.
+
+Grading runs on this device and looks for the core ideas in the reference answer rather than exact wording. It is deliberately conservative: an unfamiliar but valid paraphrase may receive **Close**, but a one-word overlap will not pass. Typed answers and progress stay on this device, which makes the deck suitable for short mobile sessions.
 
 ## Sources and deeper notes
 

--- a/src/lib/trivia-decks.ts
+++ b/src/lib/trivia-decks.ts
@@ -1,3 +1,8 @@
+export interface TriviaGradingConcept {
+  label: string;
+  anyOf: string[];
+}
+
 export interface TriviaCard {
   id: string;
   topic: string;
@@ -5,6 +10,9 @@ export interface TriviaCard {
   answer: string;
   code?: string;
   detail?: string;
+  grading?: {
+    concepts: TriviaGradingConcept[];
+  };
 }
 
 export interface TriviaDeckData {
@@ -22,6 +30,38 @@ export const pythonTriviaDeck: TriviaDeckData = {
       topic: 'Semantics',
       question: 'Are Python arguments passed by value or by reference?',
       answer: 'Python uses pass-by-assignment, also called object sharing. A function receives another binding to the same object. Mutating that object can affect the caller; rebinding the local name cannot.',
+      grading: {
+        concepts: [
+          {
+            label: 'pass-by-assignment or object sharing',
+            anyOf: [
+              'pass by assignment',
+              'object sharing',
+              'binding same object',
+              'reference same object',
+            ],
+          },
+          {
+            label: 'mutation can affect the caller',
+            anyOf: [
+              'mutation affect caller',
+              'mutation visible caller',
+              'mutation visible outside',
+              'change affect caller',
+              'change visible outside',
+            ],
+          },
+          {
+            label: 'rebinding stays local',
+            anyOf: [
+              'rebinding local',
+              'reassign local',
+              'assignment new object local',
+              'rebinding not affect caller',
+            ],
+          },
+        ],
+      },
     },
     {
       id: 'python-is-equality',

--- a/src/lib/trivia-grader.ts
+++ b/src/lib/trivia-grader.ts
@@ -1,0 +1,199 @@
+import type { TriviaCard, TriviaGradingConcept } from './trivia-decks';
+
+export type TriviaGradeStatus = 'correct' | 'close' | 'needs-work';
+
+export interface TriviaGrade {
+  status: TriviaGradeStatus;
+  label: 'Correct' | 'Close' | 'Needs work';
+  explanation: string;
+  matchedConcepts: string[];
+  missingConcepts: string[];
+}
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'because', 'been', 'being', 'both',
+  'by', 'can', 'called', 'does', 'each', 'for', 'from', 'has', 'have', 'if', 'in',
+  'into', 'is', 'it', 'its', 'may', 'no', 'normally', 'not', 'of', 'on', 'only', 'or',
+  'so', 'such', 'than', 'that', 'the', 'their', 'them', 'then', 'there', 'therefore',
+  'they', 'this', 'through', 'to', 'use', 'used', 'uses', 'using', 'when', 'where',
+  'whether', 'which', 'while', 'with', 'without', 'would', 'asks', 'another', 'same',
+  'function', 'values', 'value', 'name', 'names', 'make', 'makes', 'made', 'returns',
+  'return', 'receives', 'receive', 'produces', 'produce', 'lets', 'let', 'means', 'yes',
+]);
+
+const PHRASE_ALIASES: Array<[RegExp, string]> = [
+  [/pass(?:ed)? by assignment/g, 'passbyassignment'],
+  [/object sharing/g, 'passbyassignment'],
+  [/exact(?:ly)? the same object/g, 'identity'],
+  [/exact(?:ly)? same object/g, 'identity'],
+  [/same object/g, 'identity'],
+  [/compare(?:s|d)? equal/g, 'equality'],
+  [/in[ -]place/g, 'inplace'],
+  [/log[ -]softmax/g, 'logsoftmax'],
+  [/negative log[ -]likelihood/g, 'nll'],
+  [/state[ _-]dict/g, 'statedict'],
+  [/requires[ _-]grad/g, 'requiresgrad'],
+  [/no[ _-]grad/g, 'nograd'],
+];
+
+const WORD_ALIASES: Record<string, string> = {
+  assigned: 'assignment',
+  assigns: 'assignment',
+  bind: 'binding',
+  binds: 'binding',
+  bound: 'binding',
+  changed: 'mutation',
+  changes: 'mutation',
+  changing: 'mutation',
+  equal: 'equality',
+  equals: 'equality',
+  gradients: 'gradient',
+  grads: 'gradient',
+  identical: 'identity',
+  indices: 'index',
+  logits: 'logit',
+  modifies: 'mutation',
+  modified: 'mutation',
+  modifying: 'mutation',
+  mutate: 'mutation',
+  mutated: 'mutation',
+  mutates: 'mutation',
+  mutating: 'mutation',
+  probabilities: 'probability',
+  references: 'reference',
+  reassign: 'rebinding',
+  reassigned: 'rebinding',
+  reassigning: 'rebinding',
+  reassignment: 'rebinding',
+  rebind: 'rebinding',
+  tensors: 'tensor',
+};
+
+function canonicalToken(token: string): string {
+  if (WORD_ALIASES[token]) return WORD_ALIASES[token];
+  if (token.length > 5 && token.endsWith('ies')) return `${token.slice(0, -3)}y`;
+  if (token.length > 5 && token.endsWith('ing')) return token.slice(0, -3);
+  if (token.length > 4 && token.endsWith('ed')) return token.slice(0, -2);
+  if (token.length > 4 && token.endsWith('s')) return token.slice(0, -1);
+  return token;
+}
+
+function tokenize(text: string): string[] {
+  let normalized = text.toLowerCase().replaceAll('`', '');
+  for (const [pattern, replacement] of PHRASE_ALIASES) {
+    normalized = normalized.replace(pattern, replacement);
+  }
+
+  return (normalized.match(/[a-z0-9_+.-]+/g) ?? [])
+    .map((token) => token.replace(/^[.+-]+|[.+-]+$/g, ''))
+    .map(canonicalToken)
+    .filter((token) => token.length > 1 && !STOP_WORDS.has(token));
+}
+
+function matchesCuratedConcept(answerTokens: Set<string>, concept: TriviaGradingConcept): boolean {
+  return concept.anyOf.some((pattern) => {
+    const patternTokens = tokenize(pattern);
+    return patternTokens.length > 0 && patternTokens.every((token) => answerTokens.has(token));
+  });
+}
+
+function conceptLabel(clause: string): string {
+  const clean = clause.replaceAll('`', '').replace(/\s+/g, ' ').trim();
+  if (clean.length <= 100) return clean;
+  return `${clean.slice(0, 97).trimEnd()}…`;
+}
+
+function derivedConcepts(referenceAnswer: string): Array<{ label: string; terms: Set<string> }> {
+  const clauses = referenceAnswer
+    .split(/(?:\.(?:\s+|$)|[;:]|\bbut\b|\bwhereas\b|\bhowever\b)/i)
+    .map((clause) => clause.trim())
+    .filter(Boolean)
+    .map((clause) => ({ label: conceptLabel(clause), terms: new Set(tokenize(clause)) }))
+    .filter((concept) => concept.terms.size > 0);
+
+  return clauses.length > 0 ? clauses : [{
+    label: conceptLabel(referenceAnswer),
+    terms: new Set(tokenize(referenceAnswer)),
+  }];
+}
+
+function gradeFromCounts(
+  answerTokenCount: number,
+  matchedConcepts: string[],
+  missingConcepts: string[],
+  singleConceptTermMatches = 0,
+): TriviaGradeStatus {
+  const conceptCount = matchedConcepts.length + missingConcepts.length;
+  const coverage = conceptCount === 0 ? 0 : matchedConcepts.length / conceptCount;
+  const minimumMatched = conceptCount === 1 ? 1 : 2;
+  const singleConceptPasses = conceptCount !== 1 || singleConceptTermMatches >= 2;
+
+  if (
+    answerTokenCount >= 3
+    && matchedConcepts.length >= minimumMatched
+    && coverage >= 0.6
+    && singleConceptPasses
+  ) {
+    return 'correct';
+  }
+  if (matchedConcepts.length > 0 || singleConceptTermMatches > 0) return 'close';
+  return 'needs-work';
+}
+
+export function gradeTriviaAnswer(card: TriviaCard, answer: string): TriviaGrade {
+  const answerTokens = new Set(tokenize(answer));
+  const matchedConcepts: string[] = [];
+  const missingConcepts: string[] = [];
+  let singleConceptTermMatches = 0;
+
+  if (card.grading) {
+    for (const concept of card.grading.concepts) {
+      if (matchesCuratedConcept(answerTokens, concept)) matchedConcepts.push(concept.label);
+      else missingConcepts.push(concept.label);
+    }
+  } else {
+    const concepts = derivedConcepts(card.answer);
+    for (const concept of concepts) {
+      const termMatches = Array.from(concept.terms)
+        .filter((term) => answerTokens.has(term)).length;
+      if (termMatches > 0) matchedConcepts.push(concept.label);
+      else missingConcepts.push(concept.label);
+      if (concepts.length === 1) singleConceptTermMatches = termMatches;
+    }
+  }
+
+  const status = gradeFromCounts(
+    answerTokens.size,
+    matchedConcepts,
+    missingConcepts,
+    singleConceptTermMatches,
+  );
+
+  if (status === 'correct') {
+    return {
+      status,
+      label: 'Correct',
+      explanation: 'Your answer covers the main ideas in the reference answer.',
+      matchedConcepts,
+      missingConcepts,
+    };
+  }
+  if (status === 'close') {
+    return {
+      status,
+      label: 'Close',
+      explanation: 'You have part of the answer. Add the missing idea before treating this card as learned.',
+      matchedConcepts,
+      missingConcepts,
+    };
+  }
+  return {
+    status,
+    label: 'Needs work',
+    explanation: answerTokens.size === 0
+      ? 'No answer was entered. Use the reference answer to learn the required ideas.'
+      : 'Your answer does not yet explain a required idea from the reference answer.',
+    matchedConcepts,
+    missingConcepts,
+  };
+}

--- a/tests/trivia-deck.test.tsx
+++ b/tests/trivia-deck.test.tsx
@@ -4,6 +4,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import TriviaDeck from '../src/components/TriviaDeck';
+import { gradeTriviaAnswer } from '../src/lib/trivia-grader';
 import {
   pythonTriviaDeck,
   pytorchTriviaDeck,
@@ -14,7 +15,18 @@ const deck: TriviaDeckData = {
   id: 'test-deck',
   title: 'Test trivia',
   cards: [
-    { id: 'one', topic: 'Semantics', question: 'Question `one`?', answer: 'Answer `one`.' },
+    {
+      id: 'one',
+      topic: 'Semantics',
+      question: 'Question `one`?',
+      answer: 'A complete answer covers object identity and value equality.',
+      grading: {
+        concepts: [
+          { label: 'object identity', anyOf: ['object identity'] },
+          { label: 'value equality', anyOf: ['value equality'] },
+        ],
+      },
+    },
     { id: 'two', topic: 'Runtime', question: 'Question two?', answer: 'Answer two.' },
   ],
 };
@@ -60,42 +72,44 @@ describe('TriviaDeck', () => {
     });
   }
 
-  it('hides the answer until reveal and renders inline code accessibly', async () => {
+  it('hides the answer until grading and renders the automatic result accessibly', async () => {
     await renderDeck();
 
     expect(container.textContent).toContain('Question one?');
-    expect(container.textContent).not.toContain('Answer one.');
+    expect(container.textContent).not.toContain('complete answer');
     expect(container.querySelector('[role="heading"] code')?.textContent).toBe('one');
     expect(container.querySelector('textarea')).not.toBeNull();
 
     enterAnswer('My candidate answer.');
 
-    click('Show answer');
+    click('Grade answer');
 
-    expect(container.textContent).toContain('Answer one.');
+    expect(container.textContent).toContain('complete answer');
     expect(container.textContent).toContain('My candidate answer.');
-    expect(container.querySelector('.trivia-card__answer code')?.textContent).toBe('one');
+    expect(container.querySelector('[aria-label="Automatic grade"]')).not.toBeNull();
   });
 
-  it('marks a card correct, persists the answer and score, and advances', async () => {
+  it('marks a passing answer correct and persists the automatic score', async () => {
     await renderDeck();
-    enterAnswer('My answer.');
-    click('Show answer');
-    click('Got it right');
+    enterAnswer('Object identity is distinct from value equality.');
+    click('Grade answer');
 
-    expect(container.textContent).toContain('Question two?');
+    expect(container.textContent).toContain('Correct');
     expect(container.textContent).toContain('1/1 right');
     const saved = window.localStorage.getItem('trivia-progress:test-deck');
-    expect(saved).toContain('My answer.');
+    expect(saved).toContain('Object identity');
     expect(saved).toContain('"attemptedCardIds":["one"]');
     expect(saved).toContain('"correctCardIds":["one"]');
   });
 
-  it('counts an incorrect self-grade as attempted but not correct', async () => {
+  it('rejects a vague answer and identifies concepts to review', async () => {
     await renderDeck();
-    click('Show answer');
-    click('Not quite');
+    enterAnswer('reference');
+    click('Grade answer');
 
+    expect(container.textContent).toContain('Needs work');
+    expect(container.textContent).toContain('Review:');
+    expect(container.textContent).toContain('object identity');
     expect(container.textContent).toContain('0/1 right');
   });
 
@@ -127,8 +141,8 @@ describe('TriviaDeck', () => {
 
   it('scopes the score to the selected topic', async () => {
     await renderDeck();
-    click('Show answer');
-    click('Got it right');
+    enterAnswer('Object identity differs from value equality.');
+    click('Grade answer');
 
     const select = container.querySelector('select');
     await act(async () => {
@@ -138,6 +152,86 @@ describe('TriviaDeck', () => {
     });
 
     expect(container.textContent).toContain('0/0 right');
+  });
+});
+
+describe('automatic trivia grading', () => {
+  it.each([...pythonTriviaDeck.cards, ...pytorchTriviaDeck.cards])(
+    'accepts the full reference answer for $id',
+    (card) => {
+      expect(gradeTriviaAnswer(card, card.answer).status).toBe('correct');
+    },
+  );
+
+  it.each([...pythonTriviaDeck.cards, ...pytorchTriviaDeck.cards])(
+    'never passes a one-word response for $id',
+    (card) => {
+      expect(gradeTriviaAnswer(card, 'reference').status).not.toBe('correct');
+    },
+  );
+
+  it('rejects the one-word answer from the reported Python example', () => {
+    const card = pythonTriviaDeck.cards.find(
+      (candidate) => candidate.id === 'python-pass-by-assignment',
+    );
+    expect(card).toBeDefined();
+
+    const grade = gradeTriviaAnswer(card!, 'reference');
+
+    expect(grade.status).toBe('needs-work');
+    expect(grade.missingConcepts).toContain('pass-by-assignment or object sharing');
+    expect(grade.missingConcepts).toContain('rebinding stays local');
+  });
+
+  it('accepts a strong paraphrase of pass-by-assignment', () => {
+    const card = pythonTriviaDeck.cards.find(
+      (candidate) => candidate.id === 'python-pass-by-assignment',
+    );
+    expect(card).toBeDefined();
+
+    const grade = gradeTriviaAnswer(
+      card!,
+      'Python passes a reference to the same object. Mutation is visible outside, but reassignment stays local.',
+    );
+
+    expect(grade.status).toBe('correct');
+  });
+
+  it('marks a partial explanation close and names the missing distinction', () => {
+    const card = pythonTriviaDeck.cards.find(
+      (candidate) => candidate.id === 'python-pass-by-assignment',
+    );
+    expect(card).toBeDefined();
+
+    const grade = gradeTriviaAnswer(card!, 'Python uses object sharing with the same object.');
+
+    expect(grade.status).toBe('close');
+    expect(grade.missingConcepts).toContain('mutation can affect the caller');
+    expect(grade.missingConcepts).toContain('rebinding stays local');
+  });
+
+  it('accepts concise Python identity and equality terminology', () => {
+    const card = pythonTriviaDeck.cards.find(
+      (candidate) => candidate.id === 'python-is-equality',
+    );
+    expect(card).toBeDefined();
+
+    expect(gradeTriviaAnswer(card!, '`is` checks identity; `==` checks equality.').status)
+      .toBe('correct');
+  });
+
+  it('accepts the core PyTorch cross-entropy contract', () => {
+    const card = pytorchTriviaDeck.cards.find(
+      (candidate) => candidate.id === 'torch-cross-entropy-logits',
+    );
+    expect(card).toBeDefined();
+
+    const grade = gradeTriviaAnswer(
+      card!,
+      'Pass logits, not softmax probabilities. The loss fuses log-softmax with NLL for numerical stability.',
+    );
+
+    expect(grade.status).toBe('correct');
   });
 });
 


### PR DESCRIPTION
## Summary
- grade Python and PyTorch responses locally as Correct, Close, or Needs work
- show matched and missing concepts, and update the correct-over-attempted score automatically
- document the conservative on-device grading behavior and keep answers private in browser storage

## Validation
- git diff --check
- npm run ci (273 tests; 327 pages built)
- mobile QA at 390 px on both trivia decks
- verified the reported one-word response "reference" grades Needs work