### PR TITLE
Keep runnable examples in revealed code solutions

### DIFF
--- a/src/components/CodePracticeLab.tsx
+++ b/src/components/CodePracticeLab.tsx
@@ -58,7 +58,13 @@ function getInitialEditorCode(problem: CodePracticeProblem) {
 
 function getReferenceEditorCode(problem: CodePracticeProblem, currentCode: string) {
   if (startsFromBlankFile(problem)) {
-    return `# Reference solution\n${problem.solutionCode}`;
+    // Blank-start exercises should still reveal a complete runnable file. Use
+    // the stored scaffold only at reveal time so the sample inputs and print
+    // calls remain available without giving the learner an initial template.
+    return augmentCodeWithSolution(problem, removeTodoCommentBlocks(problem.starterCode))
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('# Original placeholder:'))
+      .join('\n');
   }
 
   return augmentCodeWithSolution(problem, currentCode);

--- a/tests/code-practice-lab.test.tsx
+++ b/tests/code-practice-lab.test.tsx
@@ -131,8 +131,11 @@ describe('CodePracticeLab', () => {
   }
 
   it('keeps a direct solution action in the workspace and applies it to the editor', async () => {
+    const runPythonAsync = vi.fn().mockResolvedValue({
+      toJs: () => ['solution output\n', ''],
+    });
     loadPyodideRuntime.mockResolvedValueOnce({
-      runPythonAsync: vi.fn(),
+      runPythonAsync,
     });
 
     await render();
@@ -163,6 +166,7 @@ describe('CodePracticeLab', () => {
     expect(getEditor().textContent).toContain('# Reference solution');
     expect(getEditor().textContent).toContain('def softmax_cross_entropy');
     expect(getEditor().textContent).toContain('return "solution"');
+    expect(getEditor().textContent).toContain('print("starter")');
     expect(container.querySelector('.code-practice-lab--reference')).not.toBeNull();
     expect(getEditor().textContent).not.toContain('raise NotImplementedError');
     expect(container.querySelector('.cm-solution-line-toggle')).toBeNull();
@@ -173,6 +177,16 @@ describe('CodePracticeLab', () => {
     );
     expect(container.querySelector('.code-practice-lab__solution-diagram')).not.toBeNull();
     expect(container.textContent).toContain('(N, 1) × (1, M) → (N, M)');
+
+    const runButton = container.querySelector<HTMLButtonElement>('button[aria-label="Run code"]');
+    await act(async () => {
+      runButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushAsyncWork();
+
+    expect(runPythonAsync).toHaveBeenCalledOnce();
+    expect(runPythonAsync.mock.calls[0][0]).toContain('print("starter")');
+    expect(container.textContent).toContain('solution output');
   });
 
   it('loads required packages and prints run output', async () => {


### PR DESCRIPTION
## What changed
- keep function practice editors blank on initial load
- reveal the completed implementation together with its sample inputs and print calls
- verify the revealed code runs and sends printed output to the result panel

## Why
Blank-start exercises should not expose a scaffold, but the Solution action should still produce a complete runnable file.

## Validation
- npm run ci
- 273 tests passed
- Astro check, build, and build verification passed