### PR TITLE
Fix first-click Blog audio playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
+        "@types/jsdom": "^30.0.0",
         "@types/node": "^25.5.0",
         "jsdom": "^29.0.1",
         "vitest": "^4.1.0"
@@ -2620,6 +2621,52 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^8.9.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.10.0.tgz",
+      "integrity": "sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/katex": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
@@ -2693,6 +2740,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
+    "@types/jsdom": "^30.0.0",
     "@types/node": "^25.5.0",
     "jsdom": "^29.0.1",
     "vitest": "^4.1.0"

--- a/src/components/ReadAloud.astro
+++ b/src/components/ReadAloud.astro
@@ -50,74 +50,9 @@ const { src, title } = Astro.props;
   </audio>
 </section>
 
-<script is:inline>
-  (() => {
-    const formatTime = (seconds) => {
-      if (!Number.isFinite(seconds)) return '--:--';
-      const minutes = Math.floor(seconds / 60);
-      const remainingSeconds = Math.floor(seconds % 60).toString().padStart(2, '0');
-      return `${minutes}:${remainingSeconds}`;
-    };
+<script>
+  import { initReadAloud } from '../lib/read-aloud';
 
-    const initReadAloud = () => {
-      document.querySelectorAll('[data-read-aloud]').forEach((root) => {
-        if (root.dataset.readAloudReady === 'true') return;
-        const audio = root.querySelector('[data-read-aloud-audio]');
-        const toggle = root.querySelector('[data-read-aloud-toggle]');
-        const label = root.querySelector('[data-read-aloud-label]');
-        const icon = root.querySelector('[data-read-aloud-icon]');
-        const progress = root.querySelector('[data-read-aloud-progress]');
-        const current = root.querySelector('[data-read-aloud-current]');
-        const duration = root.querySelector('[data-read-aloud-duration]');
-        const speed = root.querySelector('[data-read-aloud-speed]');
-        if (!audio || !toggle || !label || !icon || !progress || !current || !duration || !speed) return;
-
-        root.dataset.readAloudReady = 'true';
-        root.classList.add('read-aloud--enhanced');
-
-        const renderState = () => {
-          const playing = !audio.paused && !audio.ended;
-          icon.textContent = playing ? 'Ⅱ' : '▶';
-          label.textContent = playing ? 'Pause' : audio.ended ? 'Listen again' : 'Listen';
-          toggle.setAttribute('aria-label', playing ? 'Pause audio' : 'Listen to this post');
-          toggle.setAttribute('aria-pressed', String(playing));
-          root.classList.toggle('read-aloud--playing', playing);
-        };
-
-        toggle.addEventListener('click', () => {
-          if (audio.paused || audio.ended) {
-            if (audio.ended) audio.currentTime = 0;
-            void audio.play().catch(() => {
-              label.textContent = 'Press again to play';
-            });
-          } else {
-            audio.pause();
-          }
-        });
-        audio.addEventListener('play', renderState);
-        audio.addEventListener('pause', renderState);
-        audio.addEventListener('ended', renderState);
-        audio.addEventListener('loadedmetadata', () => {
-          duration.textContent = formatTime(audio.duration);
-          progress.max = String(audio.duration);
-          progress.disabled = false;
-        });
-        audio.addEventListener('timeupdate', () => {
-          current.textContent = formatTime(audio.currentTime);
-          progress.value = String(audio.currentTime);
-        });
-        progress.addEventListener('input', () => {
-          audio.currentTime = Number(progress.value);
-        });
-        speed.addEventListener('change', () => {
-          audio.playbackRate = Number(speed.value);
-        });
-        progress.disabled = true;
-        renderState();
-      });
-    };
-
-    initReadAloud();
-    document.addEventListener('astro:page-load', initReadAloud);
-  })();
+  initReadAloud();
+  document.addEventListener('astro:page-load', () => initReadAloud());
 </script>

--- a/src/lib/read-aloud.ts
+++ b/src/lib/read-aloud.ts
@@ -1,0 +1,78 @@
+const formatTime = (seconds: number): string => {
+  if (!Number.isFinite(seconds)) return '--:--';
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.floor(seconds % 60).toString().padStart(2, '0');
+  return `${minutes}:${remainingSeconds}`;
+};
+
+export const initReadAloud = (scope: ParentNode = document): void => {
+  scope.querySelectorAll<HTMLElement>('[data-read-aloud]').forEach((root) => {
+    if (root.dataset.readAloudReady === 'true') return;
+
+    const audio = root.querySelector<HTMLAudioElement>('[data-read-aloud-audio]');
+    const toggle = root.querySelector<HTMLButtonElement>('[data-read-aloud-toggle]');
+    const label = root.querySelector<HTMLElement>('[data-read-aloud-label]');
+    const icon = root.querySelector<HTMLElement>('[data-read-aloud-icon]');
+    const progress = root.querySelector<HTMLInputElement>('[data-read-aloud-progress]');
+    const current = root.querySelector<HTMLElement>('[data-read-aloud-current]');
+    const duration = root.querySelector<HTMLElement>('[data-read-aloud-duration]');
+    const speed = root.querySelector<HTMLSelectElement>('[data-read-aloud-speed]');
+    if (!audio || !toggle || !label || !icon || !progress || !current || !duration || !speed) return;
+
+    root.dataset.readAloudReady = 'true';
+    root.classList.add('read-aloud--enhanced');
+
+    const renderState = () => {
+      const playing = !audio.paused && !audio.ended;
+      icon.textContent = playing ? 'Ⅱ' : '▶';
+      label.textContent = playing ? 'Pause' : audio.ended ? 'Listen again' : 'Listen';
+      toggle.setAttribute('aria-label', playing ? 'Pause audio' : 'Listen to this post');
+      toggle.setAttribute('aria-pressed', String(playing));
+      root.classList.toggle('read-aloud--playing', playing);
+    };
+
+    const renderMetadata = () => {
+      duration.textContent = formatTime(audio.duration);
+      progress.max = String(audio.duration);
+      progress.disabled = false;
+    };
+
+    toggle.addEventListener('click', () => {
+      if (audio.paused || audio.ended) {
+        if (audio.ended) audio.currentTime = 0;
+        // Astro's client router swaps the element into the page without always
+        // selecting its source. load() makes the first click work after an
+        // in-site navigation instead of requiring a full page reload.
+        if (!audio.currentSrc) audio.load();
+        void audio.play().catch(() => {
+          label.textContent = 'Press again to play';
+        });
+      } else {
+        audio.pause();
+      }
+    });
+    audio.addEventListener('play', renderState);
+    audio.addEventListener('pause', renderState);
+    audio.addEventListener('ended', renderState);
+    audio.addEventListener('loadedmetadata', renderMetadata);
+    audio.addEventListener('timeupdate', () => {
+      current.textContent = formatTime(audio.currentTime);
+      progress.value = String(audio.currentTime);
+    });
+    progress.addEventListener('input', () => {
+      audio.currentTime = Number(progress.value);
+    });
+    speed.addEventListener('change', () => {
+      audio.playbackRate = Number(speed.value);
+    });
+
+    progress.disabled = true;
+    renderState();
+    if (audio.readyState >= audio.HAVE_METADATA) renderMetadata();
+
+    // A swapped-in media element can have a src attribute while currentSrc is
+    // still empty. Start metadata loading as part of initialization as well as
+    // guarding the user-initiated play path above.
+    if (!audio.currentSrc) audio.load();
+  });
+};

--- a/tests/read-aloud.test.ts
+++ b/tests/read-aloud.test.ts
@@ -1,0 +1,49 @@
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { initReadAloud } from '../src/lib/read-aloud';
+
+const playerMarkup = `
+  <section data-read-aloud>
+    <button data-read-aloud-toggle aria-pressed="false">
+      <span data-read-aloud-icon></span>
+      <span data-read-aloud-label>Listen</span>
+    </button>
+    <select data-read-aloud-speed><option value="1">1x</option></select>
+    <input data-read-aloud-progress type="range" />
+    <span data-read-aloud-current></span>
+    <span data-read-aloud-duration></span>
+    <audio data-read-aloud-audio src="/post.mp3"></audio>
+  </section>
+`;
+
+describe('initReadAloud', () => {
+  it('loads a media source inserted by client-side navigation', () => {
+    const dom = new JSDOM(playerMarkup);
+    const audio = dom.window.document.querySelector('audio')!;
+    const load = vi.fn();
+    audio.load = load;
+
+    initReadAloud(dom.window.document);
+
+    expect(audio.currentSrc).toBe('');
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it('retries source selection inside the first play gesture', () => {
+    const dom = new JSDOM(playerMarkup);
+    const audio = dom.window.document.querySelector('audio')!;
+    const toggle = dom.window.document.querySelector<HTMLButtonElement>('[data-read-aloud-toggle]')!;
+    const load = vi.fn();
+    const play = vi.fn().mockResolvedValue(undefined);
+    audio.load = load;
+    audio.play = play;
+
+    initReadAloud(dom.window.document);
+    load.mockClear();
+    toggle.click();
+
+    expect(load).toHaveBeenCalledOnce();
+    expect(play).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What changed
- explicitly load Blog audio sources after Astro client-side page swaps
- keep the first play gesture resilient when the browser has not selected the source yet
- move the player behavior into a typed, testable module and add regression coverage

## Why
Navigating Home → Blog → post left the swapped-in audio element with an empty current source. The first play attempt failed and only a full reload initialized the MP3.

## Tested
- npm run ci
- browser QA through Home → Blog → post: first click starts playback without reload
- no browser console errors