### PR TITLE
Deepen trivia explanations and unify controls

### DIFF
--- a/public/css/override.css
+++ b/public/css/override.css
@@ -2488,7 +2488,7 @@ h3,
   text-transform: none;
 }
 
-.trivia-deck__quiet-action {
+.trivia-deck__toolbar-action {
   align-self: end;
 }
 
@@ -2578,8 +2578,8 @@ h3,
 
 .trivia-card__reveal {
   align-self: flex-start;
+  justify-self: start;
   margin-top: 0.45rem;
-  color: var(--link-color) !important;
 }
 
 .trivia-card__comparison {
@@ -2639,10 +2639,24 @@ h3,
   line-height: 1.5;
 }
 
+.trivia-card__scenario {
+  margin: 0 0 1.2rem;
+}
+
+.trivia-card__scenario > p {
+  margin: 0 0 0.45rem;
+  color: var(--text-secondary-color);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 .trivia-card__prompt-code {
   width: 100%;
   max-width: 100%;
-  margin: 0 0 1.2rem;
+  margin: 0;
   padding: 0.85rem;
   overflow-x: auto;
   border: 1px solid var(--button-border);
@@ -2663,7 +2677,8 @@ h3,
   border-top: 1px solid var(--button-border);
 }
 
-.trivia-card__answer .trivia-card__explanation h4 {
+.trivia-card__answer .trivia-card__explanation h4,
+.trivia-card__answer .trivia-card__detail h4 {
   margin: 0 0 0.45rem;
   color: var(--text-secondary-color);
   font-family: var(--font-mono);
@@ -2674,6 +2689,12 @@ h3,
 
 .trivia-card__answer .trivia-card__detail {
   margin-top: 0.9rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--button-border);
+}
+
+.trivia-card__answer .trivia-card__detail p {
+  margin: 0;
   color: var(--text-secondary-color);
   font-size: 0.92rem;
 }
@@ -2682,9 +2703,10 @@ h3,
   margin-top: 0.85rem;
 }
 
-.trivia-deck .trivia-deck__primary {
+.trivia-deck .trivia-deck__action {
   display: inline-flex;
   min-width: 8.5rem;
+  min-height: 3rem;
   align-items: center;
   justify-content: center;
   gap: 0.55rem;
@@ -2695,8 +2717,8 @@ h3,
   font-weight: 700;
 }
 
-.trivia-deck .trivia-deck__primary:hover,
-.trivia-deck .trivia-deck__primary:focus-visible {
+.trivia-deck .trivia-deck__action:hover,
+.trivia-deck .trivia-deck__action:focus-visible {
   border-color: var(--trivia-primary-bg);
   background: var(--trivia-primary-bg);
   box-shadow: 0 10px 24px color-mix(in srgb, var(--link-color) 38%, transparent);
@@ -2707,15 +2729,6 @@ h3,
   color: var(--text-secondary-color);
   font-family: var(--font-mono);
   font-size: 0.7rem;
-}
-
-.trivia-deck__footer button {
-  min-height: 2rem;
-  padding: 0.25rem 0;
-  border: 0;
-  background: transparent;
-  color: var(--text-secondary-color);
-  font-size: inherit;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -3916,7 +3929,7 @@ body.home-page small {
     flex-direction: column;
   }
 
-  .trivia-deck__quiet-action,
+  .trivia-deck__toolbar-action,
   .trivia-deck__toolbar select {
     width: 100%;
     max-width: none;
@@ -3931,8 +3944,7 @@ body.home-page small {
     min-height: 8rem;
   }
 
-  .trivia-deck__navigation > button,
-  .trivia-deck__navigation .trivia-deck__primary {
+  .trivia-deck__navigation > button {
     flex: 1 1 0;
   }
 

--- a/src/components/TriviaDeck.tsx
+++ b/src/components/TriviaDeck.tsx
@@ -216,7 +216,11 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
             {topics.map((item) => <option key={item}>{item}</option>)}
           </select>
         </label>
-        <button type="button" className="trivia-deck__quiet-action" onClick={shuffleCards}>
+        <button
+          type="button"
+          className="trivia-deck__action trivia-deck__toolbar-action"
+          onClick={shuffleCards}
+        >
           Shuffle
         </button>
       </div>
@@ -239,9 +243,12 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
       <article className={`trivia-card${revealed ? ' trivia-card--revealed' : ''}`} aria-live="polite">
         <p className="trivia-card__topic">{card.topic}</p>
         {card.code && (
-          <pre className="trivia-card__prompt-code" aria-label="Production code scenario">
-            <code>{card.code}</code>
-          </pre>
+          <section className="trivia-card__scenario" aria-label="Code scenario">
+            <p>Code scenario</p>
+            <pre className="trivia-card__prompt-code">
+              <code>{card.code}</code>
+            </pre>
+          </section>
         )}
         <p className="trivia-card__question" role="heading" aria-level={2}>
           {inlineCode(card.question)}
@@ -267,7 +274,7 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
             />
             <button
               type="button"
-              className="trivia-card__reveal"
+              className="trivia-deck__action trivia-card__reveal"
               onClick={gradeAnswer}
               aria-expanded="false"
             >
@@ -307,23 +314,33 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
               <p>{inlineCode(card.answer)}</p>
               {card.explanation && (
                 <div className="trivia-card__explanation">
-                  <h4>Why it matters</h4>
+                  <h4>Why it works</h4>
                   <p>{inlineCode(card.explanation)}</p>
                 </div>
               )}
-              {card.detail && <p className="trivia-card__detail">{inlineCode(card.detail)}</p>}
+              {card.detail && (
+                <div className="trivia-card__detail">
+                  <h4>Mental model</h4>
+                  <p>{inlineCode(card.detail)}</p>
+                </div>
+              )}
             </section>
           </div>
         )}
       </article>
 
       <div className="trivia-deck__navigation">
-        <button type="button" onClick={() => move(-1)} aria-label="Previous trivia card">
+        <button
+          type="button"
+          className="trivia-deck__action"
+          onClick={() => move(-1)}
+          aria-label="Previous trivia card"
+        >
           Previous
         </button>
         <button
           type="button"
-          className="trivia-deck__primary"
+          className="trivia-deck__action"
           onClick={() => move(1)}
           aria-label="Next trivia card"
         >
@@ -334,7 +351,9 @@ export default function TriviaDeck({ deck }: TriviaDeckProps) {
 
       <div className="trivia-deck__footer">
         <span>Enter grades · arrows move</span>
-        <button type="button" onClick={resetProgress}>Reset progress</button>
+        <button type="button" className="trivia-deck__action" onClick={resetProgress}>
+          Reset progress
+        </button>
       </div>
     </section>
   );

--- a/src/lib/python-practical-trivia.ts
+++ b/src/lib/python-practical-trivia.ts
@@ -1,4 +1,5 @@
 import type { TriviaDeckData } from './trivia-decks';
+import { pythonTriviaDetails } from './python-trivia-details';
 
 /**
  * Practical Python recall for ML engineering work.
@@ -6,14 +7,15 @@ import type { TriviaDeckData } from './trivia-decks';
  * Each card keeps the scenario and concept together: `answer` is the short
  * phrase the grader checks, while `explanation` supplies the production rule.
  */
-export const practicalPythonTriviaDeck = {
+const practicalPythonTriviaSourceDeck = {
   id: 'python-interview-trivia-v3',
   title: 'Practical Python for ML engineering',
   cards: [
     {
       id: 'python-aliasing-append',
       topic: 'References & values',
-      question: 'What is `b` after `a = []; b = a; a.append("sample")`?',
+      code: 'a: list[str] = []\nb = a\na.append("sample")',
+      question: 'What value does `b` contain?',
       answer: '`["sample"]`',
       acceptedAnswers: ['[sample]'],
       explanation: 'Assignment aliases the same list instead of copying it, so mutation is visible through both names.',
@@ -30,7 +32,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-identity-vs-equality',
       topic: 'References & values',
-      question: 'Which operators belong in `cached ___ None` and `prediction ___ target`?',
+      code: 'cached ___ None\nprediction ___ target',
+      question: 'Which operator belongs in each blank?',
       answer: '`is` / `==`',
       acceptedAnswers: ['is and ==', 'is, =='],
       explanation: 'Use identity for `None` and sentinels, and equality for values.',
@@ -38,6 +41,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-missing-sentinel',
       topic: 'References & values',
+      code: 'MISSING = object()\n\ndef load(value: object = MISSING) -> object:\n    ...',
       question: 'What should represent “not supplied” when `None` is a valid value?',
       answer: 'Sentinel',
       acceptedAnswers: ['MISSING', 'object sentinel'],
@@ -55,7 +59,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-repeated-inner-list',
       topic: 'References & values',
-      question: 'What is `rows` after `rows = [[]] * 3; rows[0].append(1)`?',
+      code: 'rows: list[list[int]] = [[]] * 3\nrows[0].append(1)',
+      question: 'What value does `rows` contain?',
       answer: '`[[1], [1], [1]]`',
       acceptedAnswers: ['[[1],[1],[1]]'],
       explanation: 'List repetition copied one reference three times, so every row names the same inner list.',
@@ -72,13 +77,15 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-tuple-shallow-immutability',
       topic: 'References & values',
-      question: 'Does `cfg = ({"lr": 1e-3},); cfg[0]["lr"] = 1e-4` succeed?',
+      code: 'cfg = ({"lr": 1e-3},)\ncfg[0]["lr"] = 1e-4',
+      question: 'Does the assignment succeed?',
       answer: 'Yes',
       explanation: 'A tuple fixes its references but does not freeze the mutable objects stored in its slots.',
     },
     {
       id: 'python-falsy-valid-value',
       topic: 'References & values',
+      code: 'lr = 1e-3 if supplied_lr is None else supplied_lr',
       question: 'How should `lr` default when `0.0` is valid and `None` means missing?',
       answer: 'Explicit `None` check',
       acceptedAnswers: ['if lr is None', 'is None'],
@@ -87,14 +94,16 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-nan-equality',
       topic: 'References & values',
-      question: 'What does `x == x` return after `x = float("nan")`?',
+      code: 'x = float("nan")\nresult = x == x',
+      question: 'What value does `result` contain?',
       answer: '`False`',
       explanation: 'NaN is not equal to itself; detect it with `math.isnan(x)`.',
     },
     {
       id: 'python-float-comparison',
       topic: 'References & values',
-      question: 'How should code compare `0.1 + 0.2` with `0.3`?',
+      code: 'actual = 0.1 + 0.2\nexpected = 0.3',
+      question: 'How should code compare `actual` with `expected`?',
       answer: '`math.isclose()`',
       acceptedAnswers: ['math.isclose', 'isclose'],
       explanation: 'Binary floating-point arithmetic is approximate, so equality checks need explicit relative and absolute tolerances.',
@@ -103,7 +112,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-list-vs-tuple',
       topic: 'Collections',
-      question: 'Which types fit a mutable transform pipeline and a fixed `(scene_id, frame_id)` key?',
+      code: 'pipeline = [decode, resize, normalize]\ncache_key = (scene_id, frame_id)',
+      question: 'Which collection contract fits each value?',
       answer: 'List / tuple',
       acceptedAnswers: ['list and tuple', 'list, tuple'],
       explanation: 'Use a list for a mutable sequence and a tuple for a fixed record or hashable composite key.',
@@ -127,7 +137,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-split-leakage-intersection',
       topic: 'Collections',
-      question: 'What does `train_ids & val_ids` reveal when both values are sets?',
+      code: 'overlap = train_ids & val_ids',
+      question: 'What does a nonempty `overlap` reveal?',
       answer: 'Split leakage',
       acceptedAnswers: ['set intersection', 'overlapping ids', 'intersection'],
       explanation: 'Set intersection returns the IDs present in both dataset splits.',
@@ -142,7 +153,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-sort-vs-sorted',
       topic: 'Collections',
-      question: 'How do `xs.sort()` and `sorted(xs)` differ?',
+      code: 'in_place_result = xs.sort()\nnew_list = sorted(xs)',
+      question: 'How do the two operations differ?',
       answer: 'In-place / new list',
       acceptedAnswers: ['mutates / copies', 'in place and copy'],
       explanation: '`sort()` mutates and returns `None`; `sorted()` returns a stable new list.',
@@ -150,6 +162,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-zip-strict',
       topic: 'Collections',
+      code: 'for label, prediction in zip(labels, predictions, strict=True):\n    evaluate(label, prediction)',
       question: 'How should labels and predictions be zipped when their lengths must match?',
       answer: '`zip(..., strict=True)`',
       acceptedAnswers: ['strict zip', 'zip strict true'],
@@ -200,7 +213,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-eager-vs-lazy-comprehension',
       topic: 'Functions & iteration',
-      question: 'How do `[decode(p) for p in paths]` and `(decode(p) for p in paths)` evaluate?',
+      code: 'eager = [decode(path) for path in paths]\nlazy = (decode(path) for path in paths)',
+      question: 'How do `eager` and `lazy` evaluate?',
       answer: 'Eager / lazy',
       acceptedAnswers: ['list eager generator lazy'],
       explanation: 'The list computes and stores every result immediately; the generator computes during iteration.',
@@ -208,7 +222,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-yield-generator-function',
       topic: 'Functions & iteration',
-      question: 'What does calling a function that contains `yield batch` return?',
+      code: 'def batches(loader: Loader) -> Iterator[Batch]:\n    for batch in loader:\n        yield batch\n\nresult = batches(loader)',
+      question: 'What kind of object is `result`?',
       answer: 'Generator iterator',
       acceptedAnswers: ['generator'],
       explanation: 'Calling a generator function returns an iterator whose local frame resumes after each `yield`.',
@@ -216,7 +231,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-first-match',
       topic: 'Functions & iteration',
-      question: 'What does `next((s for s in samples if s.id == target), None)` return?',
+      code: 'match = next(\n    (sample for sample in samples if sample.id == target),\n    None,\n)',
+      question: 'What value does `match` receive?',
       answer: 'First match or `None`',
       acceptedAnswers: ['match or none', 'first match'],
       explanation: 'The generator stops at the first match and avoids constructing a temporary list.',
@@ -233,7 +249,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-closure-late-binding',
       topic: 'Functions & iteration',
-      question: 'What does `[f() for f in [lambda: i for i in range(3)]]` return?',
+      code: 'functions = [lambda: i for i in range(3)]\nresult = [function() for function in functions]',
+      question: 'What value does `result` contain?',
       answer: '`[2, 2, 2]`',
       acceptedAnswers: ['[2,2,2]'],
       explanation: 'Closures look up `i` when called; capture each loop value with `lambda i=i: i`.',
@@ -241,7 +258,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-partial-callable',
       topic: 'Functions & iteration',
-      question: 'What does `partial(resize, size=224)` create?',
+      code: 'resize_224 = partial(resize, size=224)',
+      question: 'What kind of object is `resize_224`?',
       answer: 'Pre-bound callable',
       acceptedAnswers: ['partial function', 'functools.partial', 'callable'],
       explanation: '`functools.partial` creates a callable with selected arguments already bound.',
@@ -257,7 +275,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-lru-cache-contract',
       topic: 'Functions & iteration',
-      question: 'When is `@lru_cache` appropriate for `load_schema(path)`?',
+      code: '@lru_cache(maxsize=128)\ndef load_schema(path: Path) -> Schema:\n    ...',
+      question: 'When is this cache safe and useful?',
       answer: 'Pure, hashable calls',
       acceptedAnswers: ['pure function', 'hashable arguments'],
       explanation: 'Memoization assumes equivalent hashable arguments produce reusable results, and the cache retains arguments and return values.',
@@ -284,7 +303,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-bound-method-self',
       topic: 'Classes & interfaces',
-      question: 'What does accessing `obj.run` bind automatically?',
+      code: 'bound_run = obj.run',
+      question: 'What argument does `bound_run` carry automatically?',
       answer: '`self`',
       acceptedAnswers: ['instance'],
       explanation: 'Instance attribute access turns the function on the class into a bound method carrying `obj` as `self`.',
@@ -292,7 +312,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-classmethod-constructor',
       topic: 'Classes & interfaces',
-      question: 'What pattern does `@classmethod def from_dict(cls, data) -> Self` implement?',
+      code: '@classmethod\ndef from_dict(cls, data: Mapping[str, object]) -> Self:\n    return cls(**data)',
+      question: 'What construction pattern does this method implement?',
       answer: 'Alternative constructor',
       acceptedAnswers: ['factory method'],
       explanation: 'Constructing through `cls` preserves the correct runtime class for subclasses.',
@@ -308,7 +329,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-property-boundary',
       topic: 'Classes & interfaces',
-      question: 'When is `@property def num_samples(self)` a good interface?',
+      code: '@property\ndef num_samples(self) -> int:\n    return len(self.samples)',
+      question: 'When is this property a good interface?',
       answer: 'Cheap derived state',
       acceptedAnswers: ['computed attribute', 'cheap computation'],
       explanation: 'Properties fit cheap, unsurprising derived values; hidden expensive I/O should remain an explicit method.',
@@ -316,7 +338,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-callable-transform',
       topic: 'Classes & interfaces',
-      question: 'Which method lets a configured transform object support `transform(sample)`?',
+      code: 'output = transform(sample)',
+      question: 'Which method lets a configured object support this call?',
       answer: '`__call__`',
       explanation: '`__call__` makes an instance callable while keeping its configuration and state on the object.',
     },
@@ -331,7 +354,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-protocol-interface',
       topic: 'Classes & interfaces',
-      question: 'Which typing construct accepts any object with `transform(sample)` without inheritance?',
+      code: 'class Transform(Protocol):\n    def __call__(self, sample: Sample) -> Sample:\n        ...',
+      question: 'Which typing construct accepts matching objects without inheritance?',
       answer: '`Protocol`',
       acceptedAnswers: ['typing.Protocol', 'structural protocol'],
       explanation: 'A protocol defines a structural static interface based on available members.',
@@ -339,7 +363,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-super-mro',
       topic: 'Classes & interfaces',
-      question: 'Where does `super().run()` dispatch?',
+      code: 'class TimedStage(Stage):\n    def run(self) -> Result:\n        start_timer()\n        return super().run()',
+      question: 'Where does the final call dispatch?',
       answer: 'Next in the MRO',
       acceptedAnswers: ['method resolution order', 'next MRO implementation'],
       explanation: '`super()` continues after the current class in the runtime method resolution order, not necessarily at the textual parent.',
@@ -348,7 +373,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-annotations-runtime',
       topic: 'Typing',
-      question: 'Does `def train(epochs: int): ...; train("10")` fail because of the annotation?',
+      code: 'def train(epochs: int) -> None:\n    ...\n\ntrain("10")',
+      question: 'Does Python reject the call because of the annotation?',
       answer: 'No',
       explanation: 'Python stores annotations but does not enforce them at runtime unless another tool participates.',
     },
@@ -363,7 +389,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-nullable-not-optional',
       topic: 'Typing',
-      question: 'Does `cache_dir: Path | None` make the function argument optional?',
+      code: 'def load(cache_dir: Path | None) -> Dataset:\n    ...',
+      question: 'Does the signature let the caller omit `cache_dir`?',
       answer: 'No',
       explanation: 'The annotation permits `None`; the argument becomes optional to callers only when the signature also supplies a default.',
     },
@@ -378,7 +405,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-iterable-vs-iterator-type',
       topic: 'Typing',
-      question: 'What extra contract does `Iterator[Sample]` add beyond `Iterable[Sample]`?',
+      code: 'source: Iterable[Sample]\ncursor: Iterator[Sample]',
+      question: 'What extra contract does `cursor` add beyond `source`?',
       answer: '`next()` and consumption',
       acceptedAnswers: ['next', 'stateful cursor'],
       explanation: 'An iterator is its own advancing traversal cursor, while an iterable only needs to produce an iterator.',
@@ -394,7 +422,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-callable-signature',
       topic: 'Typing',
-      question: 'What does `Callable[[Sample], Sample]` require?',
+      code: 'transform: Callable[[Sample], Sample]',
+      question: 'What input-output contract does `transform` have?',
       answer: 'Sample-to-Sample callable',
       acceptedAnswers: ['callable from Sample to Sample', 'function signature'],
       explanation: 'The value must be callable with one `Sample` and statically return a `Sample`.',
@@ -409,7 +438,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-literal-optimizer',
       topic: 'Typing',
-      question: 'Which type restricts `optimizer` to the exact strings `"adam"` and `"sgd"`?',
+      code: 'optimizer: Literal["adam", "sgd"]',
+      question: 'Which type restricts `optimizer` to these exact strings?',
       answer: '`Literal["adam", "sgd"]`',
       acceptedAnswers: ['Literal', 'typing.Literal'],
       explanation: '`Literal` lets a static checker reject other string values.',
@@ -417,7 +447,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-annotated-field',
       topic: 'Typing',
-      question: 'What does `Annotated[int, Field(gt=0)]` communicate?',
+      code: 'batch_size: Annotated[int, Field(gt=0)]',
+      question: 'What does this annotation communicate?',
       answer: '`int` plus metadata',
       acceptedAnswers: ['Annotated metadata', 'int with validation metadata'],
       explanation: 'Static type checkers see `int`, while Pydantic consumes the attached runtime constraint.',
@@ -435,6 +466,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-dataclass-generated-methods',
       topic: 'Dataclasses',
+      code: '@dataclass\nclass RunConfig:\n    epochs: int\n    lr: float',
       question: 'What does plain `@dataclass` normally generate?',
       answer: '`__init__`, `__repr__`, `__eq__`',
       acceptedAnswers: ['init repr eq'],
@@ -443,6 +475,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-dataclass-mutable-default',
       topic: 'Dataclasses',
+      code: '@dataclass\nclass Sample:\n    tags: list[str] = field(default_factory=list)',
       question: 'How should a dataclass declare `tags` with a fresh empty list per instance?',
       answer: '`field(default_factory=list)`',
       acceptedAnswers: ['default_factory=list', 'default factory'],
@@ -451,6 +484,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-dataclass-post-init',
       topic: 'Dataclasses',
+      code: 'def __post_init__(self) -> None:\n    if self.warmup_steps >= self.total_steps:\n        raise ValueError("warmup must end before training")',
       question: 'Where should a dataclass enforce `warmup_steps < total_steps`?',
       answer: '`__post_init__`',
       acceptedAnswers: ['post init'],
@@ -459,7 +493,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-dataclass-classvar',
       topic: 'Dataclasses',
-      question: 'What does `VERSION: ClassVar[str] = "v2"` declare in a dataclass?',
+      code: 'VERSION: ClassVar[str] = "v2"',
+      question: 'What kind of dataclass attribute is `VERSION`?',
       answer: 'Class variable',
       acceptedAnswers: ['ClassVar'],
       explanation: '`ClassVar` excludes the name from dataclass fields and the generated initializer.',
@@ -467,14 +502,16 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-dataclass-frozen-shallow',
       topic: 'Dataclasses',
-      question: 'Can a list field inside `@dataclass(frozen=True)` still mutate?',
+      code: '@dataclass(frozen=True)\nclass Config:\n    tags: list[str]',
+      question: 'Can the `tags` list still mutate?',
       answer: 'Yes',
       explanation: 'Frozen dataclasses block normal field rebinding but do not recursively freeze referenced objects.',
     },
     {
       id: 'python-dataclass-kw-only',
       topic: 'Dataclasses',
-      question: 'What does `@dataclass(kw_only=True)` require at construction?',
+      code: '@dataclass(kw_only=True)\nclass RunConfig:\n    epochs: int\n    lr: float',
+      question: 'How must callers provide the generated initializer arguments?',
       answer: 'Named fields',
       acceptedAnswers: ['keyword arguments', 'keyword-only fields'],
       explanation: 'Every generated initializer parameter must be supplied by keyword.',
@@ -482,7 +519,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-dataclass-slots',
       topic: 'Dataclasses',
-      question: 'What is the usual effect of `@dataclass(slots=True)`?',
+      code: '@dataclass(slots=True)\nclass Point:\n    x: float\n    y: float',
+      question: 'What is the usual effect of enabling `slots`?',
       answer: 'Generated slots',
       acceptedAnswers: ['__slots__', 'lower instance overhead'],
       explanation: 'The decorator generates slots, which usually reduce per-instance overhead and prevent undeclared attributes.',
@@ -490,6 +528,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-dataclass-replace',
       topic: 'Dataclasses',
+      code: 'updated = replace(config, lr=1e-4)',
       question: 'How should code create a modified configuration without mutating the dataclass instance?',
       answer: '`dataclasses.replace()`',
       acceptedAnswers: ['replace', 'dataclasses.replace'],
@@ -498,7 +537,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-dataclass-asdict',
       topic: 'Dataclasses',
-      question: 'Why can `asdict(state)` be risky when fields hold large runtime objects?',
+      code: 'payload = asdict(training_state)',
+      question: 'Why can this conversion be risky when fields hold large runtime objects?',
       answer: 'Recursive deep copy',
       acceptedAnswers: ['deep copy', 'recursive conversion'],
       explanation: '`asdict` recurses through nested containers and deep-copies other objects; serialize selected metadata instead.',
@@ -515,7 +555,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-dataclass',
       topic: 'Pydantic v2',
-      question: 'What does `@pydantic.dataclasses.dataclass` add to dataclass ergonomics?',
+      code: '@pydantic.dataclasses.dataclass\nclass RunConfig:\n    epochs: int',
+      question: 'What does the Pydantic decorator add?',
       answer: 'Runtime validation',
       acceptedAnswers: ['validated dataclass', 'Pydantic validation'],
       explanation: 'Pydantic validates construction; use `TypeAdapter` when model-style validation, dump, or schema APIs are needed.',
@@ -523,7 +564,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-default-coercion',
       topic: 'Pydantic v2',
-      question: 'What is `RunConfig(epochs="10").epochs` under default Pydantic settings?',
+      code: 'config = RunConfig(epochs="10")\nresult = config.epochs',
+      question: 'What value and runtime type does `result` have under default settings?',
       answer: '`10` as an `int`',
       acceptedAnswers: ['10', 'integer 10', 'int 10'],
       explanation: 'Pydantic uses coercive validation by default and converts compatible strings to integers.',
@@ -531,6 +573,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-strict-mode',
       topic: 'Pydantic v2',
+      code: 'class RunConfig(BaseModel):\n    model_config = ConfigDict(strict=True)\n    epochs: int',
       question: 'How should a model reject the string `"10"` for an integer field?',
       answer: 'Strict mode',
       acceptedAnswers: ['strict=True', 'ConfigDict(strict=True)'],
@@ -539,6 +582,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-extra-forbid',
       topic: 'Pydantic v2',
+      code: 'class RunConfig(BaseModel):\n    model_config = ConfigDict(extra="forbid")\n    batch_size: int',
       question: 'Which configuration catches a misspelled key such as `batch_szie`?',
       answer: '`ConfigDict(extra="forbid")`',
       acceptedAnswers: ['extra forbid', 'extra="forbid"'],
@@ -547,7 +591,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-positive-field',
       topic: 'Pydantic v2',
-      question: 'How should a Pydantic field require `batch_size > 0`?',
+      code: 'batch_size: int = Field(gt=0)',
+      question: 'How does this field require a positive value?',
       answer: '`Field(gt=0)`',
       acceptedAnswers: ['gt=0', 'Field greater than zero'],
       explanation: 'A declarative field constraint produces validation and schema metadata from the same rule.',
@@ -555,6 +600,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-default-factory',
       topic: 'Pydantic v2',
+      code: 'tags: list[str] = Field(default_factory=list)',
       question: 'How should a Pydantic model give every instance a fresh `tags` list?',
       answer: '`Field(default_factory=list)`',
       acceptedAnswers: ['default_factory=list', 'default factory'],
@@ -563,6 +609,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-field-validator',
       topic: 'Pydantic v2',
+      code: '@field_validator("model_name")\n@classmethod\ndef normalize_name(cls, value: str) -> str:\n    return value.strip().lower()',
       question: 'Which validator should normalize one field such as `model_name`?',
       answer: '`@field_validator`',
       acceptedAnswers: ['field_validator', 'field validator'],
@@ -571,6 +618,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-model-validator',
       topic: 'Pydantic v2',
+      code: '@model_validator(mode="after")\ndef validate_schedule(self) -> Self:\n    if self.warmup_steps >= self.total_steps:\n        raise ValueError("invalid schedule")\n    return self',
       question: 'Which validator should enforce `warmup_steps < total_steps`?',
       answer: '`@model_validator`',
       acceptedAnswers: ['model_validator', 'model validator'],
@@ -579,7 +627,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-assignment-validation',
       topic: 'Pydantic v2',
-      question: 'Which configuration revalidates `cfg.batch_size = "bad"` after construction?',
+      code: 'class RunConfig(BaseModel):\n    model_config = ConfigDict(validate_assignment=True)\n    batch_size: int\n\nconfig.batch_size = "bad"',
+      question: 'Which configuration revalidates the final assignment?',
       answer: '`validate_assignment=True`',
       acceptedAnswers: ['validate assignment', 'ConfigDict(validate_assignment=True)'],
       explanation: 'Pydantic does not revalidate ordinary field assignment unless assignment validation is enabled.',
@@ -587,6 +636,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-io-api',
       topic: 'Pydantic v2',
+      code: 'config = RunConfig.model_validate(payload)\nnormalized = config.model_dump()',
       question: 'Which Pydantic v2 API pair validates Python input and returns Python output?',
       answer: '`model_validate` / `model_dump`',
       acceptedAnswers: ['model_validate and model_dump', 'validate / dump'],
@@ -595,7 +645,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-type-adapter',
       topic: 'Pydantic v2',
-      question: 'How should code validate `list[Sample]` without a wrapper model?',
+      code: 'samples_adapter = TypeAdapter(list[Sample])\nsamples = samples_adapter.validate_python(payload)',
+      question: 'Which object validates the list without a wrapper model?',
       answer: '`TypeAdapter(list[Sample])`',
       acceptedAnswers: ['TypeAdapter', 'type adapter'],
       explanation: 'A reusable `TypeAdapter` validates, serializes, and produces schemas for arbitrary annotated types.',
@@ -603,6 +654,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-private-attr',
       topic: 'Pydantic v2',
+      code: '_cache: dict[str, Tensor] = PrivateAttr(default_factory=dict)',
       question: 'How should a model store a runtime-only cache or database client?',
       answer: '`PrivateAttr`',
       acceptedAnswers: ['private attribute'],
@@ -611,7 +663,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-arbitrary-tensor',
       topic: 'Pydantic v2',
-      question: 'What does `arbitrary_types_allowed=True` validate for a `torch.Tensor` field?',
+      code: 'model_config = ConfigDict(arbitrary_types_allowed=True)\nfeatures: torch.Tensor',
+      question: 'What does this configuration validate about `features`?',
       answer: '`isinstance` only',
       acceptedAnswers: ['instance type only', 'type only'],
       explanation: 'The setting checks the runtime class, not tensor shape, dtype, values, layout, or device.',
@@ -619,6 +672,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-model-construct',
       topic: 'Pydantic v2',
+      code: 'config = RunConfig.model_construct(**trusted_payload)',
       question: 'Which API constructs a model from already trusted data without validation?',
       answer: '`model_construct()`',
       acceptedAnswers: ['model_construct'],
@@ -627,13 +681,15 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-pydantic-model-copy',
       topic: 'Pydantic v2',
-      question: 'Does `cfg.model_copy()` normally copy nested model state deeply?',
+      code: 'copied = config.model_copy()',
+      question: 'Does `copied` contain deep copies of nested model state by default?',
       answer: 'No',
       explanation: '`model_copy()` is shallow by default; pass `deep=True` when nested objects must be copied.',
     },
     {
       id: 'python-pydantic-discriminated-union',
       topic: 'Pydantic v2',
+      code: 'OptimizerConfig = Annotated[\n    AdamConfig | SGDConfig,\n    Field(discriminator="type"),\n]',
       question: 'Which construct models Adam and SGD configurations with different required fields?',
       answer: 'Discriminated union',
       acceptedAnswers: ['tagged union', 'Field discriminator'],
@@ -650,7 +706,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-explicit-exception-cause',
       topic: 'Reliability & I/O',
-      question: 'What does `raise ConfigError(path) from exc` preserve?',
+      code: 'try:\n    payload = read_config(path)\nexcept OSError as exc:\n    raise ConfigError(path) from exc',
+      question: 'What does the final statement preserve?',
       answer: 'Explicit cause',
       acceptedAnswers: ['exception cause', 'traceback chain', '__cause__'],
       explanation: 'Exception chaining preserves the original failure and its traceback while adding boundary-specific context.',
@@ -658,7 +715,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-context-manager-cleanup',
       topic: 'Reliability & I/O',
-      question: 'What guarantee does `with open(path) as handle:` provide?',
+      code: 'with path.open("rb") as handle:\n    payload = handle.read()',
+      question: 'What cleanup guarantee does the context manager provide?',
       answer: 'Exit-time cleanup',
       acceptedAnswers: ['file cleanup', 'close on exit', 'context manager'],
       explanation: 'The context manager runs its exit logic on both normal completion and exceptions.',
@@ -681,7 +739,8 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-sorted-glob',
       topic: 'Reliability & I/O',
-      question: 'How should reproducible ingestion consume `Path(root).glob("*.json")`?',
+      code: 'paths = sorted(Path(root).glob("*.json"))',
+      question: 'Why is the explicit sort required for reproducible ingestion?',
       answer: '`sorted(...)`',
       acceptedAnswers: ['sort the paths', 'sorted'],
       explanation: 'Filesystem enumeration order is not a reproducibility guarantee.',
@@ -696,6 +755,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-stable-experiment-id',
       topic: 'Reliability & I/O',
+      code: 'digest = hashlib.sha256(canonical_config_bytes).hexdigest()',
       question: 'How should code derive a persistent experiment ID from canonical configuration bytes?',
       answer: '`hashlib` digest',
       acceptedAnswers: ['cryptographic hash', 'stable digest', 'hashlib'],
@@ -704,6 +764,7 @@ export const practicalPythonTriviaDeck = {
     {
       id: 'python-multiprocessing-entrypoint',
       topic: 'Reliability & I/O',
+      code: 'def worker(item: Item) -> Result:\n    ...\n\nif __name__ == "__main__":\n    run_pool(worker)',
       question: 'What makes a multiprocessing script safe under the spawn start method?',
       answer: 'Main guard and top-level worker',
       acceptedAnswers: ['if __name__ main', 'main guard', 'spawn-safe entrypoint'],
@@ -718,4 +779,20 @@ export const practicalPythonTriviaDeck = {
       explanation: 'Threads overlap blocking I/O, processes bypass the traditional GIL for Python CPU work, and `asyncio` coordinates nonblocking I/O.',
     },
   ],
+} satisfies TriviaDeckData;
+
+const missingDetailIds = practicalPythonTriviaSourceDeck.cards
+  .map((card) => card.id)
+  .filter((id) => !pythonTriviaDetails[id]);
+
+if (missingDetailIds.length > 0) {
+  throw new Error(`Python trivia cards missing mental models: ${missingDetailIds.join(', ')}`);
+}
+
+export const practicalPythonTriviaDeck = {
+  ...practicalPythonTriviaSourceDeck,
+  cards: practicalPythonTriviaSourceDeck.cards.map((card) => ({
+    ...card,
+    detail: pythonTriviaDetails[card.id],
+  })),
 } satisfies TriviaDeckData;

--- a/src/lib/python-trivia-details.ts
+++ b/src/lib/python-trivia-details.ts
@@ -1,0 +1,111 @@
+/**
+ * The second teaching layer for each Python trivia card.
+ *
+ * The card-local explanation states the immediate rule. These details name the
+ * mental model, boundary, or failure mode that makes the rule reusable.
+ */
+export const pythonTriviaDetails: Record<string, string> = {
+  // References and values
+  'python-aliasing-append': 'Python names point to objects. Assignment changes which object a name points to; it does not duplicate that object. Copy only when the two names must be allowed to evolve independently.',
+  'python-mutation-vs-rebinding': 'A function receives another reference to the caller’s object. Mutating that object crosses the call boundary, while rebinding the local parameter changes only the function’s local name.',
+  'python-identity-vs-equality': '`is` asks whether two names point to the same object. `==` asks whether their values compare equal and may invoke custom equality logic. Identity is the reliable test for `None` and unique sentinels.',
+  'python-missing-sentinel': 'A sentinel adds a third state: missing, explicit `None`, or a concrete value. Compare a private sentinel by identity so no user value can accidentally equal it.',
+  'python-shared-mutable-default': 'A function definition is executable code, so its default expressions run once when Python executes the `def`. Treat defaults as long-lived objects; allocate per-call mutable state inside the function.',
+  'python-repeated-inner-list': 'Sequence multiplication repeats element references, not the objects behind those references. Use a comprehension such as `[[] for _ in range(3)]` when each position needs independent mutable state.',
+  'python-shallow-list-copy': 'A shallow copy breaks aliasing at one container boundary only. Draw the object graph: `a` and `b` are different lists, but both outgoing edges still reach the same dictionary.',
+  'python-tuple-shallow-immutability': 'Tuple immutability protects the tuple’s slots from rebinding. It says nothing about the mutability of objects reached through those slots, so nested dictionaries and lists can still change.',
+  'python-falsy-valid-value': 'Truth testing merges several distinct values—`0`, `0.0`, `False`, empty containers, and `None`—into one branch. Test the exact missing-state contract instead of using truthiness as a substitute.',
+  'python-nan-equality': 'IEEE NaN represents an undefined or unrepresentable numeric result, and comparisons involving it are intentionally unordered. Equality therefore cannot serve as a missing-value test.',
+  'python-float-comparison': 'A useful tolerance has two parts: relative tolerance scales with the magnitude, while absolute tolerance handles values near zero. Choose both from the error budget of the computation.',
+
+  // Collections
+  'python-list-vs-tuple': 'Choose a collection by contract, not syntax alone. A list advertises changeable sequence state; a tuple advertises a fixed grouping and is hashable only when every contained value is hashable.',
+  'python-dict-key-contract': 'A dictionary first selects a hash bucket and then uses equality to find the key. If a key’s hash-relevant state changes while stored, future lookups may search the wrong bucket.',
+  'python-set-deduplication': 'Sets use the same hash-and-equality machinery as dictionaries. They make membership and uniqueness cheap, but they do not promise a presentation order; sort at output boundaries that require determinism.',
+  'python-split-leakage-intersection': 'A nonempty intersection is a concrete witness that the same identity appears in both splits. Check the intersection before training so evaluation cannot benefit from duplicated examples.',
+  'python-dict-iteration-order': 'Insertion order is a history of writes, not an ordering relation on keys. Two dictionaries with the same pairs can iterate differently if they were constructed in different orders.',
+  'python-sort-vs-sorted': 'The mutating method returns `None` so code does not confuse the operation with a new value. Use `sorted` when the input must survive unchanged or when the source is any iterable rather than a list.',
+  'python-zip-strict': 'Ordinary `zip` treats early exhaustion as normal control flow. At paired-data boundaries, strict mode converts a silent truncation bug into an immediate structural error.',
+  'python-counter-labels': 'A `Counter` is a frequency mapping specialized for repeated observations. It keeps counting logic declarative and exposes operations such as `most_common` without a manual update loop.',
+  'python-defaultdict-grouping': 'The factory defines how missing keys become values. Remember that reading a missing key also inserts it, so use ordinary `dict.get` when observation must not mutate the mapping.',
+  'python-bounded-loss-history': 'A bounded deque makes retention part of the data structure rather than cleanup logic. Appending a new item evicts the oldest automatically, keeping memory bounded over an unbounded run.',
+
+  // Functions and iteration
+  'python-iterable-vs-iterator': 'An iterable is a source that can produce traversal state. An iterator is that stateful traversal itself: `iter(iterator) is iterator`, and each `next` consumes one position.',
+  'python-generator-exhaustion': 'A generator stores one suspended execution frame, not a replayable recipe. Recreate the generator for another pass or materialize its values when repeated traversal is required.',
+  'python-eager-vs-lazy-comprehension': 'A list comprehension pays all compute and memory up front. A generator expression defers work and can stream, but errors also move to consumption time and the values remain one-shot.',
+  'python-yield-generator-function': 'Calling a generator function creates a suspended frame without running its body. Each `next` resumes execution until the next `yield`, preserving local variables between resumptions.',
+  'python-first-match': 'The generator expression and `next` form a short-circuit search: production stops as soon as one item satisfies the predicate. The explicit default defines the no-match branch without an exception.',
+  'python-keyword-only-hyperparameters': 'Keyword-only parameters turn call-site position into a named contract. They make reviews easier and let APIs add or reorder optional controls without changing the meaning of existing calls.',
+  'python-closure-late-binding': 'A closure captures a variable cell, not a frozen snapshot of its current value. A default argument works here because its expression is evaluated when each lambda is created.',
+  'python-partial-callable': 'Partial application stores selected arguments and returns another callable. It is useful for configuration, but the resulting callable still shares any mutable objects captured in those bound arguments.',
+  'python-wraps-decorator': 'A decorator replaces one callable with another. `wraps` copies the public metadata and records `__wrapped__`, allowing introspection, documentation, and tools to recover the original function.',
+  'python-lru-cache-contract': 'Caching trades memory and staleness risk for avoided work. The key comes from function arguments, so results are safe to reuse only when those arguments fully determine the result and invalidation is understood.',
+
+  // Classes and interfaces
+  'python-instance-shadows-class': 'Attribute lookup checks the instance before falling back to the class. Assigning through an instance creates a nearer binding; it does not edit the class attribute seen by other instances.',
+  'python-mutable-class-attribute': 'A class attribute is one object shared through class lookup. Use it for intentional shared state; initialize per-instance mutable state in `__init__` when instances must be isolated.',
+  'python-bound-method-self': 'Functions implement the descriptor protocol. Reading one through an instance produces a bound method that carries the instance, which is why the later call supplies only the remaining arguments.',
+  'python-classmethod-constructor': 'A class method receives the runtime class rather than an instance. Constructing with `cls(...)` preserves polymorphism: a subclass calling the inherited constructor receives a subclass instance.',
+  'python-staticmethod-helper': 'A static method changes namespacing, not behavior: it is an ordinary function retrieved from the class without automatic `self` or `cls`. Keep it on the class only when that ownership aids discovery.',
+  'python-property-boundary': 'Attribute syntax suggests cheap, deterministic access. A property can preserve that interface while computing a value, but hidden network, disk, or heavyweight work violates the cost model callers infer.',
+  'python-callable-transform': 'A callable object separates configuration from invocation. `__init__` stores reusable state, while `__call__` applies that state through the same interface as a function.',
+  'python-composition-pipeline': 'Composition keeps behavior in small objects connected by an explicit data flow. Each stage can be replaced or tested independently, avoiding inheritance trees where one change affects unrelated subclasses.',
+  'python-protocol-interface': 'A protocol names the behavior a consumer needs instead of the ancestry a provider must have. Static compatibility follows members and signatures, so third-party types can participate without adapter inheritance.',
+  'python-super-mro': '`super` is a cooperative method-resolution tool. It starts after the current class in the runtime MRO, which lets every class in a multiple-inheritance chain participate exactly once when each forwards correctly.',
+
+  // Typing
+  'python-annotations-runtime': 'Annotations are metadata consumed by type checkers, editors, frameworks, or explicit runtime validators. The Python call mechanism itself does not reject a value merely because it disagrees with an annotation.',
+  'python-any-vs-object': '`Any` asks the checker to stop checking operations that flow through the value. `object` preserves uncertainty safely: every value fits, but code must narrow the type before using specialized operations.',
+  'python-nullable-not-optional': 'Nullability is a property of the accepted value set. Optionality is a property of the call signature. A required parameter can accept `None`, and an optional parameter can still reject `None`.',
+  'python-sequence-parameter': 'Annotate the smallest behavior the function needs. `Sequence` provides length and indexed read access while leaving tuples, lists, and other sequence implementations available to callers.',
+  'python-iterable-vs-iterator-type': 'Accepting an iterator tells callers the function may consume shared traversal state. Accepting an iterable is broader and may permit the function to request a fresh iterator.',
+  'python-mapping-parameter': 'A read-only `Mapping` annotation prevents the signature from promising mutation and accepts more providers than `dict`. Use a mutable mapping type only when writes are part of the contract.',
+  'python-callable-signature': '`Callable[[Sample], Sample]` describes the input-output relation but not every call detail. For richer methods, keyword names, or attributes, define a callback `Protocol` instead.',
+  'python-typeddict-runtime': 'A `TypedDict` exists primarily in the static type system. Data crossing a JSON or user-input boundary still needs explicit runtime validation before code can trust its keys and values.',
+  'python-literal-optimizer': 'A literal type turns a small closed set of values into a checked interface. It catches misspellings before runtime and lets a checker narrow branches based on the selected value.',
+  'python-annotated-field': '`Annotated` keeps the base static type while attaching metadata for a cooperating runtime library. The metadata has no effect unless some tool, such as Pydantic, chooses to interpret it.',
+  'python-typevar-relationship': 'A type variable carries a relationship across positions in a signature. Each call chooses a concrete `T`, allowing the checker to infer that the returned value has the same element type as the input sequence.',
+
+  // Dataclasses
+  'python-dataclass-generated-methods': 'A dataclass derives boilerplate from annotated fields. It is still a normal Python class: annotations are not validated, methods can be added, and generated behavior can be configured or overridden.',
+  'python-dataclass-mutable-default': 'The factory is stored in the field definition and called during each initialization. This moves mutable allocation to instance construction and prevents object graphs from being shared accidentally.',
+  'python-dataclass-post-init': '`__post_init__` runs after the generated initializer has assigned every field. That makes it the natural place for derived fields and invariants that depend on more than one constructor argument.',
+  'python-dataclass-classvar': 'Marking a name as `ClassVar` tells dataclass machinery that the name belongs to the class contract, not instance data. It is excluded from generated initialization, comparison, and representation.',
+  'python-dataclass-frozen-shallow': 'Frozen instances prevent normal attribute assignment, which is useful for stable configuration references. Deep immutability still requires immutable field values or defensive copying.',
+  'python-dataclass-kw-only': 'Keyword-only construction makes field names visible at every call site. This reduces argument-order mistakes and lets the class evolve without silently reinterpreting positional calls.',
+  'python-dataclass-slots': 'Slots replace the usual per-instance attribute dictionary with a fixed layout. They can reduce memory and catch undeclared attributes, but they also change inheritance, weak-reference, and dynamic-attribute behavior.',
+  'python-dataclass-replace': '`replace` expresses a copy-with-changes operation at the dataclass level. Because it calls the initializer, normal initialization and `__post_init__` invariants apply to the new instance.',
+  'python-dataclass-asdict': '`asdict` walks the full dataclass object graph and deep-copies non-dataclass leaves. That is convenient for small value records but costly or invalid for tensors, clients, locks, and other runtime objects.',
+
+  // Pydantic v2
+  'python-pydantic-boundary-choice': 'Use validation where trust changes. Internal code benefits from lightweight typed records, while serialized or user-controlled data needs parsing, rejection rules, and useful boundary errors.',
+  'python-pydantic-dataclass': 'A Pydantic dataclass keeps the dataclass programming model while validating initialization. It does not become a `BaseModel`; wrap the type in a `TypeAdapter` for schema and serialization operations.',
+  'python-pydantic-default-coercion': 'Coercion is useful at text-heavy boundaries, but it can hide upstream schema drift. Decide deliberately whether a boundary should normalize compatible values or reject anything with the wrong runtime type.',
+  'python-pydantic-strict-mode': 'Strictness changes the boundary contract from “convert if possible” to “require the expected type.” It can be applied globally or narrowly where coercion would make bad input look valid.',
+  'python-pydantic-extra-forbid': 'Ignoring unknown keys makes forward compatibility easy but also hides typos. For configuration files, forbidding extras usually gives a safer failure: the misspelled control cannot silently fall back to its default.',
+  'python-pydantic-positive-field': 'Declarative constraints keep validation, generated schema, and error locations tied to the field. Prefer them over a custom validator when the rule is a standard local bound.',
+  'python-pydantic-default-factory': 'The default factory runs for every successful model construction. It gives each model an independent mutable value and can also derive a default from already validated earlier fields when needed.',
+  'python-pydantic-field-validator': 'A field validator owns one field’s normalization or local rule. Choose before-validation only when raw input must be transformed; after-validation can rely on the parsed field type.',
+  'python-pydantic-model-validator': 'Cross-field rules belong at model scope because no single field owns the invariant. An after-model validator sees the completed typed model and can return it after checking the relationship.',
+  'python-pydantic-assignment-validation': 'Construction-time validity does not guarantee lifetime validity when fields remain mutable. Assignment validation moves the boundary to each write, at an ongoing runtime cost.',
+  'python-pydantic-io-api': 'Choose the API that matches the representation at the boundary. Python-object methods avoid an unnecessary JSON round trip; JSON methods own decoding or encoding when bytes or text are the real interface.',
+  'python-pydantic-type-adapter': 'A type adapter gives an arbitrary annotation the same validation and serialization engine used by models. Build it once and reuse it rather than creating a wrapper class or rebuilding schemas per call.',
+  'python-pydantic-private-attr': 'Private attributes hold operational state rather than validated domain data. They are omitted from schemas and dumps, so another mechanism must recreate them after deserialization.',
+  'python-pydantic-arbitrary-tensor': 'Allowing an arbitrary class only proves that the object has that class. Tensor invariants—rank, shape, dtype, device, finiteness, or value range—still need explicit validation.',
+  'python-pydantic-model-construct': 'Bypassing validation moves responsibility to the caller. Use construction without validation only after another trusted layer has established every invariant; otherwise invalid state enters the model silently.',
+  'python-pydantic-model-copy': 'A shallow model copy creates a new outer model while retaining nested references. Choose `deep=True` only when nested isolation is required, because deep copying can be expensive or unsupported for runtime resources.',
+  'python-pydantic-discriminated-union': 'The discriminator makes variant selection explicit and efficient. After Pydantic reads the tag, it validates only the matching model and can report errors against that concrete configuration shape.',
+
+  // Reliability and I/O
+  'python-narrow-exception': 'An exception boundary should catch only failures it can translate, retry, or recover from. Broad catches turn programming defects into misleading configuration errors and make the original fault harder to locate.',
+  'python-explicit-exception-cause': 'Exception chaining keeps both abstraction levels: the outer error explains the failed operation, while the cause preserves the low-level reason and traceback needed to diagnose it.',
+  'python-context-manager-cleanup': 'A context manager encodes acquisition and release as one protocol. Its exit method runs while an exception is propagating, so resource cleanup does not depend on every control-flow path remembering to close.',
+  'python-assert-input-validation': 'Assertions document conditions that should already be true if the program is correct. External data can always be wrong, so validate it with an explicit branch and stable exception regardless of optimization mode.',
+  'python-str-vs-bytes': 'Encoding maps Unicode text to bytes; decoding maps bytes to text. Make the codec explicit at the boundary so the rest of the program operates on one representation with known meaning.',
+  'python-sorted-glob': 'Directory iteration order can vary across filesystems, runs, and machines. Sorting converts that environmental accident into a stable ingestion order before it can affect splits, hashes, or outputs.',
+  'python-untrusted-pickle': 'Pickle reconstructs Python objects by executing a serialization program, not by parsing inert data. Authentication or a safer data format is required when the producer is outside the trust boundary.',
+  'python-stable-experiment-id': 'The digest is stable only if the serialized bytes are stable. Canonicalize key order, numeric representation, and omitted defaults before hashing so equivalent configurations produce the same identity.',
+  'python-multiprocessing-entrypoint': 'Spawn starts a fresh interpreter that imports the main module. The guard prevents child imports from recursively creating more processes, and top-level callables give pickle an importable name.',
+  'python-concurrency-choice': 'Match the tool to the waiting model. Threads help when native or blocking work releases the interpreter, processes isolate CPU-bound Python execution, and `asyncio` needs nonblocking libraries plus explicit cooperative scheduling.',
+};

--- a/src/lib/trivia-decks.ts
+++ b/src/lib/trivia-decks.ts
@@ -111,13 +111,13 @@ const pytorchTriviaSourceDeck: TriviaSourceDeck = {
       id: 'torch-leaf-grad',
       topic: 'Autograd',
       question: 'Which tensors receive a populated `.grad` after backward?',
-      answer: 'Leaf tensors with `requires_grad=True` accumulate gradients by default. Intermediates need `retain_grad()` if their `.grad` field must be inspected.',
+      answer: 'Leaf tensors with `requires_grad=True` accumulate gradients by default. Intermediates need `retain_grad()` if their `.grad` field must be inspected. This default keeps retained gradient state focused on optimization inputs.',
     },
     {
       id: 'torch-grad-accumulation',
       topic: 'Autograd',
       question: 'Does `backward()` overwrite existing parameter gradients?',
-      answer: 'No. It accumulates into `.grad`. Clear gradients at the intended accumulation boundary, commonly with `optimizer.zero_grad(set_to_none=True)`.',
+      answer: 'No. It accumulates into `.grad`. Clear gradients at the intended accumulation boundary, commonly with `optimizer.zero_grad(set_to_none=True)`. Accumulation enables larger effective batches but makes stale gradients dangerous.',
     },
     {
       id: 'torch-none-zero-grad',
@@ -195,7 +195,7 @@ const pytorchTriviaSourceDeck: TriviaSourceDeck = {
       id: 'torch-forward-call',
       topic: 'Modules & state',
       question: 'Why call `model(x)` instead of `model.forward(x)`?',
-      answer: '`nn.Module.__call__` wraps `forward` with framework behavior such as hooks and compiled-call machinery. Directly calling `forward` bypasses that wrapper.',
+      answer: '`nn.Module.__call__` wraps `forward` with framework behavior such as hooks and compiled-call machinery. Directly calling `forward` bypasses that wrapper. Treat `model(...)` as the module’s public invocation boundary.',
     },
     {
       id: 'torch-cross-entropy-logits',
@@ -420,7 +420,7 @@ function buildAtomicDeck(
       answer: spec.answer,
       acceptedAnswers: spec.acceptedAnswers,
       explanation,
-      detail: source.detail,
+      detail: source.detail ?? source.answer,
     };
 
     if (!spec.code) return [conceptCard];
@@ -443,6 +443,7 @@ function buildAtomicDeck(
         acceptedAnswers: spec.codeAcceptedAnswers,
         explanation: codeExplanation,
         code: spec.code,
+        detail: source.detail ?? source.answer,
       },
     ];
   });

--- a/tests/trivia-deck.test.tsx
+++ b/tests/trivia-deck.test.tsx
@@ -22,6 +22,7 @@ const deck: TriviaDeckData = {
       answer: 'Object identity',
       acceptedAnswers: ['identity'],
       explanation: 'Identity asks whether two names refer to the same object.',
+      detail: 'Names are labels for objects, so identity compares the referenced objects instead of comparing their values.',
     },
     {
       id: 'two',
@@ -91,7 +92,19 @@ describe('TriviaDeck', () => {
 
     expect(container.textContent).toContain('same object');
     expect(container.textContent).toContain('My candidate answer.');
+    expect(container.textContent).toContain('Why it works');
+    expect(container.textContent).toContain('Mental model');
+    expect(container.textContent).toContain('Names are labels for objects');
     expect(container.querySelector('[aria-label="Automatic grade"]')).not.toBeNull();
+  });
+
+  it('uses one consistent treatment for every deck action', async () => {
+    await renderDeck();
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    expect(buttons).toHaveLength(5);
+    expect(buttons.every((button) => button.classList.contains('trivia-deck__action')))
+      .toBe(true);
   });
 
   it('marks a passing answer correct and persists the automatic score', async () => {
@@ -111,7 +124,7 @@ describe('TriviaDeck', () => {
     await renderDeck();
     click('Next trivia card');
 
-    expect(container.querySelector('[aria-label="Production code scenario"]')?.textContent)
+    expect(container.querySelector('[aria-label="Code scenario"]')?.textContent)
       .toContain('service.run()');
     expect(container.textContent).not.toContain('The runtime executes the program.');
 
@@ -119,7 +132,7 @@ describe('TriviaDeck', () => {
     click('Grade answer');
 
     expect(container.textContent).toContain('The runtime executes the program.');
-    expect(container.querySelectorAll('[aria-label="Production code scenario"]')).toHaveLength(1);
+    expect(container.querySelectorAll('[aria-label="Code scenario"]')).toHaveLength(1);
   });
 
   it('rejects a vague answer and identifies concepts to review', async () => {
@@ -251,6 +264,10 @@ describe('published trivia data', () => {
       expect(publishedDeck.cards.every((card) => card.question && card.answer && card.topic)).toBe(true);
       expect(publishedDeck.cards.every((card) => !card.answer.includes('\n'))).toBe(true);
       expect(publishedDeck.cards.every((card) => Boolean(card.explanation))).toBe(true);
+      const shallowMentalModels = publishedDeck.cards
+        .filter((card) => (card.detail?.trim().split(/\s+/).length ?? 0) < 20)
+        .map((card) => card.id);
+      expect(shallowMentalModels).toEqual([]);
     },
   );
 
@@ -274,7 +291,7 @@ describe('published trivia data', () => {
 
   it('keeps code and concept on the same practical Python card', () => {
     const codeCards = pythonTriviaDeck.cards.filter((card) => card.code);
-    expect(codeCards.length).toBeGreaterThanOrEqual(8);
+    expect(codeCards.length).toBeGreaterThanOrEqual(60);
     expect(codeCards.every((card) => !card.id.endsWith('-code'))).toBe(true);
     expect(pythonTriviaDeck.cards.every((card) => card.topic !== 'Code scenarios')).toBe(true);
   });


### PR DESCRIPTION
## What changed
- give Shuffle, Grade answer, Previous, Next, and Reset progress one visible, consistent 48px action treatment
- render executable prompts as labeled code blocks and convert 68 Python cards to scenario-first code presentation
- add a distinct mental-model explanation to every Python and PyTorch trivia card
- add regression coverage for consistent controls, teaching layers, and complete card depth

## Why
The two trivia decks should teach reusable mental models, not just test short-answer recall, while keeping their controls predictable and easy to see.

## Tested
- git diff --check
- npm run ci (449 tests; Astro check, production build, and build verification)
- browser QA on both routes at desktop and 390px mobile widths in light and dark themes