### PR TITLE
Clarify the cache lookup trivia prompt

### DIFF
--- a/src/lib/trivia-atomic-specs.ts
+++ b/src/lib/trivia-atomic-specs.ts
@@ -31,7 +31,7 @@ export const pythonAtomicSpecs: AtomicTriviaSpec[] = [
     question: 'Which operator checks object identity?',
     answer: '`is`',
     code: 'cached = cache.get(key)\nif cached is None:\n    cached = build_value(key)',
-    codeQuestion: 'Which cache-miss sentinel is tested?',
+    codeQuestion: 'If `cache.get(key)` finds nothing, what value does this code check for?',
     codeAnswer: '`None`',
   },
   { sourceId: 'python-is-equality', id: 'python-equality-operator', question: 'Which operator checks value equality?', answer: '`==`', acceptedAnswers: ['equals'] },

--- a/tests/trivia-deck.test.tsx
+++ b/tests/trivia-deck.test.tsx
@@ -261,4 +261,14 @@ describe('published trivia data', () => {
     );
     expect(comparison?.explanation).toContain('Strict rejection is configurable—not the default.');
   });
+
+  it('asks the cache lookup question in concrete terms', () => {
+    const cacheCard = pythonTriviaDeck.cards.find(
+      (card) => card.id === 'python-is-operator-code',
+    );
+    expect(cacheCard?.question).toBe(
+      'If `cache.get(key)` finds nothing, what value does this code check for?',
+    );
+    expect(cacheCard?.answer).toBe('`None`');
+  });
 });


### PR DESCRIPTION
## What changed
- replace the jargon-heavy cache-miss sentinel wording with a concrete question about cache.get
- keep the one-word answer as None
- add a regression test for the published card

## Validation
- focused trivia suite: 449 tests passed
- npm run ci: 498 tests, Astro checks, production build, and route verification passed
- pre-push CI passed