### PR TITLE
Make trivia Next button consistent and visible

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2407,6 +2407,8 @@ h3,
 }
 
 .trivia-deck {
+  --trivia-primary-bg: #2b5fe7;
+  --trivia-primary-text: #fff;
   width: 100%;
   min-width: 0;
   margin: 2rem 0 2.5rem;
@@ -2416,6 +2418,11 @@ h3,
   background: var(--panel-bg);
   box-shadow: var(--button-shadow);
   box-sizing: border-box;
+}
+
+:root[data-theme="dark"] .trivia-deck {
+  --trivia-primary-bg: var(--link-color);
+  --trivia-primary-text: #050505;
 }
 
 .trivia-deck:focus-visible {
@@ -2675,15 +2682,24 @@ h3,
   margin-top: 0.85rem;
 }
 
-.trivia-deck__rating {
-  display: flex;
+.trivia-deck .trivia-deck__primary {
+  display: inline-flex;
+  min-width: 8.5rem;
+  align-items: center;
+  justify-content: center;
   gap: 0.55rem;
+  border-color: var(--trivia-primary-bg);
+  background: var(--trivia-primary-bg);
+  color: var(--trivia-primary-text);
+  box-shadow: 0 8px 20px color-mix(in srgb, var(--link-color) 28%, transparent);
+  font-weight: 700;
 }
 
-.trivia-deck .trivia-deck__primary {
-  border-color: var(--link-color);
-  background: var(--link-color);
-  color: var(--page-bg);
+.trivia-deck .trivia-deck__primary:hover,
+.trivia-deck .trivia-deck__primary:focus-visible {
+  border-color: var(--trivia-primary-bg);
+  background: var(--trivia-primary-bg);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--link-color) 38%, transparent);
 }
 
 .trivia-deck__footer {
@@ -3916,8 +3932,7 @@ body.home-page small {
   }
 
   .trivia-deck__navigation > button,
-  .trivia-deck__rating,
-  .trivia-deck__rating button {
+  .trivia-deck__navigation .trivia-deck__primary {
     flex: 1 1 0;
   }
 

--- a/src/components/TriviaDeck.tsx
+++ b/src/components/TriviaDeck.tsx
@@ -321,17 +321,15 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
         <button type="button" onClick={() => move(-1)} aria-label="Previous trivia card">
           Previous
         </button>
-        {revealed ? (
-          <div className="trivia-deck__rating">
-            <button type="button" className="trivia-deck__primary" onClick={() => move(1)}>
-              Next card
-            </button>
-          </div>
-        ) : (
-          <button type="button" className="trivia-deck__primary" onClick={() => move(1)}>
-            Next
-          </button>
-        )}
+        <button
+          type="button"
+          className="trivia-deck__primary"
+          onClick={() => move(1)}
+          aria-label="Next trivia card"
+        >
+          <span>Next card</span>
+          <span aria-hidden="true">→</span>
+        </button>
       </div>
 
       <div className="trivia-deck__footer">

--- a/tests/trivia-deck.test.tsx
+++ b/tests/trivia-deck.test.tsx
@@ -57,7 +57,9 @@ describe('TriviaDeck', () => {
 
   function click(label: string) {
     const button = Array.from(container.querySelectorAll('button'))
-      .find((candidate) => candidate.textContent === label);
+      .find((candidate) => (
+        candidate.textContent === label || candidate.getAttribute('aria-label') === label
+      ));
     expect(button).not.toBeUndefined();
     act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
   }
@@ -107,7 +109,7 @@ describe('TriviaDeck', () => {
 
   it('shows a production snippet on the front of its own card', async () => {
     await renderDeck();
-    click('Next');
+    click('Next trivia card');
 
     expect(container.querySelector('[aria-label="Production code scenario"]')?.textContent)
       .toContain('service.run()');
@@ -144,7 +146,7 @@ describe('TriviaDeck', () => {
 
   it('filters by topic and resets the visible position', async () => {
     await renderDeck();
-    click('Next');
+    click('Next trivia card');
 
     const select = container.querySelector('select');
     await act(async () => {


### PR DESCRIPTION
## Summary
- use one persistent Next card action before and after grading
- strengthen its size, contrast, shadow, and directional cue in both themes
- keep Previous and Next equal-width on mobile without overflow

## Testing
- npm run ci
- browser-tested desktop and 390px mobile layouts
- verified Next advances after grading
- verified contrast: 5.39:1 light, 16.0:1 dark