### PR TITLE
Rewrite and tighten all Blog posts

### DIFF
--- a/src/content/posts/attention-mechanisms-demystified.mdx
+++ b/src/content/posts/attention-mechanisms-demystified.mdx
@@ -197,7 +197,7 @@ The table is the map: these methods are not one flat list because they solve dif
 
 The irreversible choice is the memory carrier. GQA preserves token-addressable K/V vectors but reduces how many independent copies exist. MLA keeps a token-indexed cache but compresses each token through learned latent projections. Delta-rule models stop retaining a token-indexed history at all: later writes share finite state, so targeted update and forgetting become part of retrieval quality. A hybrid does not erase that distinction; it spends most layers on bounded memory and inserts occasional layers that can still inspect explicit positions.
 
-> **Deep insight:** Attention variants are memory policies. Each one decides what remains addressable after a write, and its characteristic failure follows from what that policy discards.
+Attention variants are memory policies. Each one decides what remains addressable after a write, and its characteristic failure follows from what that policy discards.
 
 ### Share the cache
 
@@ -497,23 +497,3 @@ Attention still answers one question: for this output position, which sources ma
 - Hybrid models spend most layers on cheap memory updates and reserve some layers for stronger retrieval.
 
 No variant dominates every regime. Full attention preserves exact access but grows expensive with context. Cache-sharing methods are simpler but reduce K/V capacity. Latent, sparse, and recurrent methods buy more efficiency with new approximation, tuning, kernel, or serving burdens. The right comparison is therefore not “which attention name is newest?” but “which bottleneck dominates this model, and which retrieval failure can it afford?”
-
-## References
-
-- Ali (`@waterloo_intern`), [“22580: From GPT2 to Kimi3, Explained”](https://x.com/i/status/2081762065392541951)
-- Sebastian Raschka, [“A Visual Guide to Attention Variants in Modern LLMs”](https://magazine.sebastianraschka.com/p/visual-attention-variants)
-- Bahdanau, Cho, and Bengio, [“Neural Machine Translation by Jointly Learning to Align and Translate”](https://arxiv.org/abs/1409.0473)
-- Vaswani et al., [“Attention Is All You Need”](https://arxiv.org/abs/1706.03762)
-- Shazeer, [“Fast Transformer Decoding: One Write-Head is All You Need”](https://arxiv.org/abs/1911.02150)
-- Katharopoulos et al., [“Transformers are RNNs: Fast Autoregressive Transformers with Linear Attention”](https://arxiv.org/abs/2006.16236)
-- Ainslie et al., [“GQA: Training Generalized Multi-Query Transformer Models from Multi-Head Checkpoints”](https://arxiv.org/abs/2305.13245)
-- DeepSeek-AI, [“DeepSeek-V2: A Strong, Economical, and Efficient Mixture-of-Experts Language Model”](https://arxiv.org/abs/2405.04434)
-- Yang et al., [“Parallelizing Linear Transformers with the Delta Rule over Sequence Length”](https://arxiv.org/abs/2406.06484)
-- Yang et al., [“Gated Delta Networks: Improving Mamba2 with Delta Rule”](https://arxiv.org/abs/2412.06464)
-- Gemma Team, [“Gemma 3 Technical Report”](https://arxiv.org/abs/2503.19786)
-- Qiu et al., [“Gated Attention for Large Language Models: Non-linearity, Sparsity, and Attention-Sink-Free”](https://arxiv.org/abs/2505.06708)
-- Kimi Team, [“Kimi Linear: An Expressive, Efficient Attention Architecture”](https://arxiv.org/abs/2510.26692)
-- Kimi Team, [“Attention Residuals”](https://arxiv.org/abs/2603.15031)
-- DeepSeek-AI, [“DeepSeek-V3.2: Pushing the Frontier of Open Large Language Models”](https://arxiv.org/abs/2512.02556)
-- PyTorch, [`torch.nn.functional.scaled_dot_product_attention`](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention)
-- PyTorch, [`torch.nn.attention.flex_attention`](https://docs.pytorch.org/docs/stable/nn.attention.flex_attention.html)

--- a/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
+++ b/src/content/posts/building-local-blog-audio-with-qwen3-tts.md
@@ -61,7 +61,7 @@ The fix belongs in the article first. I do not ask the voice model to invent a b
 
 This project did not converge through one parameter sweep. Each failure invalidated an assumption in the design.
 
-The first assumption was that a good voice description creates a stable speaker. I used Qwen3-TTS VoiceDesign and repeated the same request—warm, measured, close-miked, restrained—for every chunk. The broad style survived. The person did not. Each chunk redesigned the voice, so timbre, pitch, register, and energy moved across an article.
+The first assumption was that a good voice description creates a stable speaker. I used Qwen3-TTS VoiceDesign and repeated the same request for every chunk: warm, measured, close-miked, and restrained. The broad style survived. The person did not. Each chunk redesigned the voice, so timbre, pitch, register, and energy moved across an article.
 
 The second assumption was that a shared reference waveform solves identity. Qwen3-TTS Base can condition on a reference WAV and its transcript. Giving every chunk the same synthetic sample did anchor one speaker. It also created the most obvious bug in the entire feature: “the delivery is warm” appeared before chunk after chunk.
 
@@ -170,20 +170,8 @@ The interval between the two PRs is an incomplete Blog release. It is not a reas
 
 The technical work ended up changing the prose more than I expected. A listener cannot glance back at a table, infer that “this” names the left panel, or hold five unexplained acronyms while a sentence detours through a citation. The spoken path makes missing transitions obvious.
 
-That pressure is useful. The page can remain the richer artifact—with code, equations, figures, links, tables, and references—while the prose itself carries a complete argument. The narration compiler removes objects that require vision. It should not remove the reasoning those objects support.
+That pressure is useful. The page can remain the richer artifact, with code, equations, figures, links, tables, and references, while the prose itself carries a complete argument. The narration compiler removes objects that require vision. It should not remove the reasoning those objects support.
 
 I started with a player. What I actually built is a second rendering contract for the Blog. The source must be final. The narrator must be versioned. The generation boundary must preserve enough context to sound human. Duration limits must reshape the script rather than cut the ending. And production must serve the exact waveform that passed both machine checks and a listener's ear.
 
 That is the part I would carry into any generated-media feature. A model call creates an artifact. A product needs a compiler, a release protocol, and evidence that the artifact people receive is the one you meant to make.
-
-## References
-
-- [Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS)
-- [MLX-Audio](https://github.com/Blaizzy/mlx-audio)
-- [Astro content collections](https://docs.astro.build/en/guides/content-collections/)
-- [Initial local read-aloud release](https://github.com/arunabh1904/arunabh1904.github.io/commit/693eb337f81ff93aaa0c998584fffd9bfd2e628f)
-- [ICL preface repair](https://github.com/arunabh1904/arunabh1904.github.io/pull/198)
-- [Reference-free corpus release](https://github.com/arunabh1904/arunabh1904.github.io/pull/204)
-- [Non-truncating 30-minute compiler](https://github.com/arunabh1904/arunabh1904.github.io/pull/223)
-- [Bounded narration corpus](https://github.com/arunabh1904/arunabh1904.github.io/pull/228)
-- [Selected-voice corpus release](https://github.com/arunabh1904/arunabh1904.github.io/pull/233)

--- a/src/content/posts/code-is-cheap-understanding-isnt.md
+++ b/src/content/posts/code-is-cheap-understanding-isnt.md
@@ -44,7 +44,7 @@ That is context, and context engineering is not the same thing as putting more t
 
 The real skill is deciding what an agent needs to know for this task, right now. Sometimes good context engineering means adding a design decision, production invariant, or failure trace. Sometimes it means deleting an obsolete instruction. The goal is not maximum context. It is the smallest context that preserves the decisions the agent cannot safely rediscover.
 
-> **Deep insight:** Good context engineering is selective memory. Preserve the decisions a system cannot safely rediscover; remove the history that only makes those decisions harder to see.
+Good context engineering is selective memory. Preserve the decisions a system cannot safely rediscover; remove the history that only makes those decisions harder to see.
 
 ## Do not become a slop cannon
 
@@ -131,14 +131,14 @@ Speed is useful. Tenacity is different.
 
 ## What remains
 
-The amount of human labor required to produce software will probably fall. Pretending otherwise does not help anyone. If one engineer can direct five, ten, or twenty capable agents, the economics of engineering organizations change—perhaps unevenly and not all at once, but in a direction that is hard to ignore.
+The amount of human labor required to produce software will probably fall. Pretending otherwise does not help anyone. If one engineer can direct five, ten, or twenty capable agents, the economics of engineering organizations change. The shift may be uneven and gradual, but its direction is hard to ignore.
 
 Imagine two engineers in that organization. One has become extraordinarily good at generating things. Every task invokes the largest model. Every problem becomes a giant agent run. The engineer produces enormous diffs, consumes enormous amounts of inference, and understands a shrinking fraction of what ships.
 
 The other understands the system and the business. They decompose ambiguous problems, know when a small model will do, keep context clean, run independent work in parallel, delete aggressively, challenge the output, and take responsibility for what reaches production.
 
 [![An engineer routes distinct tasks to small specialist robots while reserving one large machine for the hardest work.](/assets/images/agentic-engineering-orchestration.png)](/assets/images/agentic-engineering-orchestration.png)
-_Agent manager — imagined by OpenAI ImageGen._
+_Agent manager, imagined by OpenAI ImageGen._
 
 Which one do you retain?
 

--- a/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
+++ b/src/content/posts/from-ppo-to-grpo-rl-for-reasoning-and-vlas.md
@@ -9,7 +9,7 @@ tags:
   - Reinforcement Learning
   - Reasoning
   - Robotics
-summary: 'How PPO, DPO, GRPO, and on-policy distillation construct their learning signals—and which assumptions survive contact with physical action.'
+summary: 'How PPO, DPO, GRPO, and on-policy distillation construct their learning signals, and which assumptions survive contact with physical action.'
 ---
 
 # PPO, DPO, GRPO, and On-Policy Distillation
@@ -20,7 +20,7 @@ The useful history is not the sequence of names. It is the sequence of compromis
 
 > Given behavior sampled from the current policy, what evidence should increase or decrease its probability, and relative to what baseline?
 
-This essay follows that question from PPO through verifiable-reward reasoning and into VLA post-training. It is intentionally narrower than [Post-Training VLAs: A Reading Guide to Closed-Loop Improvement](/blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html). That guide covers the whole deployment loop: action interfaces, failure mining, feedback collection, critics, evaluation, and reproducibility. Here, those are held at the boundary. The subject is the update machinery itself—sampling distribution, advantage construction, likelihood ratio, and credit assignment.
+This essay follows that question from PPO through verifiable-reward reasoning and into VLA post-training. It is intentionally narrower than [Post-Training VLAs: A Reading Guide to Closed-Loop Improvement](/blog/2026/07/16/post-training-vision-language-action-models-zero-to-hero.html). That guide covers the whole deployment loop: action interfaces, failure mining, feedback collection, critics, evaluation, and reproducibility. Here, those are held at the boundary. The subject is the update machinery itself: sampling distribution, advantage construction, likelihood ratio, and credit assignment.
 
 The evidence cutoff is July 27, 2026. PPO, DPO, DeepSeekMath/GRPO, GKD, DeepSeek-R1, and the early VLA-RL systems are reported evidence. The final hybrid design is synthesis: a falsifiable proposal, not a result already established across robots.
 
@@ -78,7 +78,7 @@ The clipping rule answers a narrow question: how much should the optimizer trust
 
 That compromise fit early RLHF. A language model supplies tractable token log-probabilities; a learned reward model scores a completion; a value model predicts return; and a frozen reference policy supplies a KL anchor. But the complete training stack can require the actor, reference, reward model, and critic in memory, while generation dominates wall-clock time. The critic is especially awkward for sparse sequence rewards: it must predict the eventual quality of a long answer from every partial prefix.
 
-PPO therefore established the durable skeleton—online sampling, relative probability updates, and reference control—while making the value model the obvious component to challenge.
+PPO therefore established the durable skeleton: online sampling, relative probability updates, and reference control. It also made the value model the obvious component to challenge.
 
 ## DPO: store the contrast
 
@@ -123,7 +123,7 @@ This is an excellent bargain when three conditions hold:
 
 Math and code fit unusually well. A sampler can produce eight solutions without changing the problem, and an exact checker can often score the final answer. DeepSeekMath reports gains after GRPO-based training across GSM8K, MATH, and multilingual mathematics. [DeepSeek-R1](https://arxiv.org/abs/2501.12948) pushes the idea further: R1-Zero shows that verifiable-reward RL without supervised reasoning traces can elicit longer reasoning, self-checking, and strategy changes. Its language mixing and poor readability also show what correctness-only reward leaves unconstrained. The final R1 recipe adds cold-start data and staged training rather than treating pure RL as sufficient.
 
-> **Deep insight:** GRPO removes the critic, not the estimation problem. It moves that problem into the sampler because the group now defines the baseline.
+GRPO removes the critic, not the estimation problem. It moves that problem into the sampler because the group now defines the baseline.
 
 ## When the group says nothing
 
@@ -253,7 +253,7 @@ This hypothesis is falsifiable. Compare four methods under identical model initi
 3. on-policy distillation from a privileged teacher;
 4. the hybrid of sparse RL and segment-level distillation.
 
-Report success and safety, but also zero-variance group rate, critic/teacher calls, policy KL, action entropy, recovery success, real robot-hours, and performance after the teacher or simulator distribution shifts. The hybrid earns its complexity only if it improves reliable success per unit of interaction—not merely final reward after consuming more rollouts and teacher inference.
+Report success and safety, but also zero-variance group rate, critic/teacher calls, policy KL, action entropy, recovery success, real robot-hours, and performance after the teacher or simulator distribution shifts. The hybrid earns its complexity only if it improves reliable success per unit of interaction, not merely final reward after consuming more rollouts and teacher inference.
 
 ## Where the signal comes from
 
@@ -263,21 +263,4 @@ Reasoning models made GRPO powerful because prompts reset perfectly and verifier
 
 > Sample where the policy will act, compare only what the environment makes comparable, and make feedback no coarser than the decision it is supposed to credit.
 
-That principle explains the past decade of policy optimization better than the acronym sequence—and gives VLA post-training a testable path beyond copying language-model RL.
-
-## References
-
-- [Proximal Policy Optimization Algorithms](https://arxiv.org/abs/1707.06347)
-- [Direct Preference Optimization](https://arxiv.org/abs/2305.18290)
-- [On-Policy Distillation of Language Models](https://arxiv.org/abs/2306.13649)
-- [DeepSeekMath / GRPO](https://arxiv.org/abs/2402.03300)
-- [DeepSeek-R1](https://arxiv.org/abs/2501.12948)
-- [DAPO](https://arxiv.org/abs/2503.14476)
-- [Diffusion Policy Policy Optimization](https://arxiv.org/abs/2409.00588)
-- [RLDG](https://arxiv.org/abs/2412.09858)
-- [RIPT-VLA](https://arxiv.org/abs/2505.17016)
-- [SimpleVLA-RL](https://arxiv.org/abs/2509.09674)
-- [RobustVLA](https://arxiv.org/abs/2511.01331)
-- [LifeLong-RFT](https://arxiv.org/abs/2602.10503)
-- [Self-Supervised On-Policy Distillation for Reasoning LMs](https://arxiv.org/abs/2605.17497)
-- [Advantage Collapse in GRPO](https://arxiv.org/abs/2605.21125)
+That principle explains the past decade of policy optimization better than the acronym sequence and gives VLA post-training a testable path beyond copying language-model RL.

--- a/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
+++ b/src/content/posts/from-seeing-to-doing-the-evolution-of-vision-language-models.md
@@ -216,7 +216,7 @@ The video-language models above still turn visual evidence into words. JEPA chan
 
 A useful exchange between [Rohan Anil](https://x.com/_arohan_/status/2007597891381031029) and [Yann LeCun](https://x.com/ylecun/status/2007907701989232684) gets at the deeper point. JEPA is not defined by opposition to language models or generative decoders. It changes where the predictive burden sits. Instead of asking a decoder to reproduce every unpredictable detail in input space, the encoder learns a latent target that keeps what is useful and suppresses what is not. Preventing that latent space from collapsing is therefore part of the learning problem, not an implementation detail.
 
-> **Deep insight:** A predictive representation is a learned bottleneck. Its value comes from throwing away variation that does not help prediction. Its risk is throwing away the local geometry and motion that a later controller needs.
+A predictive representation is a learned bottleneck. Its value comes from throwing away variation that does not help prediction. Its risk is throwing away the local geometry and motion that a later controller needs.
 
 The global-versus-local problem therefore returns even without language. A strong video embedding can still be poor at depth or local motion. [V-JEPA 2.1](/paper%20shorts/2026/03/15/v-jepa-2-1-dense-video-features.html) adds dense prediction and self-supervision at intermediate layers so depth, anticipation, and interaction do not have to survive only through a global target.
 

--- a/src/content/posts/how-to-read-scaling-laws-for-language-models.md
+++ b/src/content/posts/how-to-read-scaling-laws-for-language-models.md
@@ -175,7 +175,7 @@ If latency, data access, or evaluation reliability is the bottleneck, more compu
 
 **Use loss to choose a pretraining frontier; use a capability vector to accept a system.** NLL is the right dense signal for deciding whether one pretraining recipe is more sample- or compute-efficient. It cannot decide whether the resulting system is acceptable for a target domain, latency budget, safety envelope, or tool-use task. Keep those evaluations separate, and treat a divergence between loss and capability as evidence that the scalar training objective is no longer the bottleneck you care about.
 
-> **The law is not the strategy.** It is a local map of where marginal return currently lives. The strategy is choosing which map describes the system we are building—and knowing when to redraw it.
+> **The law is not the strategy.** It is a local map of where marginal return currently lives. The strategy is choosing which map describes the system we are building and knowing when to redraw it.
 
 ## A reading map
 

--- a/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
+++ b/src/content/posts/how-unified-sensor-models-are-built-for-autonomous-driving.md
@@ -196,7 +196,7 @@ One response is to let each modality generate proposals and merge them before re
 
 This creates a general diagnostic question for any fusion architecture: **which modality controls admission into the shared representation?** If the answer is one sensor's proposals, points, or confidence threshold, then that sensor's recall becomes a ceiling unless another path explicitly bypasses it.
 
-> **Deep insight:** In multimodal fusion, the hidden bottleneck is often admission rather than attention. The sensor that creates the proposals, points, or thresholds decides which evidence becomes eligible for downstream computation; without a bypass, its recall becomes the system's ceiling.
+In multimodal fusion, the hidden bottleneck is often admission rather than attention. The sensor that creates the proposals, points, or thresholds decides which evidence becomes eligible for downstream computation; without a bypass, its recall becomes the system's ceiling.
 
 ### Interaction can occur before either stream is finished
 A simple architecture runs a camera encoder and a LiDAR encoder to completion, then applies one fusion block. [DeepInteraction](/paper%20shorts/2022/08/23/deepinteraction-3d-object-detection-via-modality-interaction.html) lets the streams update one another across representation stages. [UniTR](/paper%20shorts/2023/08/15/unitr-unified-efficient-multimodal-transformer-for-bev.html) applies shared transformer blocks after modality-specific tokenization.

--- a/src/content/posts/my-journey-so-far-full-story.md
+++ b/src/content/posts/my-journey-so-far-full-story.md
@@ -43,15 +43,15 @@ Even with that ridiculous ending, the concept was real. A similar design is now 
 ![The areca-nut harvesting robot built for my undergraduate thesis](/assets/images/IMG_8842.jpg)
 _Our undergraduate prototype climbed an areca palm and used a remotely controlled cutter. Source: personal project archive._
 
-Undergrad changed my direction because the late start still compounded. The GPA recovery proved I could rebuild after wasting time; the robot proved that I cared most when engineering had a physical consequence for someone else. The reversed video was classic *jugaad*—funny in retrospect and not a substitute for a working demonstration—but the underlying problem made robotics feel worth pursuing.
+Undergrad changed my direction because the late start still compounded. The GPA recovery proved I could rebuild after wasting time; the robot proved that I cared most when engineering had a physical consequence for someone else. The reversed video was classic *jugaad*. It is funny in retrospect and was not a substitute for a working demonstration, but the underlying problem made robotics feel worth pursuing.
 
 ## Depression
 
 After college, I went through depression. It is better understood in India today than it was a decade ago, but people around me often had no language for it. More than once, when I said I did not feel like getting up or leaving my room, someone told me, "Just take a cold shower; you'll be fine." I wish I could have explained what was happening inside: my brain felt like it was on fire, I felt like screaming from the inside, and I could not see a way out. I am sharing this because someone reading it may need to know they are not alone.
 
-After graduation, I had my heart set on pursuing a master's degree in Germany. The education was free, and many of my friends were heading there—naturally, it seemed like the best reason to go. I returned to Jaipur for what was supposed to be a brief stay, with one goal: apply to colleges in Germany and leave within six months. I took the GRE, prepared my applications, and applied to a few universities, including an ultra-safe option to ensure I'd get in. When the day came, I mailed all five applications together, confident about my future.
+After graduation, I had my heart set on pursuing a master's degree in Germany. The education was free, and many of my friends were heading there. Naturally, it seemed like the best reason to go. I returned to Jaipur for what was supposed to be a brief stay, with one goal: apply to colleges in Germany and leave within six months. I took the GRE, prepared my applications, and applied to a few universities, including an ultra-safe option to ensure I'd get in. When the day came, I mailed all five applications together, confident about my future.
 
-A month later, I was anxiously waiting for the results. Then, I received an email from my safe school. I opened it, expecting good news, only to read that I was being rejected for missing documents. To my horror, I realized I had accidentally sent the documents meant for the safe school to another university. Slowly, the rejection emails from all five universities trickled in, and the reality set in—I wasn't going to Germany.
+A month later, I was anxiously waiting for the results. Then, I received an email from my safe school. I opened it, expecting good news, only to read that I was being rejected for missing documents. To my horror, I realized I had accidentally sent the documents meant for the safe school to another university. Slowly, the rejection emails from all five universities trickled in. I wasn't going to Germany.
 
 ![The missing-documents rejection notice that exposed my application mix-up](/assets/images/tuhh.png)
 _The rejection notice that exposed the document mix-up across my German university applications. Source: personal archive._
@@ -94,20 +94,19 @@ _The hexapod project paired a 1D LiDAR and Pixy camera with a small mobile platf
 
 Looking back, the best thing I did was build a strong foundation in the skills I cared about and then find practical ways to use them. Grades mattered, but the projects I took on, the problems I solved, and the people I learned from shaped me more. My advice to current graduate students is simple: take on projects that stretch you, use the resources around you, and follow problems that genuinely excite you. That is how progress starts to compound.
 
-## Getting hired
+## Breaking into robotics
 
-Landing your first job out of grad school in the U.S. can be difficult, especially if you want the dream job immediately and you are not coming from a top university. Even if you spent grad school building skills, doing research, and working on relevant projects, the search can still be tough. These are the things that helped me:
+Landing my first job after graduate school was difficult. I wanted a robotics role in the United States, had no industry experience, and was not graduating from a university that would carry the application by itself. Research and projects helped me become credible. They did not remove the need to learn the interview process as its own skill.
 
-**Interviewing** is a slightly different beast than actually doing the job. There is a certain progression to it, and you have to prepare for every level.
+Five habits made the search more tractable:
 
-- **Resume Preparation**: The first step is your resume. Aim for a simple one-pager. Make sure to highlight key projects tailored to the specific role you’re applying for.
-- **Code Screen**: Spend time learning the fundamentals of the primary language required for the role (C++ and Python for robotics). Brush up on data structures and algorithms with a curated list like Blind 75.
-- **Onsite Interview**: Multiple rounds, including algorithms, behavioral questions, and domain knowledge. Be able to expand on anything on your resume and dive deep if asked.
-- **Apply Broadly**: Quantity often beats quality for fresh grads. Keep a spreadsheet with details of your applications.
-- **Start Early**: Begin before your final semester, look for research projects or internships.
-- **Get Experience First**: Don’t be overly selective about your first role; initial experience can make it easier to pivot later.
-- **Career Fairs**: These can be helpful, but don’t rely on them exclusively.
-- **Honesty**: Never lie on your resume.
+- Keep the resume to one page and make the relevant projects easy to find. Be ready to explain every line in depth.
+- Practice the actual screening format. For robotics, that meant C++, Python, data structures, algorithms, behavioral questions, and domain fundamentals.
+- Start before the final semester. Research projects, internships, and career fairs can create leads, but no single channel is reliable enough on its own.
+- Apply broadly and track every application. For a new graduate, a larger honest funnel often matters more than perfecting a few dream applications.
+- Optimize the first role for useful experience. The first job does not need to be the final destination, but the resume must remain truthful.
+
+The process felt mechanical compared with the work I wanted to do. That was the point. Interview preparation turned the projects I had already completed into evidence a hiring team could evaluate.
 
 ## DEKA
 
@@ -125,13 +124,13 @@ DEKA opened the door to my dream job. The projects taught me technical skills, b
 
 ## Zoox
 
-Joining Zoox realized a long-held goal: working on autonomous driving. I am now a technical lead on the Perception team, where I lead a broader initiative to make our autonomy systems more capable and efficient. But I also had imposter syndrome when I moved into the role. I was surrounded by incredibly talented people and felt out of place at first. The way through it was not one dramatic breakthrough; it was small wins—understanding the system, making good technical decisions, and helping the team ship. The work has to improve a system that runs on real vehicles, so technical quality and production usefulness are inseparable.
+Joining Zoox realized a long-held goal: working on autonomous driving. I am now a technical lead on the Perception team, where I lead a broader initiative to make our autonomy systems more capable and efficient. But I also had imposter syndrome when I moved into the role. I was surrounded by incredibly talented people and felt out of place at first. The way through it was not one dramatic breakthrough. It was a series of small wins: understanding the system, making good technical decisions, and helping the team ship. The work has to improve a system that runs on real vehicles, so technical quality and production usefulness are inseparable.
 
 One part of that work I am particularly proud of is where it began. Around the middle of last year, I started prototyping the idea as a small side project. At first, it was simply something I wanted to test. Once we had enough evidence that the approach could work, the project grew into a dedicated team and roadmap. Over the last couple of quarters, we turned it into a production improvement that made the system more efficient while improving quality, and we shipped the result earlier this year.
 
-That transition—from a side project to a team—also changed my role. Moving from an IC role back into technical leadership was intentional. By then, I had enough experience under my belt to be useful in both modes: I could go deep on the hard technical decisions, but I could also set direction, explain tradeoffs, and help other people execute. I also participate in a broader research committee across Zoox, which gives me exposure to technical direction outside my immediate area.
+That transition from a side project to a team also changed my role. Moving from an IC role back into technical leadership was intentional. By then, I had enough experience under my belt to be useful in both modes: I could go deep on the hard technical decisions, but I could also set direction, explain tradeoffs, and help other people execute. I also participate in a broader research committee across Zoox, which gives me exposure to technical direction outside my immediate area.
 
-> **Deep insight:** Confidence was usually the lagging indicator. I acted before I felt ready, and the evidence from small wins changed what I believed I could do.
+Confidence was usually the lagging indicator. I acted before I felt ready, and the evidence from small wins changed what I believed I could do.
 
 ## Looking back
 

--- a/src/content/posts/omni-model-pretraining-decisions.md
+++ b/src/content/posts/omni-model-pretraining-decisions.md
@@ -189,7 +189,7 @@ These questions usually expose what changed:
 
 A frozen encoder tests whether the pretrained features already contain what the robot needs. Full fine-tuning tests whether those weights are a useful starting point. World-model reconstruction tests prediction. Closed-loop planning tests whether that prediction helps the robot. These claims should not be collapsed into one transfer score.
 
-## So.... let's recap
+## What pretraining must preserve
 
 | Leap | What the model learned to predict | What it bought | What remained unresolved |
 | --- | --- | --- | --- |
@@ -202,32 +202,8 @@ A frozen encoder tests whether the pretrained features already contain what the 
 | Video and latent-action pretraining | temporal change before robot labels | cheap interaction and motion priors | latent change is not yet executable action |
 | Action-conditioned world models | consequences under proposed actions | planning and counterfactual ranking | causal fidelity over long rollouts |
 
-The pattern mirrors Part I. Every new target asks the model to preserve more: first semantics, then geometry, motion, actions, and consequences. The action representation decides how much of that knowledge reaches the controller.
-
-## A testable thesis
-
-I would start with a strong vision-language model for semantics, dense visual features that persist through time, and a continuous action expert for control. Discrete action tokens are useful when they make web and robot data easier to train together. I would not assume those same tokens should run the robot. The motor path should be pretrained too, unless an ablation shows that random initialization is good enough.
+Every new target asks the model to preserve more: first semantics, then geometry, motion, actions, and consequences. The action representation decides how much of that knowledge reaches the controller. I would start with a strong vision-language model for semantics, dense visual features that persist through time, and a continuous action expert for control. Discrete action tokens are useful when they make web and robot data easier to train together. I would not assume those same tokens should run the robot. The motor path should be pretrained too, unless an ablation shows that random initialization is good enough.
 
 If the model claims to plan, train it to predict action-conditioned futures and check that a changed action changes the future. If it claims cross-robot transfer, define the shared physical quantity before pooling controls. If it claims scale, report independent decisions and few-shot transfer, not only token count and training loss.
 
-The VLM can know what a drawer is. The temporal model can track that it moved. The world model must preserve what the robot caused. The policy must choose and execute the action before the deadline.
-
-Pretraining succeeds when these components transfer useful structure into the policy without removing the geometric, temporal, and control distinctions required during execution.
-
-## Selected references
-
-- [PaLM-E: An Embodied Multimodal Language Model](/paper%20shorts/2023/03/06/palm-e-embodied-multimodal-language-model.html)
-- [RT-1: Robotics Transformer for Real-World Control at Scale](/paper%20shorts/2022/12/13/rt-1-robotics-transformer-for-real-world-control-at-scale.html)
-- [RT-2: Vision-Language-Action Models Transfer Web Knowledge to Robotic Control](/paper%20shorts/2023/07/28/rt-2-vision-language-action-models-transfer-web-knowledge-to-robotic-control.html)
-- [Open X-Embodiment: Robotic Learning Datasets and RT-X Models](/paper%20shorts/2023/10/13/open-x-embodiment-robotic-learning-datasets-and-rt-x-models.html)
-- [Octo: An Open-Source Generalist Robot Policy](/paper%20shorts/2024/05/20/octo-an-open-source-generalist-robot-policy.html)
-- [OpenVLA: An Open-Source Vision-Language-Action Model](/paper%20shorts/2024/06/01/openvla-open-source-vision-language-action-model.html)
-- [Action Chunking with Transformers](/paper%20shorts/2023/04/23/action-chunking-with-transformers-act.html)
-- [Diffusion Policy](/paper%20shorts/2023/03/07/diffusion-policy-visuomotor-policy-learning-via-action-diffusion.html)
-- [FAST: Efficient Action Tokenization for Vision-Language-Action Models](/paper%20shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html)
-- [Pi0: A Vision-Language-Action Flow Model for General Robot Control](/paper%20shorts/2024/10/01/pi0-vision-language-action-flow-model-for-general-robot-control.html)
-- [Pi0.5: A Vision-Language-Action Model with Open-World Generalization](/paper%20shorts/2025/04/22/pi0-5-vision-language-action-model-with-open-world-generalization.html)
-- [GR00T N1: An Open Foundation Model for Humanoid Robots](/paper%20shorts/2025/03/18/groot-n1-open-foundation-model-for-humanoid-robots.html)
-- [Genie: Generative Interactive Environments](/paper%20shorts/2024/02/23/genie-generative-interactive-environments.html)
-- [V-JEPA 2: Self-Supervised Video Models Enable Understanding, Prediction and Planning](/paper%20shorts/2025/06/11/v-jepa-2-self-supervised-video-models.html)
-- [Xiaomi-Robotics-1: Scaling VLA Models with Real-World Trajectories](/paper%20shorts/2026/07/16/xiaomi-robotics-1-scaling-vla-with-real-world-trajectories.html)
+The VLM can know what a drawer is. The temporal model can track that it moved. The world model must preserve what the robot caused. The policy must choose and execute the action before the deadline. Pretraining succeeds when those components transfer useful structure without removing the geometric, temporal, and control distinctions required during execution.

--- a/src/content/posts/on-engineering-management.md
+++ b/src/content/posts/on-engineering-management.md
@@ -22,7 +22,7 @@ I do not measure management by the number of meetings I attend, the decisions th
 
 Management, at its best, is a compounding system. Good decisions create progress. Progress creates information. Information improves judgment. Better judgment produces greater autonomy, which allows the team to take on harder problems. My job is to keep that loop moving.
 
-## Code Is Only as Good as the Problem It Solves
+## Code is only as good as the problem it solves
 
 I love writing code. Building things is still one of the best ways to understand them. But code is only as good as the problem it solves.
 
@@ -40,7 +40,7 @@ Staying technical keeps those instincts honest. That might mean reviewing a diff
 
 Leading by example is different from leading through dependency. If I always take over the hardest problems, the team learns that important work eventually routes through me. The goal is not to prove that I can still be the strongest engineer in the room. It is to create more people who can solve problems I could not solve alone.
 
-## Go Slow to Go Fast
+## Go slow to go fast
 
 Engineering has two distinct modes: deciding where to go and moving in the chosen direction. Confusing them creates waste.
 
@@ -54,7 +54,7 @@ Expensive decisions deserve cheap evidence. A prototype, benchmark, ablation, tr
 
 Exploration still needs an exit condition. Research becomes procrastination when nobody knows what evidence would be sufficient to act. Before investigating, we should know what uncertainty we are trying to reduce, how much time we will spend, and what result would change the decision. Careful thinking should make execution more decisive, not postpone it.
 
-## Argue Before the Decision, Rebase After It
+## Argue before the decision, rebase after it
 
 Before a decision, I want lots of voices. I want engineers to challenge the framing, question the data, expose missing assumptions, and propose alternatives. Silence is not alignment. It may simply mean that people do not believe disagreement is worth the cost.
 
@@ -68,7 +68,7 @@ Disagree and commit only works when commitment is earned. People are more willin
 
 Then we execute. A team that learns from reality will usually beat one that is still defending its forecast. Time in execution often beats an incredibly smart prior.
 
-## Make Progress Tangible
+## Make progress tangible
 
 Progress is not merely a reporting concern. It is a management primitive.
 
@@ -80,7 +80,7 @@ This is why I break large efforts into meaningful milestones. The goal is not to
 
 Small, repeated wins also build confidence. Give people problems they can own, make the goal clear, let the result be visible, and then increase the scope. Growth often looks like a sequence of small wins long before it looks like a promotion.
 
-## Trust Is Consistency Over Time
+## Trust is consistency over time
 
 Trust is not built through a single vulnerable conversation, a team offsite, or a well-written values document. Trust is consistency over time: between what a manager says and does, across people and standards, and between calm periods and schedule pressure.
 
@@ -90,7 +90,7 @@ Trust creates speed. People spend less time protecting themselves, interpreting 
 
 High trust does not mean low accountability. Expectations should be clear: what good work looks like, where people have autonomy, when they need to escalate, and how performance will be evaluated. Hidden standards make every outcome feel political. Culture is not what we say we value. It is the pattern of consequences people observe.
 
-## One-on-Ones
+## One-on-ones
 
 One-on-ones are an incredible coaching tool if used correctly. But I have often seen them boil down to status meetings. Status can usually be communicated asynchronously or discussed in a project forum. A one-on-one should focus on the person, the relationship, and the conditions under which that person is doing their work.
 
@@ -102,7 +102,7 @@ Good one-on-ones are not passive listening sessions. A manager should bring obse
 
 One-on-ones also require follow-through. If someone raises the same concern three times and nothing happens, the meeting teaches them that candor is performative. Trust grows when a person can see that being honest changed something.
 
-## Delegate Opportunity, Not Just Work
+## Delegate opportunity, not just work
 
 Delegation is not unloading tasks. It is designing ownership.
 
@@ -116,7 +116,7 @@ Autonomy does not mean isolation. People should be able to make progress without
 
 The manager remains accountable but should become less central. The test of delegation is not whether work disappeared from my plate. It is whether judgment appeared somewhere else on the team.
 
-## Empathy by Default, Firmness When Required
+## Empathy by default, firmness when required
 
 My default is empathy. I want to understand the situation before prescribing a solution because the same visible problem can have different causes: missing context, excessive parallel work, a skill gap, burnout, or avoidance. Good management begins with diagnosis.
 
@@ -126,7 +126,7 @@ Firmness means being clear when something needs to change. Feedback should be ti
 
 It is kinder to have a difficult conversation early than to let uncertainty accumulate for months. Someone can be capable and still be struggling. Someone can have good intentions and still create a harmful pattern. The purpose of firmness is not punishment. It is clarity.
 
-## Innovation Needs Capacity
+## Innovation needs capacity
 
 Managers often say they want innovation while planning every engineer at full utilization, rewarding only predictable delivery, and treating failed experiments as wasted time. Teams learn what is valued from what managers fund, review, celebrate, and protect.
 
@@ -138,7 +138,7 @@ Continuous improvement should be a reflex. What slowed us down this week? What r
 
 A high-performing team should not merely deliver more over time. It should become better at delivering. Its tools improve, its decisions become clearer, its operational burden falls, and its engineers take on broader ownership. Every few months, the team should be capable of work that would previously have overwhelmed it.
 
-## What I Am Trying to Build
+## What I am trying to build
 
 My management style can be summarized as high context, high ownership, high standards, and low ego.
 
@@ -146,7 +146,7 @@ I want people to understand what matters and why, and to have enough context to 
 
 Lots of voices, one direction.
 
-I want progress to be visible because it improves learning and builds confidence. I want people to receive exciting work as well as necessary overhead. I want one-on-ones to cover judgment, growth, motivation, and friction—not project status. I want engineers to ask for help before a small blockage becomes a large surprise.
+I want progress to be visible because it improves learning and builds confidence. I want people to receive exciting work as well as necessary overhead. I want one-on-ones to cover judgment, growth, motivation, and friction, not project status. I want engineers to ask for help before a small blockage becomes a large surprise.
 
 I want trust to come from consistency. I want to understand circumstances with empathy and protect standards with firmness. I want to lead by example without making myself indispensable.
 

--- a/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/open-weight-models-that-fit-on-a-64-gb-macbook-pro.md
@@ -34,7 +34,7 @@ This is a fit guide dated August 13, 2026. File sizes are from the linked model 
 
 “Comfortable” does not mean “load a 128K context for free.” It means the weights leave a credible working budget. The KV cache, Metal buffers, multimodal projector, speculative draft model, application processes, and macOS all draw from the same physical memory. A model whose files consume `60+ GB` is not a `64 GB` laptop model merely because the operating system can swap.
 
-> **Deep insight:** Model fit is an application budget, not a weight-file test. The useful model is the one that leaves memory for its context, runtime, tools, and the rest of the machine.
+Model fit is an application budget, not a weight-file test. The useful model is the one that leaves memory for its context, runtime, tools, and the rest of the machine.
 
 I am using *open-weight* deliberately. These releases do not all use the same license, publish the same training information, or provide equally official Mac artifacts. A downloadable checkpoint is a deployment property, not a blanket claim that every part of the model is open source.
 

--- a/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
+++ b/src/content/posts/post-training-vision-language-action-models-zero-to-hero.md
@@ -221,7 +221,7 @@ Start with what happened on the robot, not the optimizer name. Ask how local the
 
 The optimizer follows from these answers. PPO cannot correct a reward that assigns the wrong credit. DPO cannot create a matched counterfactual, and a process critic cannot infer contact from observations that do not contain it.
 
-## So.... let's recap
+## What the feedback can support
 
 | Leap | New feedback unit | What it changed | Remaining risk |
 | --- | --- | --- | --- |
@@ -235,37 +235,10 @@ The optimizer follows from these answers. PPO cannot correct a reward that assig
 | Interactive RL | fresh rollout group and environment reward | improved the data distribution while learning | reward exploitation and rollout cost |
 | Specialist distillation | improved specialist trajectory | protected the generalist from direct RL instability | loss of specialist behavior during distillation |
 
-The feedback becomes more precise as we move down the table. A terminal bit says the rollout ended badly. An intervention says behavior crossed a boundary near this state. A correction says what to do from the reached state. A process critic marks which transition made progress. A matched replay is the rare case that can show what another action would have caused.
-
-The update should use the most specific feedback supported by the deployment event, rather than the most complex objective available in the training stack.
-
-## A testable thesis
-
-The central requirement for VLA post-training is accurate attribution. Each feedback event should identify the state, action, or transition it provides evidence about before that evidence changes the policy.
+The feedback becomes more precise as we move down the table. A terminal bit says the rollout ended badly. An intervention says behavior crossed a boundary near this state. A correction says what to do from the reached state. A process critic marks which transition made progress. A matched replay is the rare case that can show what another action would have caused. The central requirement is accurate attribution: each event should identify the state, action, or transition it provides evidence about before that evidence changes the policy.
 
 I would start with an action representation that matches the controller and use SFT as the baseline. Corrections should be collected in states reached by the policy. Preference optimization requires a defensible comparison, while RL requires a reward and rollout system that have been validated through cheaper evaluations.
 
 My strongest bet is a process critic conditioned on persistent objects, geometry, contact, controller state, and task progress. It should identify the earliest defensible failure window and support a conservative update. That update must then be tested for physical success and retention of older skills before deployment.
 
-A policy can learn reliably from deployment only when the update remains no broader than the evidence. Every consequence must also be traceable to the policy that created it.
-
-## Selected references
-
-- [DAgger: A Reduction of Imitation Learning and Structured Prediction to No-Regret Online Learning](/paper%20shorts/2011/04/11/dagger-reduction-of-imitation-learning-to-no-regret-online-learning.html)
-- [OpenVLA-OFT: Fine-Tuning VLAs for High-Throughput Robot Control](/paper%20shorts/2025/02/27/openvla-oft-optimizing-speed-and-success.html)
-- [FAST: Efficient Action Tokenization for Vision-Language-Action Models](/paper%20shorts/2025/01/01/fast-efficient-action-tokenization-for-vision-language-action-models.html)
-- [Pi0.5: A Vision-Language-Action Model with Open-World Generalization](/paper%20shorts/2025/04/22/pi0-5-vision-language-action-model-with-open-world-generalization.html)
-- [Alpamayo-R1: Bridging Reasoning and Action Prediction](/paper%20shorts/2025/10/30/alpamayo-r1-bridging-reasoning-and-action-prediction-for-generalizable-autonomous-driving-in-the-long-tail.html)
-- [Direct Preference Optimization](/paper%20shorts/2023/05/01/direct-preference-optimization-dpo.html)
-- [KTO: Model Alignment as Prospect Theoretic Optimization](/paper%20shorts/2024/02/02/kto-model-alignment-as-prospect-theoretic-optimization.html)
-- [Action Preference Optimization for Robotic Policy Refinement](/paper%20shorts/2025/06/08/action-preference-optimization-for-robotic-policy-refinement.html)
-- [VisualPRM: Process Reward Models for Multimodal Reasoning](/paper%20shorts/2025/03/13/visualprm-process-reward-model-for-multimodal-reasoning.html)
-- [VLAC: Vision-Language-Action Critic for Real-World RL](/paper%20shorts/2025/09/19/vlac-vision-language-action-critic-for-real-world-rl.html)
-- [DPPO: Diffusion Policy Policy Optimization](/paper%20shorts/2024/09/01/dppo-diffusion-policy-policy-optimization.html)
-- [RIPT-VLA: Interactive Post-Training for Vision-Language-Action Models](/paper%20shorts/2025/05/22/ript-vla-interactive-post-training-for-vision-language-action-models.html)
-- [SimpleVLA-RL: Scaling VLA Training via Reinforcement Learning](/paper%20shorts/2025/09/11/simplevla-rl-scaling-vla-training-via-reinforcement-learning.html)
-- [RLDG: Robotic Generalist Policy Distillation via Reinforcement Learning](/paper%20shorts/2024/12/13/rldg-robotic-generalist-policy-distillation-via-reinforcement-learning.html)
-- [RobustVLA: Robustness-Aware Reinforcement Post-Training](/paper%20shorts/2025/11/03/robustvla-robustness-aware-reinforcement-post-training.html)
-- [LIBERO-Para: Paraphrase Robustness in VLA Models](/paper%20shorts/2026/03/30/libero-para-paraphrase-robustness-in-vla-models.html)
-- [SIMPLER: Evaluating Real-World Robot Policies in Simulation](/paper%20shorts/2024/05/09/simpler-evaluating-real-world-robot-policies-in-simulation.html)
-- [VLA-REPLICA: Reproducible Real-World Evaluation](/paper%20shorts/2026/05/20/vla-replica-low-cost-reproducible-real-world-evaluation.html)
+A policy can learn reliably from deployment only when the update remains no broader than the evidence and every consequence is traceable to the policy that created it.

--- a/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
+++ b/src/content/posts/replacing-openclaw-with-hermes-agent-using-local-weights.md
@@ -43,7 +43,7 @@ The figure shows the boundary that resolved the setup. A prompt does not travel 
 
 This separation also changes how to debug. If Hermes cannot reach `/v1/chat/completions`, inspect the endpoint and configuration. If the endpoint returns HTTP `500` while loading a model, inspect the runtime, artifact, and hardware path. If text is generated but tools appear as plain text, inspect the server's chat template and tool-call support. Treating those as three different contracts avoids reinstalling the wrong layer.
 
-> **Deep insight:** The API boundary is also the debugging boundary. Agent behavior, serving behavior, and model loading can fail independently, so each needs its own test.
+The API boundary is also the debugging boundary. Agent behavior, serving behavior, and model loading can fail independently, so each needs its own test.
 
 ## Install Hermes
 
@@ -101,7 +101,7 @@ A few details mattered in that run:
 - `--parallel 1` kept the memory footprint reasonable while still leaving enough room for the larger context window.
 - `--reasoning off` matched what I wanted anyway: no extra thinking overhead for a local smoke test.
 
-The context value is the main dated part of this recipe. Current Hermes documentation requires at least `64,000` tokens for agent use with tools because the system prompt, schemas, and working conversation already consume substantial context. A new setup should therefore size both Hermes and `llama-server` consistently—typically `65536` or higher if the model and available memory support it—instead of copying the older `32768` value blindly.
+The context value is the main dated part of this recipe. Current Hermes documentation requires at least `64,000` tokens for agent use with tools because the system prompt, schemas, and working conversation already consume substantial context. A new setup should therefore size both Hermes and `llama-server` consistently, typically at `65536` or higher if the model and available memory support it, instead of copying the older `32768` value blindly.
 
 Once that server was up, it exposed the OpenAI-compatible endpoint Hermes wanted at:
 
@@ -130,7 +130,7 @@ After that, `hermes status --deep` showed exactly what I wanted:
 - provider set to `Custom endpoint`
 - no cloud API keys required
 
-## Verification
+## Verify the full path
 
 The test I cared about was extremely boring on purpose:
 
@@ -145,8 +145,6 @@ READY
 ```
 
 That was enough proof: Hermes was running locally against weights already on disk.
-
-## What the test proves
 
 The `READY` response proves the inference path, not full agent quality. A useful next pass should separately test model loading, ordinary chat, structured tool calls, long-context behavior, and recovery when the local server restarts. Those checks locate regressions at the same boundaries shown in the figure.
 

--- a/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-deepseek-v4-flash-0731-on-a-64-gb-macbook-pro.md
@@ -21,7 +21,7 @@ No. The official checkpoint is about `167 GB` on disk, and the maintained vLLM r
 
 This is a sizing analysis dated August 13, 2026, not a benchmark. I did not manufacture latency numbers for a model that cannot load on the machine.
 
-## The fit decision
+## Why active parameters do not determine fit
 
 DeepSeek V4 Flash is a mixture-of-experts model with `284B` total parameters and `13B` active parameters per generated token. The second number makes inference compute much smaller than a dense `284B` model, but it does not turn the checkpoint into a `13B` model. The router may choose only a small subset of experts for one token while choosing a different subset for the next, so the serving process still needs access to the full expert bank.
 
@@ -36,9 +36,7 @@ The official [`DeepSeek-V4-Flash-0731` repository](https://huggingface.co/deepse
 
 This table separates storage from inference. Downloading `167 GB` to the SSD proves only that the files fit on disk. It does not make them resident in memory, and macOS swap does not convert a `64 GB` laptop into a `200 GB` inference server. An experimental engine could offload experts and stream weights, but a deficit above `100 GB` moves the problem from GPU or unified-memory bandwidth to transfers from much slower storage. That is a systems experiment, not a sensible daily serving plan.
 
-> **Deep insight:** Active parameters price the arithmetic for one token. Total parameters price residency. Sparse experts change the first number, not the second.
-
-## Active is not resident
+Active parameters price the arithmetic for one token. Total parameters price residency. Sparse experts change the first number, not the second.
 
 The `13B` active count is still useful: it explains why DeepSeek can reduce the arithmetic performed for each token. It answers a compute question, not the fit question.
 

--- a/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-gemma-4-locally-on-a-64-gb-macbook-pro.md
@@ -42,7 +42,7 @@ My model recommendation is simple:
 - If you want the best Gemma 4 model that comfortably fits, start with `31B`.
 - If you want the model I would actually pay the most attention to for daily use, it is `26B A4B`.
 
-## Benchmark setup
+## Benchmark design
 
 I ran everything on:
 
@@ -69,9 +69,7 @@ The output task was intentionally boring and deterministic: read background text
 
 One important caveat: this is a fastest-practical-path comparison, not a perfect same-weights lab setup. I used the most direct current artifact for each runtime. That means the `E2B` comparison is not perfectly apples-to-apples: official `llama.cpp` GGUF for `E2B` is `Q8_0`, while the MLX and Ollama paths use 4-bit artifacts.
 
-## Benchmark controls
-
-These details kept the comparison about runtime behavior rather than hidden work:
+The remaining controls kept the comparison about runtime behavior rather than hidden work:
 
 - I disabled Gemma's thinking mode anywhere I could, because otherwise you are partly benchmarking extra reasoning tokens instead of raw runtime behavior.
 - I kept the benchmark text-only, which meant running `llama.cpp` without a multimodal projector. That was the cleanest way to measure prompt processing and decode speed instead of image overhead.
@@ -95,7 +93,7 @@ The animation keeps the model/runtime rows fixed while the input grows from `512
 
 This is the distinction the memory table cannot show. Capacity answers whether a model can load. Decode throughput answers how quickly it continues once generation has started. Prefill latency answers whether an `8K` document or agent state feels interactive at all. For daily use, the last quantity makes `26B A4B` a different product from `31B` even though both fit comfortably.
 
-> **Deep insight:** Local inference has three thresholds: load, start, and continue. Weight memory controls the first; prefill controls the second; decode throughput controls the third.
+Local inference has three thresholds: load, start, and continue. Weight memory controls the first; prefill controls the second; decode throughput controls the third.
 
 ### Short-context results
 

--- a/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-muse-glimmer-30b-locally-on-a-64-gb-macbook-pro.md
@@ -17,7 +17,7 @@ summary: >-
 
 `Muse Glimmer 30B` fits comfortably on a `64 GB` M5 Max MacBook Pro and serves through `llama.cpp`. The official `Q4_K_M` GGUF occupies `16.76 GB`. With all layers explicitly placed on Metal, it generated at `27.9 tokens/s`; adding Meta's official `1.63 GB` DFlash drafter raised short-prompt decode to `48.3 tokens/s`.
 
-The first run was much slower—about `10 tokens/s`—because I had left GPU-layer placement on the runtime's automatic setting. The controlled reruns make the practical lesson clearer than the initial number: use full Metal offload, then enable DFlash. That gets close to Meta's reported M5 Max speed on short generation. Long prompts remain the constraint: the `8K` DFlash run needed `16.4 s` to begin reasoning and `17.9 s` to show the answer.
+The first run was much slower, about `10 tokens/s`, because I had left GPU-layer placement on the runtime's automatic setting. The controlled reruns make the practical lesson clearer than the initial number: use full Metal offload, then enable DFlash. That gets close to Meta's reported M5 Max speed on short generation. Long prompts remain the constraint: the `8K` DFlash run needed `16.4 s` to begin reasoning and `17.9 s` to show the answer.
 
 This is a hardware-and-software snapshot from August 13, 2026. Muse Glimmer and its `llama.cpp` support are new enough that runtime releases may change the result materially.
 
@@ -71,7 +71,7 @@ I report two first-token measurements. *First generated token* includes hidden r
 
 The largest correction was explicit placement. `--gpu-layers all` lifted the short decode rate from `9.92` to `27.90 tok/s`, a `2.8×` change before speculation entered the comparison. It also cut the long prompt's first generated token from `32.26 s` to `17.10 s`. A model that fits in unified memory can still run slowly if the engine chooses a conservative CPU/GPU split.
 
-> **Deep insight:** Fit is only the first threshold. Runtime placement decides whether resident weights become an interactive product or a slow systems demo.
+Fit is only the first threshold. Runtime placement decides whether resident weights become an interactive product or a slow systems demo.
 
 DFlash then changed decode rather than fit. With `--spec-type draft-dflash` active, the server accepted `87.9%` of proposed short-suite draft tokens and `79.8%` on the long suite. Short decode rose from `27.90` to `48.31 tok/s`; long decode rose from `26.62` to `35.47 tok/s`. The speedup is smaller at `8K` because prompt processing is unchanged by speculative generation and dominates more of the request.
 

--- a/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
+++ b/src/content/posts/running-qwen-3-5-and-qwen-3-locally-on-a-64-gb-macbook-pro.md
@@ -52,7 +52,7 @@ The two big family-level differences that matter for local use are:
 - [`Qwen 3.5`](https://huggingface.co/Qwen/Qwen3.5-9B) defaults to thinking mode and exposes a `262,144` token default context window, so if you do not explicitly disable thinking you are partly benchmarking chain-of-thought overhead instead of plain inference behavior.
 - [`Qwen 3`](https://huggingface.co/Qwen/Qwen3-14B-GGUF) supports both thinking and non-thinking modes in the same model, and the official GGUF releases make `llama.cpp` comparisons much easier for that family.
 
-## Benchmark setup
+## Benchmark design
 
 I ran everything on:
 
@@ -81,9 +81,7 @@ The task was intentionally boring and deterministic: read repeated background te
 
 I also kept the app and the benchmark harness text-only for this pass. No images, no multimodal prompts, and no hidden reasoning tokens if I could turn them off.
 
-## Benchmark controls
-
-These details kept the benchmark from measuring hidden work:
+The remaining controls kept the benchmark from measuring hidden work:
 
 - I forced `Qwen 3.5` into non-thinking mode anywhere I could. Otherwise the benchmark stops being about raw runtime behavior.
 - I kept the local chat app text-only even though `Qwen 3.5` ships as an image-text model family. I wanted clean text-generation comparisons first.
@@ -111,7 +109,7 @@ The animation holds every measured model/runtime row fixed and changes only the 
 
 The figure separates three decisions that parameter count often collapses. Memory determines whether a model loads. Decode throughput determines continuation speed. Prefill determines whether document-scale prompts feel responsive. On this machine, moving from `4B` to `14B` changes the third quantity most sharply, which is why the quality-versus-latency decision should be made with realistic prompt lengths.
 
-> **Deep insight:** A short-prompt benchmark prices generation. An agent workload also prices the history it must reread before every turn. That second bill can dominate the experience.
+A short-prompt benchmark prices generation. An agent workload also prices the history it must reread before every turn. That second bill can dominate the experience.
 
 ### Short-context results
 

--- a/src/content/posts/thoughts-on-good-research-in-industry.md
+++ b/src/content/posts/thoughts-on-good-research-in-industry.md
@@ -54,6 +54,6 @@ Visibility only helps when the work is legible. A presentation should maximize w
 
 Compute changes the value of good judgment because it determines how quickly a question can meet evidence. Keep the GPUs busy, but make each run interpretable. Velocity without rigor produces noise; rigor without enough throughput leaves important decisions unresolved. A good research system makes the two reinforce each other.
 
-> **Deep insight:** In industry, time-to-evidence is part of rigor. A perfect result that arrives after the decision is not influence; it is an archive.
+In industry, time-to-evidence is part of rigor. A perfect result that arrives after the decision is not influence; it is an archive.
 
 That is what I took from Eugene's guide. None of these practices guarantees a breakthrough. Together they give a good idea enough structure to meet evidence, become legible to collaborators, and influence a real decision. In industry, that system matters more than the romance of the isolated insight.


### PR DESCRIPTION
## Summary
- scrub all 18 Blog posts for structure, cadence, repetition, and house style
- collapse duplicate recaps, references, benchmark sections, and verification sections
- remove em dashes and fold labeled insight callouts into the surrounding argument
- rewrite the memoir job-search section as part of the personal narrative

## Validation
- `git diff --check`
- prose audit against `origin/main` with deliberate restructuring allowed
- `npm run ci` (503 tests, 361-page build, route verification)
- representative desktop and 390 px mobile browser QA with no page overflow or console errors

## Follow-up
A separate PR will regenerate the Blog audio artifacts from the merged prose so the binary release remains independently reviewable.